### PR TITLE
feat: add global --help/-h and an honest usage block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ walden-*-darwin-arm64
 # Claude Code local config
 .claude/
 
+# Walden dogfooding artifacts (local only — never published in this repo)
+.walden/
+.github/workflows/validate-walden.yml
+.github/pull_request_template.md
+
 # Go
 *.exe
 *.exe~

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -22,20 +22,27 @@ const binaryName = "walden"
 // -ldflags and defaults to "dev" for untagged builds.
 var Version = "dev"
 
-var plannedCommands = []string{
-	"version [--json]",
-	"repo init [--json]",
-	"feature init <name> [--json]",
-	"status <feature> [--json]",
-	"reconcile <feature> [--json]",
-	"lesson log --feature <name> --phase requirements|design|tasks|execute|release --trigger <text> --lesson <text> --guardrail <text> [--json]",
-	"task status <feature> [--json]",
-	"task start <feature> [task-id] [--json]",
-	"task complete <feature> <task-id> [--json]",
-	"task complete-all <feature> [--json]",
-	"validate <feature> [--all] [--json]",
-	"review open <feature> --phase requirements|design|tasks [--json]",
-	"review approve <feature> --phase requirements|design|tasks [--json]",
+// commandUsage pairs a command's invocation syntax with a one-line summary
+// for the help output.
+type commandUsage struct {
+	Syntax  string
+	Summary string
+}
+
+var commandUsages = []commandUsage{
+	{"version [--json]", "Print the CLI and schema version"},
+	{"repo init [--json]", "Initialize Walden in the current repository"},
+	{"feature init <name> [--json]", "Scaffold a new feature spec"},
+	{"status <feature> [--json]", "Show a feature's phase, blockers, and next action"},
+	{"reconcile <feature> [--json]", "Re-sync the approval chain after upstream edits"},
+	{"lesson log --feature <name> --phase <phase> --trigger <text> --lesson <text> --guardrail <text> [--json]", "Append a structured lesson to .walden/lessons.md"},
+	{"task status <feature> [--json]", "Show execution readiness and the next runnable task"},
+	{"task start <feature> [task-id] [--json]", "Resolve normalized execution context for a task"},
+	{"task complete <feature> <task-id> [--json]", "Run a task's proofs and mark it complete"},
+	{"task complete-all <feature> [--json]", "Complete all runnable tasks in order"},
+	{"validate <feature> [--all] [--json]", "Check EARS, traceability, and freshness"},
+	{"review open <feature> --phase <phase> [--json]", "Open the review gate (move to in-review)"},
+	{"review approve <feature> --phase <phase> [--json]", "Approve the review gate (move to approved)"},
 }
 
 var commandRunner shell.Runner = shell.NewExecRunner()
@@ -48,6 +55,9 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	switch args[0] {
+	case "--help", "-h":
+		printUsage(stdout)
+		return 0
 	case "version":
 		return runVersion(args[1:], stdout, stderr)
 	case "repo":
@@ -910,11 +920,16 @@ func runReviewApprove(args []string, stdout io.Writer, stderr io.Writer) int {
 }
 
 func printUsage(w io.Writer) {
-	_, _ = fmt.Fprintf(w, "%s\n\n", binaryName)
-	_, _ = fmt.Fprintln(w, "Planned commands:")
-	for _, command := range plannedCommands {
-		_, _ = fmt.Fprintf(w, "- %s\n", command)
+	_, _ = fmt.Fprintf(w, "Usage:\n  %s <command> [arguments]\n\n", binaryName)
+	_, _ = fmt.Fprintln(w, "Commands:")
+	for _, command := range commandUsages {
+		_, _ = fmt.Fprintf(w, "  %s\n      %s\n", command.Syntax, command.Summary)
 	}
+	_, _ = fmt.Fprintln(w, "\nFlags:")
+	_, _ = fmt.Fprintln(w, "  --json           Emit machine-readable JSON instead of text")
+	_, _ = fmt.Fprintln(w, "  --all            Validate the full spec, not just the current phase (validate)")
+	_, _ = fmt.Fprintln(w, "  --phase <phase>  Target requirements|design|tasks (review open/approve)")
+	_, _ = fmt.Fprintf(w, "\nRun '%s --help' to show this help.\n", binaryName)
 }
 
 func statusSuccessResult(state workflow.FeatureState) output.Result {

--- a/internal/app/run_test.go
+++ b/internal/app/run_test.go
@@ -17,8 +17,11 @@ func TestRunNoArgsPrintsUsageAndCommands(t *testing.T) {
 	}
 
 	output := stdout.String()
-	if !strings.Contains(output, "walden") {
-		t.Fatalf("expected usage output to mention walden, got %q", output)
+	if !strings.Contains(output, "Usage:") {
+		t.Fatalf("expected usage output to contain %q, got %q", "Usage:", output)
+	}
+	if strings.Contains(output, "Planned commands:") {
+		t.Fatalf("expected usage output not to contain %q, got %q", "Planned commands:", output)
 	}
 	if !strings.Contains(output, "repo init") {
 		t.Fatalf("expected usage output to mention repo init, got %q", output)
@@ -28,5 +31,63 @@ func TestRunNoArgsPrintsUsageAndCommands(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+// TestUsageContent asserts the usage block is honest and useful: a Usage:
+// heading (not the misleading "Planned commands:"), every command listed with
+// its summary, and the key global flags documented.
+func TestUsageContent(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	Run([]string{"--help"}, &stdout, &stderr)
+	out := stdout.String()
+
+	if !strings.Contains(out, "Usage:") {
+		t.Fatalf("expected %q heading, got %q", "Usage:", out)
+	}
+	if strings.Contains(out, "Planned commands:") {
+		t.Fatalf("usage must not contain the misleading %q header", "Planned commands:")
+	}
+	for _, c := range commandUsages {
+		if !strings.Contains(out, c.Syntax) {
+			t.Fatalf("expected usage to list command %q", c.Syntax)
+		}
+		if !strings.Contains(out, c.Summary) {
+			t.Fatalf("expected usage to describe %q with %q", c.Syntax, c.Summary)
+		}
+	}
+	for _, flag := range []string{"--json", "--all", "--phase"} {
+		if !strings.Contains(out, flag) {
+			t.Fatalf("expected usage to document flag %q", flag)
+		}
+	}
+}
+
+func TestRunHelpFlag(t *testing.T) {
+	for _, arg := range []string{"--help", "-h"} {
+		var stdout, stderr bytes.Buffer
+		exitCode := Run([]string{arg}, &stdout, &stderr)
+
+		if exitCode != 0 {
+			t.Fatalf("%s: expected exit code 0, got %d", arg, exitCode)
+		}
+		if !strings.Contains(stdout.String(), "Usage:") {
+			t.Fatalf("%s: expected usage on stdout, got %q", arg, stdout.String())
+		}
+		if stderr.Len() != 0 {
+			t.Fatalf("%s: expected empty stderr, got %q", arg, stderr.String())
+		}
+	}
+}
+
+func TestRunUnknownCommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"bogus"}, &stdout, &stderr)
+
+	if exitCode == 0 {
+		t.Fatalf("expected non-zero exit code for unknown command")
+	}
+	if !strings.Contains(stderr.String(), "unknown command") {
+		t.Fatalf("expected error on stderr, got %q", stderr.String())
 	}
 }


### PR DESCRIPTION
## Summary

`walden` had no global help. Bare `walden` and every error path printed a usage block headed `Planned commands:` — wording that suggested the commands weren't implemented — and there was no `--help`/`-h` flag.

This adds an honest, useful **global** help (per-command help intentionally out of scope), built with the Go standard library only — `go.mod` stays dependency-free.

## Changes

- **`Run`**: new `--help`/`-h` handling → usage to stdout, exit 0.
- **Catalog**: `plannedCommands []string` → `commandUsages []commandUsage{Syntax, Summary}`, renamed (the commands are real, not "planned") and given one-line descriptions.
- **`printUsage`**: rewritten — a `Usage:` heading, every command with a description, and a global-flags section (`--json`/`--all`/`--phase`).
- No-args (stdout, exit 0) and unknown-command (stderr, non-zero) behavior unchanged, now under the corrected heading.
- `.gitignore`: keep this repo's local Walden dogfooding artifacts out (`.walden/`, generated `validate-walden.yml`, repo-init PR template).

## Behavior

| Invocation | Output | Exit |
|---|---|---|
| `walden --help` / `-h` | `Usage:` heading, commands + descriptions, Flags section | 0 |
| `walden` (no args) | usage to stdout | 0 |
| `walden bogus` | `unknown command: bogus` to stderr | 1 |

## Testing

Through the `Run(args, stdout, stderr) int` seam: `--help`/`-h`, no-args, usage content (`Usage:` present, `Planned commands:` gone, every command + key flag listed), and unknown command. `go test ./...` green; `go build ./...` clean; `go.mod` unchanged.

Planned and executed through Walden's own spec workflow (requirements → design → tasks → execute); the spec stays local (gitignored).