### PR TITLE
refactor: install Walden as a Claude Code skill instead of a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The setup script builds the binary, installs it to `~/.local/bin/walden`, and as
 ### 2. Open Claude Code and start building
 
 ```
-/walden We need to build a user authentication system. Let's design it with Walden.
+We need to build a user authentication system. Let's design it with Walden.
 ```
 
 That's it. The skill takes over from there.
@@ -359,18 +359,18 @@ The optional AI skill handles non-deterministic authoring work while delegating 
 **For Claude Code** (project-level):
 
 ```bash
-mkdir -p .claude/commands
-cp skill/walden/SKILL.md .claude/commands/walden.md
+mkdir -p .claude/skills/walden
+cp skill/walden/SKILL.md .claude/skills/walden/SKILL.md
 ```
 
 **For Claude Code** (user-level, available across all projects):
 
 ```bash
-mkdir -p ~/.claude/commands
-cp skill/walden/SKILL.md ~/.claude/commands/walden.md
+mkdir -p ~/.claude/skills/walden
+cp skill/walden/SKILL.md ~/.claude/skills/walden/SKILL.md
 ```
 
-Then invoke with `/walden` inside Claude Code.
+Claude Code auto-activates the skill when your request matches its description. See `skill/walden/install-claude.md` for details.
 
 **For Codex:**
 

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INSTALL_DIR="$HOME/.local/bin"
 BINARY_NAME="walden"
 SKILL_SOURCE="$SCRIPT_DIR/skill/walden/SKILL.md"
-CLAUDE_TARGET="$HOME/.claude/commands/walden.md"
+CLAUDE_TARGET="$HOME/.claude/skills/walden/SKILL.md"
+CLAUDE_COMMAND_LEGACY="$HOME/.claude/commands/walden.md"
 CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 CODEX_TARGET="$CODEX_HOME/AGENTS.md"
 CODEX_BEGIN="# --- BEGIN WALDEN SKILL ---"
@@ -125,6 +126,10 @@ install_skill_claude() {
   mkdir -p "$(dirname "$CLAUDE_TARGET")"
   cp "$SKILL_SOURCE" "$CLAUDE_TARGET"
   ok "Skill installed for Claude Code at ${CLAUDE_TARGET}"
+  if [ -f "$CLAUDE_COMMAND_LEGACY" ]; then
+    rm -f "$CLAUDE_COMMAND_LEGACY"
+    info "Removed legacy /walden command at ${CLAUDE_COMMAND_LEGACY}"
+  fi
 }
 
 # --- Skill install: Codex ---
