### PR TITLE
feat: add OpenCode skill target to installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cd walden
 ./setup.sh
 ```
 
-The setup script builds the binary, installs it to `~/.local/bin/walden`, and optionally installs the AI skill for Claude Code, Codex, or Copilot.
+The setup script builds the binary, installs it to `~/.local/bin/walden`, and optionally installs the AI skill for Claude Code, Codex, Copilot, or OpenCode.
 
 ### From Source
 
@@ -99,7 +99,7 @@ cd walden
 ./setup.sh
 ```
 
-The setup script builds the binary, installs it to `~/.local/bin/walden`, and asks whether to install the AI skill for Claude Code, Codex, or Copilot.
+The setup script builds the binary, installs it to `~/.local/bin/walden`, and asks whether to install the AI skill for Claude Code, Codex, Copilot, or OpenCode.
 
 ### 2. Open Claude Code and start building
 
@@ -384,6 +384,15 @@ cp skill/walden/SKILL.md ~/.copilot/skills/walden/SKILL.md
 ```
 
 See `skill/walden/install-copilot.md` for Copilot-specific instructions.
+
+**For OpenCode:**
+
+```bash
+mkdir -p ~/.config/opencode/skills/walden
+cp skill/walden/SKILL.md ~/.config/opencode/skills/walden/SKILL.md
+```
+
+See `skill/walden/install-opencode.md` for OpenCode-specific instructions.
 
 ### Prerequisite
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,7 @@ The first public release includes:
 
 - Deterministic CLI with all core commands
 - Versioned JSON output contract (`v0alpha1`)
-- Public skill bundle for Claude and Codex
+- Public skill bundle for Claude, Codex, Copilot, and OpenCode
 - Documentation pack (concepts, workflow, boundaries)
 - Example project with shell-safe verification
 - Repository bootstrap and feature scaffolding templates

--- a/setup.sh
+++ b/setup.sh
@@ -14,6 +14,8 @@ CODEX_BEGIN="# --- BEGIN WALDEN SKILL ---"
 CODEX_END="# --- END WALDEN SKILL ---"
 COPILOT_HOME="${COPILOT_HOME:-$HOME/.copilot}"
 COPILOT_TARGET="$COPILOT_HOME/skills/walden/SKILL.md"
+OPENCODE_HOME="${OPENCODE_HOME:-${XDG_CONFIG_HOME:-$HOME/.config}/opencode}"
+OPENCODE_TARGET="$OPENCODE_HOME/skills/walden/SKILL.md"
 
 # --- Colors (degrade gracefully) ---
 
@@ -150,6 +152,14 @@ install_skill_copilot() {
   ok "Skill installed for Copilot at ${COPILOT_TARGET}"
 }
 
+# --- Skill install: OpenCode ---
+
+install_skill_opencode() {
+  mkdir -p "$(dirname "$OPENCODE_TARGET")"
+  cp "$SKILL_SOURCE" "$OPENCODE_TARGET"
+  ok "Skill installed for OpenCode at ${OPENCODE_TARGET}"
+}
+
 # --- Skill verify ---
 
 verify_skill() {
@@ -164,6 +174,10 @@ verify_skill() {
   fi
   if [ -f "$COPILOT_TARGET" ]; then
     ok "Copilot skill present at ${COPILOT_TARGET}"
+    verified=1
+  fi
+  if [ -f "$OPENCODE_TARGET" ]; then
+    ok "OpenCode skill present at ${OPENCODE_TARGET}"
     verified=1
   fi
   if [ "$verified" -eq 0 ]; then
@@ -184,9 +198,10 @@ prompt_skill_install() {
   printf "  1) Claude Code\n"
   printf "  2) Codex\n"
   printf "  3) Copilot\n"
-  printf "  4) All\n"
-  printf "  5) Skip\n"
-  printf "\n${BOLD}Choice [1-5]:${NC} "
+  printf "  4) OpenCode\n"
+  printf "  5) All\n"
+  printf "  6) Skip\n"
+  printf "\n${BOLD}Choice [1-6]:${NC} "
 
   read -r choice < /dev/tty
 
@@ -194,8 +209,9 @@ prompt_skill_install() {
     1) install_skill_claude ;;
     2) install_skill_codex ;;
     3) install_skill_copilot ;;
-    4) install_skill_claude; install_skill_codex; install_skill_copilot ;;
-    5) info "Skill install skipped" ;;
+    4) install_skill_opencode ;;
+    5) install_skill_claude; install_skill_codex; install_skill_copilot; install_skill_opencode ;;
+    6) info "Skill install skipped" ;;
     *) warn "Invalid choice: ${choice}. Skipping skill install." ;;
   esac
 }
@@ -256,6 +272,15 @@ uninstall_skill_copilot() {
   fi
 }
 
+uninstall_skill_opencode() {
+  if [ -f "$OPENCODE_TARGET" ]; then
+    rm -rf "$(dirname "$OPENCODE_TARGET")"
+    ok "Removed ${OPENCODE_TARGET}"
+  else
+    info "OpenCode skill not found (skipping)"
+  fi
+}
+
 # --- Usage ---
 
 usage() {
@@ -289,6 +314,7 @@ main() {
       uninstall_skill_claude
       uninstall_skill_codex
       uninstall_skill_copilot
+      uninstall_skill_opencode
       printf "\n${BOLD}=== Done ===${NC}\n"
       ;;
     --help|-h)

--- a/skill/walden/install-opencode.md
+++ b/skill/walden/install-opencode.md
@@ -1,0 +1,46 @@
+# Install Walden Skill for OpenCode
+
+## Prerequisites
+
+1. Install the `walden` CLI and ensure it is available in `PATH`:
+
+   ```bash
+   go install github.com/andrearaponi/walden/cmd/walden@latest
+   ```
+
+   Verify with:
+
+   ```bash
+   walden version
+   ```
+
+2. An [OpenCode](https://opencode.ai) installation with native Agent Skills support.
+
+## Install the Skill
+
+Copy `SKILL.md` into your global OpenCode skills directory:
+
+```bash
+mkdir -p ~/.config/opencode/skills/walden
+cp skill/walden/SKILL.md ~/.config/opencode/skills/walden/SKILL.md
+```
+
+OpenCode discovers skills from several locations. Pick the one that matches your scope:
+
+| Scope | Path |
+| --- | --- |
+| Global (OpenCode) | `~/.config/opencode/skills/walden/SKILL.md` |
+| Global (shared with Claude) | `~/.claude/skills/walden/SKILL.md` |
+| Project | `.opencode/skills/walden/SKILL.md` |
+
+`SKILL.md` is used as-is: its `name`, `description`, and `metadata` frontmatter is already valid for OpenCode, and unknown fields are ignored. No edits are required.
+
+If `XDG_CONFIG_HOME` is set, OpenCode resolves the global directory under `$XDG_CONFIG_HOME/opencode/skills/` instead of `~/.config/opencode/skills/`. The `setup.sh` installer honors this automatically.
+
+## Usage
+
+Once installed, describe what you want — define requirements, create a design, generate tasks, or execute approved work for a feature. OpenCode loads the skill on demand through its built-in `skill` tool and follows the Walden workflow, using the `walden` CLI for all deterministic operations.
+
+## If the CLI Is Missing
+
+If `walden` is not in `PATH`, the skill will inform you and stop. Install the CLI before continuing. The skill does not fall back to manual frontmatter editing or legacy scripts.


### PR DESCRIPTION
## Summary

Adds OpenCode as a first-class skill target in `setup.sh`, alongside Claude Code, Codex, and Copilot.

OpenCode natively loads Agent Skills, and Walden's `SKILL.md` is already a valid skill (`name` / `description` / `metadata` frontmatter), so it installs **unchanged** — mirroring the existing Copilot target. No changes to the skill body or the CLI were needed.

Installs to `~/.config/opencode/skills/walden/SKILL.md` (or `$XDG_CONFIG_HOME/opencode/...`).

## Changes

- **`setup.sh`**: XDG-aware `OPENCODE_HOME`/`OPENCODE_TARGET` constants (honor `XDG_CONFIG_HOME` and an `OPENCODE_HOME` override), `install_skill_opencode` / `uninstall_skill_opencode` functions, a `verify_skill` check, and a new interactive menu entry (OpenCode = 4; `All` now includes it).
- **`skill/walden/install-opencode.md`**: manual install guide, mirroring the Codex/Copilot guides.
- **`README.md`**: OpenCode listed among targets + a "For OpenCode" manual section.
- **`docs/roadmap.md`**: skill bundle target list aligned.

## Testing

- `sh -n setup.sh` — POSIX syntax valid
- Isolated install test in a tmpdir: `SKILL.md` copied byte-identical, frontmatter valid for OpenCode
- `git grep` — no remaining inconsistent agent lists