### PR TITLE
fix: remove last Python reference from generated lessons header

### DIFF
--- a/internal/spec/lessons.go
+++ b/internal/spec/lessons.go
@@ -16,7 +16,7 @@ Review this file before non-trivial work when the current request matches past m
 
 ## Lessons
 
-<!-- Append entries with scripts/log_walden_lesson.py -->
+<!-- Append entries with: walden lesson log --feature <name> --phase <phase> --trigger "..." --lesson "..." --guardrail "..." -->
 `
 
 // LessonEntry is the canonical structured payload for one Walden lesson.

--- a/internal/spec/lessons_test.go
+++ b/internal/spec/lessons_test.go
@@ -40,7 +40,7 @@ Review this file before non-trivial work when the current request matches past m
 
 ## Lessons
 
-<!-- Append entries with scripts/log_walden_lesson.py -->
+<!-- Append entries with: walden lesson log --feature <name> --phase <phase> --trigger "..." --lesson "..." --guardrail "..." -->
 ### 2026-03-22T08:00:00Z | todo-app-demo | design
 - Trigger: design constraints added after approval request
 - Lesson: capture workflow constraints before approval
@@ -64,7 +64,7 @@ Review this file before non-trivial work when the current request matches past m
 
 ## Lessons
 
-<!-- Append entries with scripts/log_walden_lesson.py -->
+<!-- Append entries with: walden lesson log --feature <name> --phase <phase> --trigger "..." --lesson "..." --guardrail "..." -->
 ### 2026-03-21T14:07:51Z | repo-init-and-review-flow | design
 - Trigger: existing trigger
 - Lesson: existing lesson


### PR DESCRIPTION
## Summary

Removes the last Python reference in the codebase. When bootstrapping a fresh `lessons.md`, `internal/spec/lessons.go` wrote the header `<!-- Append entries with scripts/log_walden_lesson.py -->` — a Python script that does not exist, in a Go-only, zero-dependency project. Meanwhile `repo init`'s template (`templates/repo/walden/lessons.md`) already used the correct `walden lesson log ...` command, so `lessons.md` got a different header depending on whether it was created by `lesson log` (CLI bootstrap) or by `repo init` (template).

The bootstrap header now matches the template exactly.

## Testing

- Updated the two fixtures in `internal/spec/lessons_test.go` to expect the new header.
- `go test ./...` → all packages pass.
- `git grep -in python` across the repo → no matches.