@@ -229,10 +234,14 @@ uninstall_binary() {
 
 uninstall_skill_claude() {
   if [ -f "$CLAUDE_TARGET" ]; then
-    rm -f "$CLAUDE_TARGET"
+    rm -rf "$(dirname "$CLAUDE_TARGET")"
     ok "Removed ${CLAUDE_TARGET}"
   else
     info "Claude skill not found (skipping)"
+  fi
+  if [ -f "$CLAUDE_COMMAND_LEGACY" ]; then
+    rm -f "$CLAUDE_COMMAND_LEGACY"
+    ok "Removed legacy /walden command at ${CLAUDE_COMMAND_LEGACY}"
   fi
 }
 

--- a/skill/walden/install-claude.md
+++ b/skill/walden/install-claude.md
@@ -1,4 +1,4 @@
-# Install Walden Skill for Claude
+# Install Walden Skill for Claude Code
 
 ## Prerequisites
 
@@ -14,42 +14,40 @@
    walden version
    ```
 
-2. Claude Code or a Claude-compatible agent environment.
+2. Claude Code or a Claude-compatible agent environment with Agent Skills support.
 
-## Install as a Claude Code Custom Slash Command
+## Install the Skill
 
-1. In your project, create the directory `.claude/commands/` if it does not exist.
+Claude Code loads Agent Skills from a `skills/<name>/SKILL.md` layout and activates them automatically based on their `description`. Copy `SKILL.md` into the Walden skill directory.
 
-2. Copy `SKILL.md` into `.claude/commands/walden.md`:
-
-   ```bash
-   mkdir -p .claude/commands
-   cp skill/walden/SKILL.md .claude/commands/walden.md
-   ```
-
-3. You can now invoke the skill with `/walden` inside Claude Code.
-
-## Install as a User-Level Slash Command
-
-To make the skill available across all projects:
+**User-level** (available across all projects):
 
 ```bash
-mkdir -p ~/.claude/commands
-cp skill/walden/SKILL.md ~/.claude/commands/walden.md
+mkdir -p ~/.claude/skills/walden
+cp skill/walden/SKILL.md ~/.claude/skills/walden/SKILL.md
 ```
+
+**Project-level** (scoped to a single repository):
+
+```bash
+mkdir -p .claude/skills/walden
+cp skill/walden/SKILL.md .claude/skills/walden/SKILL.md
+```
+
+`SKILL.md` is used as-is: its `name` and `description` frontmatter is what Claude Code reads to decide when to apply the skill.
 
 ## Usage
 
-Once installed, use the `/walden` command to define requirements, create designs, generate implementation plans, or execute approved tasks.
-
-Examples:
+Once installed, Claude Code activates the skill automatically when your request matches its description — there is no slash command to remember. Just describe the spec work:
 
 ```
-/walden Define the requirements for a user authentication feature
-/walden Create the design for user-authentication
-/walden Generate the implementation plan for user-authentication
-/walden Execute task 1.1 for user-authentication
+Let's define the requirements for a user authentication feature with Walden.
+Create the design for user-authentication.
+Generate the implementation plan for user-authentication.
+Execute task 1.1 for user-authentication.
 ```
+
+Claude detects the intent, loads the skill, and follows the Walden workflow, calling the `walden` CLI for all deterministic operations.
 
 ## If the CLI Is Missing
 

--- a/skill/walden/install-opencode.md
+++ b/skill/walden/install-opencode.md
@@ -33,6 +33,8 @@ OpenCode discovers skills from several locations. Pick the one that matches your
 | Global (shared with Claude) | `~/.claude/skills/walden/SKILL.md` |
 | Project | `.opencode/skills/walden/SKILL.md` |
 
+OpenCode also reads `~/.claude/skills/`, so if you already installed Walden for Claude Code it is picked up automatically — copying it into both `~/.config/opencode/skills/` and `~/.claude/skills/` would surface the skill twice.
+
 `SKILL.md` is used as-is: its `name`, `description`, and `metadata` frontmatter is already valid for OpenCode, and unknown fields are ignored. No edits are required.
 
 If `XDG_CONFIG_HOME` is set, OpenCode resolves the global directory under `$XDG_CONFIG_HOME/opencode/skills/` instead of `~/.config/opencode/skills/`. The `setup.sh` installer honors this automatically.


### PR DESCRIPTION
## Summary

Claude Code now installs Walden as a **model-invoked Agent Skill** (`~/.claude/skills/walden/SKILL.md`) instead of a `/walden` slash command. The `SKILL.md` frontmatter (`name` + `description`) was already written for skill routing, so Claude auto-activates Walden by intent — no explicit `/walden` needed. This matches how Copilot and OpenCode already consume it.

The **OpenCode and Codex targets are unchanged** (kept separate, as decided).

## Migration (breaking)

The `/walden` slash command is removed. `setup.sh` installs the skill and **deletes any legacy `~/.claude/commands/walden.md`** on both install and uninstall, so existing users migrate automatically on their next `./setup.sh` run.

## Changes

- **`setup.sh`**: `CLAUDE_TARGET` now points to `~/.claude/skills/walden/SKILL.md`; `install_skill_claude` removes the legacy command; `uninstall_skill_claude` removes the skill directory and the legacy command.
- **`skill/walden/install-claude.md`**: rewritten for the skill model (no slash command).
- **`skill/walden/install-opencode.md`**: note that OpenCode also reads `~/.claude/skills/`, to avoid a duplicate when both targets are installed.
- **`README.md`**: drop `/walden` from the quickstart and the manual Claude Code steps.

## Testing

Exercised the real `setup.sh` functions against a redirected `HOME` (no build):
- Fresh install → skill lands at `~/.claude/skills/walden/SKILL.md`
- Migration → a pre-existing `~/.claude/commands/walden.md` is removed and the skill installed
- Uninstall → skill directory removed
- `sh -n setup.sh` passes; no residual `/walden` command or `.claude/commands` references in docs