### PR TITLE
fix: repair generated CI workflow and align example proof keyword

### DIFF
--- a/examples/todo-app-demo/.walden/specs/todo-app/tasks.md
+++ b/examples/todo-app-demo/.walden/specs/todo-app/tasks.md
@@ -12,16 +12,16 @@ source_design_approved_at: 2026-03-22T12:10:00Z
     - Requirements: `R1`, `R1.AC1`, `R1.AC2`, `NFR1`
     - Design: todo.sh component
     - Verification:
-      - argv: ["scripts/verify.sh", "1.1"]
+      - command: ["scripts/verify.sh", "1.1"]
   - [ ] 1.2 Add list and complete subcommands to src/todo.sh
     - Requirements: `R2`, `R2.AC1`, `R2.AC2`, `R3`, `R3.AC1`, `R3.AC2`, `NFR1`
     - Design: todo.sh component
     - Verification:
-      - argv: ["scripts/verify.sh", "1.2"]
+      - command: ["scripts/verify.sh", "1.2"]
 
 - [ ] 2. Write tests
   - [ ] 2.1 Create tests/test_todo.sh covering add, list, and complete
     - Requirements: `R1`, `R1.AC1`, `R1.AC2`, `R2`, `R2.AC1`, `R2.AC2`, `R3`, `R3.AC1`, `R3.AC2`
     - Design: Testing Strategy
     - Verification:
-      - argv: ["scripts/verify.sh", "2.1"]
+      - command: ["scripts/verify.sh", "2.1"]

--- a/templates/repo/github/workflows/validate-walden.yml
+++ b/templates/repo/github/workflows/validate-walden.yml
@@ -4,14 +4,12 @@ on:
   pull_request:
     paths:
       - ".walden/**"
-      - "scripts/*.py"
       - ".github/workflows/validate-walden.yml"
   push:
     branches:
       - main
     paths:
       - ".walden/**"
-      - "scripts/*.py"
       - ".github/workflows/validate-walden.yml"
 
 jobs:
@@ -21,10 +19,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          python-version: "3.12"
+          go-version: "1.25"
+
+      - name: Install walden
+        run: go install github.com/andrearaponi/walden/cmd/walden@latest
 
       - name: Validate Walden specs
         run: |
@@ -35,12 +36,12 @@ jobs:
           fi
 
           found=0
-          for dir in .walden/specs/*; do
-            if [ ! -d "$dir" ]; then
-              continue
-            fi
+          for dir in .walden/specs/*/; do
+            [ -d "$dir" ] || continue
             found=1
-            python3 scripts/validate_walden_spec.py "$(basename "$dir")"
+            feature="$(basename "$dir")"
+            echo "Validating ${feature}..."
+            walden validate "$feature" --all --json
           done
 
           if [ "$found" -eq 0 ]; then


### PR DESCRIPTION
## Summary

Two leftover artifacts that broke the first-run experience for adopters — both surfaced during a usability/adoption review.

## Fixes

1. **Generated CI workflow was broken.** `walden repo init` scaffolded a GitHub Actions workflow that ran `python3 scripts/validate_walden_spec.py` — a script that does not exist, in a Go-only, zero-dependency project. Every PR touching `.walden/**` failed. The workflow now sets up Go, installs the `walden` CLI, and runs `walden validate <feature> --all --json` (the actual product), and drops the stale `scripts/*.py` path triggers.

2. **Example used an undocumented proof keyword.** `examples/todo-app-demo` used `argv:` while every doc and template teaches `command:`. Since the example is the file users copy from, it now uses `command:` (the parser accepts both; `command:` is canonical).

## Testing

Built the CLI and ran, against a copy of the example:
- `walden validate todo-app --all --json` → valid (6/6 EARS valid)
- `walden task complete-all todo-app --json` → proofs execute, tasks marked complete
- the workflow's own shell logic → pipeline passes on the example
- no Python remains in templates; workflow YAML parses cleanly