### PR TITLE
feat: harden freshness chain with content fingerprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Thi
 
 ## [Unreleased]
 
+### Added
+
+- **Freshness hardening: content fingerprints.** `walden review approve` now records a SHA-256 fingerprint of the approved document body (`approved_fingerprint`) and binds downstream approvals to the upstream's fingerprint (`source_requirements_fingerprint`, `source_design_fingerprint`). Staleness verdicts are decided by fingerprint comparison alone — editing an approved document without re-approval, a missing fingerprint, or a malformed fingerprint all fail closed and block execution with a named cause. Timestamps remain in frontmatter as human-readable context.
+- `stale_causes` and `approved_fingerprint` fields on document entries in `status`/`validate` JSON output (additive within `schema_version: v0beta1`).
+- Fingerprint normalization treats task checkbox state as execution progress, not content: completing tasks does not stale the approved plan.
+
+### Changed
+
+- **Migration (strict):** documents approved by pre-fingerprint versions report stale with cause `approval fingerprint missing`. Run `walden reconcile <feature>` once and re-approve each phase to migrate.
+- `walden reconcile` now resets a modified-after-approval document to `draft` (previously `in-review`): changed content is unreviewed content.
+- Content-identical re-approval of an upstream document no longer marks downstream documents stale (previously any re-approval staled the chain via timestamps).
+- `walden task complete-all` on a gate-blocked feature now exits non-zero with the blocker (previously reported "no runnable tasks" with exit 0).
+
 ## [0.3.0] - 2026-06-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Each document begins with YAML frontmatter that tracks its lifecycle:
 status: draft | in-review | approved
 approved_at:
 last_modified: 2026-03-22T10:00:00Z
+approved_fingerprint:
 ---
 ```
 
@@ -197,7 +198,9 @@ last_modified: 2026-03-22T10:00:00Z
 status: draft | in-review | approved
 approved_at:
 last_modified: 2026-03-22T10:00:00Z
+approved_fingerprint:
 source_requirements_approved_at:
+source_requirements_fingerprint:
 ---
 ```
 
@@ -207,17 +210,27 @@ source_requirements_approved_at:
 status: draft | in-review | approved
 approved_at:
 last_modified: 2026-03-22T10:00:00Z
+approved_fingerprint:
 source_design_approved_at:
+source_design_fingerprint:
 ---
 ```
 
-The `source_*` fields create an approval chain. When a downstream document is approved, it records the upstream `approved_at` timestamp. If the upstream document is later re-approved with a new timestamp, the downstream becomes stale.
+The `source_*` fields create an approval chain. When `walden review approve` approves a document, it records a SHA-256 **content fingerprint** of the approved body (`approved_fingerprint`) and, on downstream documents, the upstream's approval fingerprint (`source_*_fingerprint`). The timestamps remain as human-readable context; the fingerprints carry the verdict.
 
 ### Freshness
 
-A document is **fresh** when its `source_*` timestamp matches the current upstream `approved_at`. A document is **stale** when they diverge.
+Freshness is decided by content identity, not by declared metadata:
 
-Stale documents block execution. Use `walden reconcile <feature>` to repair the chain.
+- An approved document is **intact** when its current body still matches its own `approved_fingerprint`. Editing an approved document — without re-approval — makes it stale, no matter what its metadata claims.
+- A downstream document is **fresh** when it is intact and its `source_*_fingerprint` equals the upstream's current `approved_fingerprint`. Re-approving an upstream document without changing its content does **not** stale the chain.
+- Missing or malformed fingerprints on an approved document fail closed: the document is stale, with the cause named in the output (`stale_causes` in `--json`).
+
+Fingerprint computation normalizes line endings and task checkbox state (checking a task off with `walden task complete` is execution progress, not a content change) and nothing else.
+
+Stale documents block execution. Use `walden reconcile <feature>` to repair the chain: tampered or legacy documents reset to `draft`, stale downstream documents reset to `draft`, and re-approval records fresh fingerprints.
+
+**Migrating from pre-fingerprint versions:** documents approved before fingerprints existed report stale (`approval fingerprint missing`). Run `walden reconcile <feature>` once and re-approve each phase; the chain comes back hardened.
 
 ### Requirement IDs
 
@@ -302,7 +315,8 @@ Each acceptance criterion gets a stable ID (e.g., `R1.AC1`) and uses exactly one
 | Property | Enforced by CLI today | Planned |
 | --- | --- | --- |
 | Phase ordering | Yes | - |
-| Freshness chain | Yes | Hardening planned |
+| Freshness chain (content fingerprints) | Yes | - |
+| Tamper detection on approved documents | Yes | - |
 | AC ID traceability (task reference coverage) | Yes | - |
 | EARS grammar validation (keyword shape) | Yes | - |
 | Proof coverage per AC (via covers: field) | Yes | - |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -48,16 +48,21 @@ Each document begins with YAML frontmatter that tracks its lifecycle:
 status: draft|in-review|approved
 approved_at: 2026-03-22T10:00:00Z
 last_modified: 2026-03-22T10:00:00Z
-source_requirements_approved_at:  # design.md only
-source_design_approved_at:        # tasks.md only
+approved_fingerprint: sha256:...              # recorded at approval
+source_requirements_approved_at:              # design.md only
+source_requirements_fingerprint: sha256:...   # design.md only
+source_design_approved_at:                    # tasks.md only
+source_design_fingerprint: sha256:...         # tasks.md only
 ---
 ```
 
-The `source_*` fields create an approval chain. If an upstream document is re-approved with a new timestamp, downstream documents become stale and must be reconciled.
+The `source_*` fields create an approval chain. `walden review approve` records a SHA-256 fingerprint of the approved body and binds downstream approvals to the upstream's fingerprint. If an upstream document's approved content changes, downstream documents become stale and must be reconciled.
 
 ## Freshness
 
-A document is **fresh** when its `source_*` timestamp matches the current upstream `approved_at`. A document is **stale** when the upstream approval changed after the downstream was last approved.
+Freshness is decided by content fingerprints alone; timestamps remain as human-readable context.
+
+An approved document is **intact** when its body still matches its own `approved_fingerprint` — editing approved content without re-approval makes it stale regardless of metadata. A downstream document is **fresh** when it is intact and its `source_*_fingerprint` equals the upstream's current `approved_fingerprint`. Content-identical re-approval does not stale the chain. Missing or malformed fingerprints fail closed with a named cause (documents approved by pre-fingerprint versions repair with one `walden reconcile` + re-approval cycle).
 
 Stale documents block execution. Use `walden reconcile` to repair the chain.
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -112,13 +112,13 @@ This stops on the first failing proof while preserving earlier completions.
 
 ## 6. Reconcile
 
-If you edit an approved document, downstream documents become stale. Reconcile before continuing:
+If you edit an approved document, its content no longer matches the `approved_fingerprint` recorded at approval: the document and everything downstream become stale. Reconcile before continuing:
 
 ```bash
 walden reconcile user-auth
 ```
 
-This resets stale downstream documents to draft and updates approval metadata.
+This resets the modified document and stale downstream documents to draft and clears their approval fingerprints; re-approval records fresh ones.
 
 ## 7. Lessons
 

--- a/internal/app/e2e_test.go
+++ b/internal/app/e2e_test.go
@@ -139,13 +139,18 @@ source_design_approved_at: 2026-03-22T07:10:00Z
 		t.Fatalf("expected parent task 1 to auto-complete, got %#v", task)
 	}
 
+	// Requirements are re-approved with different content: the fixture writer
+	// stamps a fresh approval fingerprint, so the downstream source
+	// fingerprints no longer match.
 	writeStatusFeatureFile(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
-approved_at: 2026-03-22T07:00:00Z
+approved_at: 2026-03-22T07:45:00Z
 last_modified: 2026-03-22T07:45:00Z
 ---
 
 # Requirements Document
+
+Revised requirement content.
 `)
 
 	assertCommandSuccess(t, []string{"reconcile", "todo-app-demo"}, "reconciliation completed for todo-app-demo")
@@ -154,8 +159,8 @@ last_modified: 2026-03-22T07:45:00Z
 	if err != nil {
 		t.Fatalf("expected feature reload after reconcile to succeed, got %v", err)
 	}
-	if feature.Requirements.Status != "in-review" {
-		t.Fatalf("expected requirements to move to in-review, got %q", feature.Requirements.Status)
+	if feature.Requirements.Status != "approved" {
+		t.Fatalf("expected re-approved requirements to stay approved, got %q", feature.Requirements.Status)
 	}
 	if feature.Design.Status != "draft" {
 		t.Fatalf("expected design to reset to draft, got %q", feature.Design.Status)

--- a/internal/app/fingerprint_fixtures_test.go
+++ b/internal/app/fingerprint_fixtures_test.go
@@ -1,0 +1,102 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/spec"
+)
+
+// stampSpecFingerprint keeps approved fixtures fingerprint-fresh: it records
+// the document's own approval fingerprint and binds it to the upstream's,
+// mirroring what `review approve` does in production. Tests that need
+// staleness rewrite the file afterwards or corrupt the fingerprint fields.
+func stampSpecFingerprint(t *testing.T, root, featureName, name string) {
+	t.Helper()
+
+	feature, err := spec.LoadFeature(root, featureName)
+	if err != nil {
+		t.Fatalf("expected fixture feature load to succeed, got %v", err)
+	}
+
+	var document *spec.Document
+	switch name {
+	case "requirements.md":
+		document = &feature.Requirements
+	case "design.md":
+		document = &feature.Design
+	case "tasks.md":
+		document = &feature.Tasks
+	default:
+		return
+	}
+
+	if !document.Exists || document.Status != "approved" {
+		return
+	}
+
+	document.ApprovedFingerprint = spec.Fingerprint(document.Body)
+	document.Fields["approved_fingerprint"] = document.ApprovedFingerprint
+
+	switch name {
+	case "design.md":
+		if feature.Requirements.Status == "approved" {
+			fingerprint := feature.Requirements.ApprovedFingerprint
+			if fingerprint == "" {
+				fingerprint = spec.Fingerprint(feature.Requirements.Body)
+			}
+			document.SourceRequirementsFingerprint = fingerprint
+			document.Fields["source_requirements_fingerprint"] = fingerprint
+		}
+	case "tasks.md":
+		if feature.Design.Status == "approved" {
+			fingerprint := feature.Design.ApprovedFingerprint
+			if fingerprint == "" {
+				fingerprint = spec.Fingerprint(feature.Design.Body)
+			}
+			document.SourceDesignFingerprint = fingerprint
+			document.Fields["source_design_fingerprint"] = fingerprint
+		}
+	}
+
+	if err := spec.SaveDocument(*document); err != nil {
+		t.Fatalf("expected fixture fingerprint stamp to succeed, got %v", err)
+	}
+}
+
+// overrideSpecFingerprintField injects a fingerprint mismatch into a fixture,
+// for tests that need a stale chain.
+func overrideSpecFingerprintField(t *testing.T, root, featureName, name, key, value string) {
+	t.Helper()
+
+	feature, err := spec.LoadFeature(root, featureName)
+	if err != nil {
+		t.Fatalf("expected fixture feature load to succeed, got %v", err)
+	}
+
+	var document *spec.Document
+	switch name {
+	case "requirements.md":
+		document = &feature.Requirements
+	case "design.md":
+		document = &feature.Design
+	case "tasks.md":
+		document = &feature.Tasks
+	}
+	if document == nil || !document.Exists {
+		t.Fatalf("fixture document %q does not exist", name)
+	}
+
+	document.Fields[key] = value
+	switch key {
+	case "approved_fingerprint":
+		document.ApprovedFingerprint = value
+	case "source_requirements_fingerprint":
+		document.SourceRequirementsFingerprint = value
+	case "source_design_fingerprint":
+		document.SourceDesignFingerprint = value
+	}
+
+	if err := spec.SaveDocument(*document); err != nil {
+		t.Fatalf("expected fixture override save to succeed, got %v", err)
+	}
+}

--- a/internal/app/freshness_e2e_test.go
+++ b/internal/app/freshness_e2e_test.go
@@ -1,0 +1,261 @@
+package app
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/spec"
+)
+
+// TestEndToEndFingerprintHardeningLifecycle walks the full hardened chain:
+// approve -> tamper -> blocked with causes -> reconcile -> re-approve ->
+// execution restored. Every step drives the real CLI entrypoint.
+func TestEndToEndFingerprintHardeningLifecycle(t *testing.T) {
+	root := t.TempDir()
+
+	previousWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("expected working directory lookup to succeed, got %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(previousWD)
+	})
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("expected chdir to succeed, got %v", err)
+	}
+
+	writeDraft := func(name, body string) {
+		t.Helper()
+		sourceKey := ""
+		switch name {
+		case "design.md":
+			sourceKey = "source_requirements_approved_at:\n"
+		case "tasks.md":
+			sourceKey = "source_design_approved_at:\n"
+		}
+		content := "---\nstatus: draft\napproved_at:\nlast_modified: 2026-07-02T08:00:00Z\n" + sourceKey + "---\n\n" + body
+		dir := filepath.Join(root, ".walden", "specs", "hardening-demo")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("expected feature directory creation to succeed, got %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("expected %s write to succeed, got %v", name, err)
+		}
+	}
+
+	run := func(args ...string) (int, string, string) {
+		t.Helper()
+		var stdout, stderr bytes.Buffer
+		code := Run(args, &stdout, &stderr)
+		return code, stdout.String(), stderr.String()
+	}
+
+	mustSucceed := func(args ...string) string {
+		t.Helper()
+		code, stdout, stderr := run(args...)
+		if code != 0 {
+			t.Fatalf("expected %v to succeed, got %d with stderr %q", args, code, stderr)
+		}
+		return stdout
+	}
+
+	mustFailWith := func(want string, args ...string) {
+		t.Helper()
+		code, stdout, stderr := run(args...)
+		if code == 0 {
+			t.Fatalf("expected %v to fail, got success with stdout %q", args, stdout)
+		}
+		if !strings.Contains(stdout+stderr, want) {
+			t.Fatalf("expected %v output to contain %q, got stdout %q stderr %q", args, want, stdout, stderr)
+		}
+	}
+
+	requirementsBody := `# Requirements Document
+
+## Introduction
+
+Demo feature for the hardened chain.
+
+## Requirements
+
+### R1 Deterministic gate
+
+**User Story:** As a developer, I want blocking gates, so that drift stops.
+
+#### Acceptance Criteria
+
+1. ` + "`R1.AC1`" + ` WHEN a proof passes, the system SHALL mark the task complete.
+
+## Non-Functional Requirements
+
+- ` + "`NFR1`" + ` The system SHALL respond within one second.
+
+## Constraints And Dependencies
+
+- ` + "`C1`" + ` Local execution only.
+
+## Out Of Scope
+
+- None.
+`
+
+	designBody := `# Feature Design
+
+## Overview
+
+Design for ` + "`R1`" + `.
+
+## Architecture
+
+Single component.
+
+## Options Considered
+
+### Option A
+
+- Summary: Preferred.
+- Why chosen: Simpler.
+
+### Option B
+
+- Summary: Alternative.
+- Why rejected: More moving parts.
+
+## Simplicity And Elegance Review
+
+- Simplest viable shape: Minimal.
+- Coupling check: Low.
+- Future-proofing: Deferred.
+
+## Components And Interfaces
+
+### Gate
+
+- Purpose: Enforce ` + "`R1`" + `.
+- Inputs/Outputs: CLI.
+- Dependencies: None.
+- Requirements: ` + "`R1`" + `
+
+## Data Models
+
+None.
+
+## Error Handling
+
+Fail fast.
+
+## Security Considerations
+
+None.
+
+## Failure Modes And Tradeoffs
+
+- Failure mode: None.
+- Mitigation: None.
+- Tradeoff: None.
+
+## Testing Strategy
+
+Unit tests.
+
+## Verification Plan
+
+- Requirement proof: Tests.
+- Test evidence: ` + "`go test ./...`" + `
+- Operational evidence: None.
+
+## Requirement Coverage
+
+| Requirement | Covered By |
+| --- | --- |
+| ` + "`R1`" + ` | Gate |
+| ` + "`NFR1`" + ` | Tests |
+`
+
+	tasksBody := `# Implementation Plan
+
+- [ ] 1. Objective
+  - [ ] 1.1 Step
+    - Requirements: ` + "`R1.AC1`" + `, ` + "`NFR1`" + `
+    - Design: Gate
+    - Verification:
+      - command: ["go", "version"]
+        covers: ["R1.AC1"]
+`
+
+	// 1. Build a genuinely approved chain through the real approve path.
+	writeDraft("requirements.md", requirementsBody)
+	mustSucceed("review", "open", "hardening-demo", "--phase", "requirements")
+	mustSucceed("review", "approve", "hardening-demo", "--phase", "requirements")
+
+	writeDraft("design.md", designBody)
+	mustSucceed("review", "open", "hardening-demo", "--phase", "design")
+	mustSucceed("review", "approve", "hardening-demo", "--phase", "design")
+
+	writeDraft("tasks.md", tasksBody)
+	mustSucceed("review", "open", "hardening-demo", "--phase", "tasks")
+	mustSucceed("review", "approve", "hardening-demo", "--phase", "tasks")
+
+	feature, err := spec.LoadFeature(root, "hardening-demo")
+	if err != nil {
+		t.Fatalf("expected feature load to succeed, got %v", err)
+	}
+	if !spec.ValidFingerprint(feature.Requirements.ApprovedFingerprint) ||
+		!spec.ValidFingerprint(feature.Design.ApprovedFingerprint) ||
+		!spec.ValidFingerprint(feature.Tasks.ApprovedFingerprint) {
+		t.Fatal("expected the approve path to record valid fingerprints on the whole chain")
+	}
+	if feature.Design.SourceRequirementsFingerprint != feature.Requirements.ApprovedFingerprint {
+		t.Fatal("expected design to be bound to the requirements approval fingerprint")
+	}
+
+	mustSucceed("task", "status", "hardening-demo")
+
+	// 2. Tamper the approved requirements body without re-approval.
+	requirementsPath := filepath.Join(root, ".walden", "specs", "hardening-demo", "requirements.md")
+	content, err := os.ReadFile(requirementsPath)
+	if err != nil {
+		t.Fatalf("expected requirements read to succeed, got %v", err)
+	}
+	if err := os.WriteFile(requirementsPath, append(content, []byte("\nInjected after approval.\n")...), 0o644); err != nil {
+		t.Fatalf("expected tampered write to succeed, got %v", err)
+	}
+
+	// 3. The gates close, with the precise cause everywhere.
+	statusOut := mustSucceed("status", "hardening-demo")
+	if !strings.Contains(statusOut, "requirements.md is stale: content does not match approval fingerprint") {
+		t.Fatalf("expected status blockers to carry the tamper cause, got %q", statusOut)
+	}
+	mustFailWith("content does not match approval fingerprint", "validate", "hardening-demo", "--all")
+	mustFailWith("requirements.md is stale", "task", "start", "hardening-demo")
+	mustFailWith("requirements.md is stale", "task", "complete", "hardening-demo", "1.1")
+	mustFailWith("requirements.md is stale", "task", "complete-all", "hardening-demo")
+
+	// 4. Reconcile repairs deterministically: the tampered document and its
+	// downstream lose approval.
+	mustSucceed("reconcile", "hardening-demo")
+	feature, err = spec.LoadFeature(root, "hardening-demo")
+	if err != nil {
+		t.Fatalf("expected feature reload to succeed, got %v", err)
+	}
+	if feature.Requirements.Status != "draft" || feature.Design.Status != "draft" || feature.Tasks.Status != "draft" {
+		t.Fatalf("expected the whole chain to reset to draft, got %q/%q/%q",
+			feature.Requirements.Status, feature.Design.Status, feature.Tasks.Status)
+	}
+
+	// 5. Re-approval restores execution.
+	mustSucceed("review", "open", "hardening-demo", "--phase", "requirements")
+	mustSucceed("review", "approve", "hardening-demo", "--phase", "requirements")
+	mustSucceed("review", "open", "hardening-demo", "--phase", "design")
+	mustSucceed("review", "approve", "hardening-demo", "--phase", "design")
+	mustSucceed("review", "open", "hardening-demo", "--phase", "tasks")
+	mustSucceed("review", "approve", "hardening-demo", "--phase", "tasks")
+
+	startOut := mustSucceed("task", "start", "hardening-demo")
+	if !strings.Contains(startOut, "task start context for hardening-demo") {
+		t.Fatalf("expected execution to be restored, got %q", startOut)
+	}
+}

--- a/internal/app/reconcile_test.go
+++ b/internal/app/reconcile_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -46,6 +47,17 @@ source_design_approved_at: 2026-03-21T14:10:00Z
     - Verification: `+"`go test ./internal/app ./internal/output`"+`
 `)
 
+	// Edit the approved requirements body without re-approval: the recorded
+	// approval fingerprint no longer matches.
+	requirementsPath := filepath.Join(root, ".walden", "specs", "todo-app-demo", "requirements.md")
+	tampered, err := os.ReadFile(requirementsPath)
+	if err != nil {
+		t.Fatalf("expected requirements read to succeed, got %v", err)
+	}
+	if err := os.WriteFile(requirementsPath, append(tampered, []byte("\nInjected after approval.\n")...), 0o644); err != nil {
+		t.Fatalf("expected tampered write to succeed, got %v", err)
+	}
+
 	previousWD, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("expected working directory lookup to succeed, got %v", err)
@@ -77,7 +89,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 		".walden/specs/todo-app-demo/design.md",
 		".walden/specs/todo-app-demo/tasks.md",
 		"Current phase: requirements",
-		"Next action: Approve requirements.md",
+		"Next action: Edit requirements.md and move it to in-review",
 	} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("expected output to contain %q, got %q", want, rendered)
@@ -88,8 +100,8 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 	if err != nil {
 		t.Fatalf("expected feature reload to succeed, got %v", err)
 	}
-	if feature.Requirements.Status != "in-review" {
-		t.Fatalf("expected requirements to be in-review, got %q", feature.Requirements.Status)
+	if feature.Requirements.Status != "draft" {
+		t.Fatalf("expected tampered requirements to reset to draft, got %q", feature.Requirements.Status)
 	}
 	if feature.Design.Status != "draft" {
 		t.Fatalf("expected design to be draft, got %q", feature.Design.Status)

--- a/internal/app/review_approve_test.go
+++ b/internal/app/review_approve_test.go
@@ -129,4 +129,6 @@ func writeReviewApproveCommandFile(t *testing.T, root, feature, name, content st
 	if err := os.WriteFile(filepath.Join(featureDir, name), []byte(content), 0o644); err != nil {
 		t.Fatalf("expected write for %q to succeed, got %v", name, err)
 	}
+
+	stampSpecFingerprint(t, root, feature, name)
 }

--- a/internal/app/review_open_test.go
+++ b/internal/app/review_open_test.go
@@ -128,4 +128,6 @@ func writeReviewCommandFile(t *testing.T, root, feature, name, content string) {
 	if err := os.WriteFile(filepath.Join(featureDir, name), []byte(content), 0o644); err != nil {
 		t.Fatalf("expected write for %q to succeed, got %v", name, err)
 	}
+
+	stampSpecFingerprint(t, root, feature, name)
 }

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -974,10 +974,12 @@ func toOutputDocumentStatus(name string, document workflow.DocumentState) output
 	}
 
 	return output.DocumentStatus{
-		Name:       name,
-		Status:     status,
-		Fresh:      document.Exists && document.Fresh,
-		ApprovedAt: document.ApprovedAt,
+		Name:                name,
+		Status:              status,
+		Fresh:               document.Exists && document.Fresh,
+		ApprovedAt:          document.ApprovedAt,
+		ApprovedFingerprint: document.ApprovedFingerprint,
+		StaleCauses:         document.StaleCauses,
 	}
 }
 

--- a/internal/app/status_test.go
+++ b/internal/app/status_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/andrearaponi/walden/internal/output"
+	"github.com/andrearaponi/walden/internal/spec"
 )
 
 func TestRunStatusPrintsHumanReadableState(t *testing.T) {
@@ -157,6 +158,8 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 # Implementation Plan
 `)
+	// The design approval was recorded against different requirements content.
+	overrideSpecFingerprintField(t, root, "todo-app-demo", "design.md", "source_requirements_fingerprint", spec.Fingerprint("some earlier requirements content"))
 
 	previousWD, err := os.Getwd()
 	if err != nil {
@@ -319,4 +322,6 @@ func writeStatusFeatureFile(t *testing.T, root, feature, name, content string) {
 	if err := os.WriteFile(filepath.Join(featureDir, name), []byte(content), 0o644); err != nil {
 		t.Fatalf("expected write for %q to succeed, got %v", name, err)
 	}
+
+	stampSpecFingerprint(t, root, feature, name)
 }

--- a/internal/app/validate_test.go
+++ b/internal/app/validate_test.go
@@ -417,4 +417,6 @@ func writeValidateFeatureFile(t *testing.T, root, feature, name, content string)
 	if err := os.WriteFile(filepath.Join(featureDir, name), []byte(content), 0o644); err != nil {
 		t.Fatalf("expected %s write to succeed, got %v", name, err)
 	}
+
+	stampSpecFingerprint(t, root, feature, name)
 }

--- a/internal/output/result.go
+++ b/internal/output/result.go
@@ -9,26 +9,26 @@ import (
 
 // Result is the shared structured output model for CLI commands.
 type Result struct {
-	Summary               string           `json:"summary"`
-	CreatedFiles          []string         `json:"created_files,omitempty"`
-	UpdatedFiles          []string         `json:"updated_files,omitempty"`
-	ChangedFiles          []string         `json:"changed_files"`
-	SkippedFiles          []string         `json:"skipped_files"`
-	CompletedTasks        []string         `json:"completed_tasks,omitempty"`
-	AutoCompleted         []string         `json:"auto_completed,omitempty"`
-	ValidatedPhases       []string         `json:"validated_phases,omitempty"`
-	SkippedPhases         []string         `json:"skipped_phases,omitempty"`
-	GitInitialized        bool             `json:"git_initialized,omitempty"`
-	GitAlreadyInitialized bool             `json:"git_already_initialized,omitempty"`
-	CurrentPhase          string           `json:"current_phase,omitempty"`
-	BranchName            string           `json:"branch_name,omitempty"`
-	Document              string           `json:"document,omitempty"`
-	Documents             []DocumentStatus `json:"documents,omitempty"`
-	Task                  *TaskStatus      `json:"task,omitempty"`
-	Blockers              []string         `json:"blockers,omitempty"`
-	NextAction            string           `json:"next_action,omitempty"`
-	Warnings              []string         `json:"warnings"`
-	EARSValidation        []EARSCriterion  `json:"ears_validation,omitempty"`
+	Summary               string            `json:"summary"`
+	CreatedFiles          []string          `json:"created_files,omitempty"`
+	UpdatedFiles          []string          `json:"updated_files,omitempty"`
+	ChangedFiles          []string          `json:"changed_files"`
+	SkippedFiles          []string          `json:"skipped_files"`
+	CompletedTasks        []string          `json:"completed_tasks,omitempty"`
+	AutoCompleted         []string          `json:"auto_completed,omitempty"`
+	ValidatedPhases       []string          `json:"validated_phases,omitempty"`
+	SkippedPhases         []string          `json:"skipped_phases,omitempty"`
+	GitInitialized        bool              `json:"git_initialized,omitempty"`
+	GitAlreadyInitialized bool              `json:"git_already_initialized,omitempty"`
+	CurrentPhase          string            `json:"current_phase,omitempty"`
+	BranchName            string            `json:"branch_name,omitempty"`
+	Document              string            `json:"document,omitempty"`
+	Documents             []DocumentStatus  `json:"documents,omitempty"`
+	Task                  *TaskStatus       `json:"task,omitempty"`
+	Blockers              []string          `json:"blockers,omitempty"`
+	NextAction            string            `json:"next_action,omitempty"`
+	Warnings              []string          `json:"warnings"`
+	EARSValidation        []EARSCriterion   `json:"ears_validation,omitempty"`
 	Coverage              *CoverageReport   `json:"coverage,omitempty"`
 	EARSDistribution      *EARSDistribution `json:"ears_distribution,omitempty"`
 	ExitCode              int               `json:"exit_code"`
@@ -68,10 +68,12 @@ type EARSCriterion struct {
 
 // DocumentStatus is the shared output view for one Walden document.
 type DocumentStatus struct {
-	Name       string `json:"name"`
-	Status     string `json:"status"`
-	Fresh      bool   `json:"fresh"`
-	ApprovedAt string `json:"approved_at,omitempty"`
+	Name                string   `json:"name"`
+	Status              string   `json:"status"`
+	Fresh               bool     `json:"fresh"`
+	ApprovedAt          string   `json:"approved_at,omitempty"`
+	ApprovedFingerprint string   `json:"approved_fingerprint,omitempty"`
+	StaleCauses         []string `json:"stale_causes,omitempty"`
 }
 
 // TaskStatus is the shared output view for one execution task context.
@@ -157,6 +159,9 @@ func PrintText(w io.Writer, result Result) {
 			_, _ = fmt.Fprintf(w, "- %s: status=%s fresh=%t", document.Name, document.Status, document.Fresh)
 			if document.ApprovedAt != "" {
 				_, _ = fmt.Fprintf(w, " approved_at=%s", document.ApprovedAt)
+			}
+			if len(document.StaleCauses) > 0 {
+				_, _ = fmt.Fprintf(w, " causes: %s", strings.Join(document.StaleCauses, "; "))
 			}
 			_, _ = fmt.Fprintln(w)
 		}

--- a/internal/spec/feature.go
+++ b/internal/spec/feature.go
@@ -13,15 +13,18 @@ var featureNamePattern = regexp.MustCompile(`[^a-z0-9]+`)
 
 // Document models a spec document loaded from disk.
 type Document struct {
-	Path                         string
-	Status                       string
-	ApprovedAt                   string
-	LastModified                 string
-	SourceRequirementsApprovedAt string
-	SourceDesignApprovedAt       string
-	Fields                       map[string]string
-	Exists                       bool
-	Body                         string
+	Path                          string
+	Status                        string
+	ApprovedAt                    string
+	LastModified                  string
+	ApprovedFingerprint           string
+	SourceRequirementsApprovedAt  string
+	SourceDesignApprovedAt        string
+	SourceRequirementsFingerprint string
+	SourceDesignFingerprint       string
+	Fields                        map[string]string
+	Exists                        bool
+	Body                          string
 }
 
 // Feature contains the document set for one Walden feature.
@@ -104,14 +107,17 @@ func loadDocument(path string) (Document, error) {
 	}
 
 	return Document{
-		Path:                         path,
-		Status:                       values.Status,
-		ApprovedAt:                   values.ApprovedAt,
-		LastModified:                 values.LastModified,
-		SourceRequirementsApprovedAt: values.SourceRequirementsApprovedAt,
-		SourceDesignApprovedAt:       values.SourceDesignApprovedAt,
-		Fields:                       values.Fields,
-		Exists:                       true,
-		Body:                         body,
+		Path:                          path,
+		Status:                        values.Status,
+		ApprovedAt:                    values.ApprovedAt,
+		LastModified:                  values.LastModified,
+		ApprovedFingerprint:           values.ApprovedFingerprint,
+		SourceRequirementsApprovedAt:  values.SourceRequirementsApprovedAt,
+		SourceDesignApprovedAt:        values.SourceDesignApprovedAt,
+		SourceRequirementsFingerprint: values.SourceRequirementsFingerprint,
+		SourceDesignFingerprint:       values.SourceDesignFingerprint,
+		Fields:                        values.Fields,
+		Exists:                        true,
+		Body:                          body,
 	}, nil
 }

--- a/internal/spec/fingerprint.go
+++ b/internal/spec/fingerprint.go
@@ -1,0 +1,48 @@
+package spec
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+	"strings"
+)
+
+const fingerprintPrefix = "sha256:"
+
+var (
+	fingerprintPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	checkedTaskPattern = regexp.MustCompile(`(?m)^(\s*)- \[[xX]\]`)
+)
+
+// Fingerprint computes the canonical content fingerprint of a document body.
+// Normalization is deliberately minimal and versioned by design: CRLF and CR
+// become LF, checked task markers (`- [x]` / `- [X]` as a line's first token)
+// are fingerprinted as unchecked — checkbox state is execution progress owned
+// by `task complete`, not approved content — then leading and trailing
+// whitespace is trimmed. Changing this normalization re-fingerprints
+// identical content and is a breaking change.
+func Fingerprint(body string) string {
+	sum := sha256.Sum256([]byte(normalizeBody(body)))
+	return fingerprintPrefix + hex.EncodeToString(sum[:])
+}
+
+// ValidFingerprint reports whether value is a well-formed fingerprint.
+func ValidFingerprint(value string) bool {
+	return fingerprintPattern.MatchString(value)
+}
+
+// BodyMatchesFingerprint reports whether the body's fingerprint equals the
+// recorded value. Malformed recorded values never match (fail-closed).
+func BodyMatchesFingerprint(body, fingerprint string) bool {
+	if !ValidFingerprint(fingerprint) {
+		return false
+	}
+	return Fingerprint(body) == fingerprint
+}
+
+func normalizeBody(body string) string {
+	normalized := strings.ReplaceAll(body, "\r\n", "\n")
+	normalized = strings.ReplaceAll(normalized, "\r", "\n")
+	normalized = checkedTaskPattern.ReplaceAllString(normalized, "${1}- [ ]")
+	return strings.TrimSpace(normalized)
+}

--- a/internal/spec/fingerprint_roundtrip_test.go
+++ b/internal/spec/fingerprint_roundtrip_test.go
@@ -1,0 +1,144 @@
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFingerprintFieldsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "design.md")
+
+	body := "# Feature Design\n\nContent under review.\n"
+	fingerprint := Fingerprint(body)
+
+	document := Document{
+		Path:   path,
+		Status: "approved",
+		Fields: map[string]string{
+			"status":                          "approved",
+			"approved_at":                     "2026-07-02T08:00:00Z",
+			"last_modified":                   "2026-07-02T08:00:00Z",
+			"approved_fingerprint":            fingerprint,
+			"source_requirements_approved_at": "2026-07-02T07:45:06Z",
+			"source_requirements_fingerprint": fingerprint,
+		},
+		Exists: true,
+		Body:   body,
+	}
+
+	if err := SaveDocument(document); err != nil {
+		t.Fatalf("SaveDocument: %v", err)
+	}
+
+	loaded, err := loadDocument(path)
+	if err != nil {
+		t.Fatalf("loadDocument: %v", err)
+	}
+
+	if loaded.ApprovedFingerprint != fingerprint {
+		t.Fatalf("ApprovedFingerprint = %q, want %q", loaded.ApprovedFingerprint, fingerprint)
+	}
+	if loaded.SourceRequirementsFingerprint != fingerprint {
+		t.Fatalf("SourceRequirementsFingerprint = %q, want %q", loaded.SourceRequirementsFingerprint, fingerprint)
+	}
+	if got := Fingerprint(loaded.Body); got != fingerprint {
+		t.Fatalf("body fingerprint changed across save/load round-trip: %q != %q", got, fingerprint)
+	}
+}
+
+func TestFingerprintUnchangedByFrontmatterOnlyEdit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "requirements.md")
+
+	body := "# Requirements Document\n\n1. `R1.AC1` WHEN x, the system SHALL y.\n"
+	fingerprint := Fingerprint(body)
+
+	document := Document{
+		Path:   path,
+		Status: "approved",
+		Fields: map[string]string{
+			"status":               "approved",
+			"approved_at":          "2026-07-02T08:00:00Z",
+			"last_modified":        "2026-07-02T08:00:00Z",
+			"approved_fingerprint": fingerprint,
+		},
+		Exists: true,
+		Body:   body,
+	}
+	if err := SaveDocument(document); err != nil {
+		t.Fatalf("SaveDocument: %v", err)
+	}
+
+	// Frontmatter-only edit: change workflow metadata, leave the body alone.
+	document.Fields["status"] = "in-review"
+	document.Fields["last_modified"] = "2026-07-03T09:00:00Z"
+	if err := SaveDocument(document); err != nil {
+		t.Fatalf("SaveDocument after frontmatter edit: %v", err)
+	}
+
+	loaded, err := loadDocument(path)
+	if err != nil {
+		t.Fatalf("loadDocument: %v", err)
+	}
+	if got := Fingerprint(loaded.Body); got != fingerprint {
+		t.Fatalf("frontmatter-only edit changed the body fingerprint: %q != %q", got, fingerprint)
+	}
+}
+
+func TestFingerprintResetClearsFields(t *testing.T) {
+	body := "# Implementation Plan\n\n- [ ] 1. Objective\n"
+	document := Document{
+		Path:                    "tasks.md",
+		Status:                  "approved",
+		ApprovedAt:              "2026-07-02T08:00:00Z",
+		LastModified:            "2026-07-02T08:00:00Z",
+		ApprovedFingerprint:     Fingerprint(body),
+		SourceDesignApprovedAt:  "2026-07-02T07:50:00Z",
+		SourceDesignFingerprint: Fingerprint("design body"),
+		Fields: map[string]string{
+			"status":                    "approved",
+			"approved_at":               "2026-07-02T08:00:00Z",
+			"last_modified":             "2026-07-02T08:00:00Z",
+			"approved_fingerprint":      Fingerprint(body),
+			"source_design_approved_at": "2026-07-02T07:50:00Z",
+			"source_design_fingerprint": Fingerprint("design body"),
+		},
+		Exists: true,
+		Body:   body,
+	}
+
+	reset, err := ResetDocumentToDraft(document, "2026-07-03T09:00:00Z")
+	if err != nil {
+		t.Fatalf("ResetDocumentToDraft: %v", err)
+	}
+
+	if reset.ApprovedFingerprint != "" || reset.Fields["approved_fingerprint"] != "" {
+		t.Fatalf("approved fingerprint not cleared: %q / %q", reset.ApprovedFingerprint, reset.Fields["approved_fingerprint"])
+	}
+	if reset.SourceDesignFingerprint != "" || reset.Fields["source_design_fingerprint"] != "" {
+		t.Fatalf("source design fingerprint not cleared: %q / %q", reset.SourceDesignFingerprint, reset.Fields["source_design_fingerprint"])
+	}
+	if reset.Status != "draft" {
+		t.Fatalf("status = %q, want draft", reset.Status)
+	}
+}
+
+func TestFingerprintLegacyDocumentLoadsWithoutFingerprint(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "requirements.md")
+
+	legacy := "---\nstatus: approved\napproved_at: 2026-04-01T10:00:00Z\nlast_modified: 2026-04-01T10:00:00Z\n---\n\n# Requirements Document\n"
+	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("write legacy document: %v", err)
+	}
+
+	loaded, err := loadDocument(path)
+	if err != nil {
+		t.Fatalf("loadDocument: %v", err)
+	}
+	if loaded.ApprovedFingerprint != "" {
+		t.Fatalf("legacy document should have no fingerprint, got %q", loaded.ApprovedFingerprint)
+	}
+}

--- a/internal/spec/fingerprint_test.go
+++ b/internal/spec/fingerprint_test.go
@@ -1,0 +1,161 @@
+package spec
+
+import "testing"
+
+func TestFingerprintGoldenVectors(t *testing.T) {
+	// Known SHA-256 vectors pin the normalization contract: any future change
+	// to normalization breaks these values and must be treated as breaking.
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "empty body",
+			body: "",
+			want: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		{
+			name: "whitespace-only body normalizes to empty",
+			body: "\n\n  \n",
+			want: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		{
+			name: "abc NIST vector",
+			body: "abc",
+			want: "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+		},
+		{
+			name: "abc with surrounding whitespace",
+			body: "\nabc\n",
+			want: "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := Fingerprint(test.body); got != test.want {
+				t.Fatalf("Fingerprint(%q) = %q, want %q", test.body, got, test.want)
+			}
+		})
+	}
+}
+
+func TestFingerprintLineEndingNormalization(t *testing.T) {
+	reference := Fingerprint("# Title\n\nBody line one\nBody line two\n")
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"CRLF endings", "# Title\r\n\r\nBody line one\r\nBody line two\r\n"},
+		{"CR endings", "# Title\r\rBody line one\rBody line two\r"},
+		{"mixed endings", "# Title\r\n\nBody line one\rBody line two\r\n"},
+		{"extra leading and trailing whitespace", "\n\n# Title\n\nBody line one\nBody line two\n\n\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := Fingerprint(test.body); got != reference {
+				t.Fatalf("Fingerprint(%q) = %q, want reference %q", test.body, got, reference)
+			}
+		})
+	}
+}
+
+func TestFingerprintCheckboxStateInsensitivity(t *testing.T) {
+	unchecked := "# Implementation Plan\n\n- [ ] 1. Objective\n  - [ ] 1.1 Step one\n  - [ ] 1.2 Step two\n"
+	partiallyChecked := "# Implementation Plan\n\n- [ ] 1. Objective\n  - [x] 1.1 Step one\n  - [ ] 1.2 Step two\n"
+	fullyChecked := "# Implementation Plan\n\n- [x] 1. Objective\n  - [x] 1.1 Step one\n  - [X] 1.2 Step two\n"
+
+	reference := Fingerprint(unchecked)
+	if got := Fingerprint(partiallyChecked); got != reference {
+		t.Fatalf("partially checked plan fingerprint diverged: %q != %q", got, reference)
+	}
+	if got := Fingerprint(fullyChecked); got != reference {
+		t.Fatalf("fully checked plan fingerprint diverged: %q != %q", got, reference)
+	}
+}
+
+func TestFingerprintCheckboxNormalizationScope(t *testing.T) {
+	// Only a line's leading task marker is normalized: inline bracket text
+	// and non-list lines remain distinguishing content.
+	if Fingerprint("verify the [x] flag") == Fingerprint("verify the [ ] flag") {
+		t.Fatal("inline bracket text must remain distinguishing content")
+	}
+	if Fingerprint("- [x] done") != Fingerprint("- [ ] done") {
+		t.Fatal("leading task marker must be normalized")
+	}
+	if Fingerprint("note - [x] not a marker") == Fingerprint("note - [ ] not a marker") {
+		t.Fatal("mid-line dashes must not be treated as task markers")
+	}
+}
+
+func TestFingerprintIsDeterministic(t *testing.T) {
+	body := "# Requirements\n\n1. `R1.AC1` WHEN x, the system SHALL y.\n"
+	first := Fingerprint(body)
+	for i := 0; i < 100; i++ {
+		if got := Fingerprint(body); got != first {
+			t.Fatalf("Fingerprint is not deterministic: %q != %q", got, first)
+		}
+	}
+}
+
+func TestFingerprintDistinguishesContent(t *testing.T) {
+	if Fingerprint("alpha") == Fingerprint("beta") {
+		t.Fatal("different bodies produced the same fingerprint")
+	}
+}
+
+func TestFingerprintValidation(t *testing.T) {
+	valid := Fingerprint("any content")
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"computed fingerprint", valid, true},
+		{"empty string", "", false},
+		{"missing prefix", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", false},
+		{"wrong prefix", "sha512:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", false},
+		{"short digest", "sha256:e3b0c442", false},
+		{"uppercase hex", "sha256:E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855", false},
+		{"trailing garbage", "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855x", false},
+		{"non-hex characters", "sha256:z3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85z", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ValidFingerprint(test.value); got != test.want {
+				t.Fatalf("ValidFingerprint(%q) = %t, want %t", test.value, got, test.want)
+			}
+		})
+	}
+}
+
+func TestFingerprintBodyMatch(t *testing.T) {
+	body := "# Design\n\nContent under approval.\n"
+	recorded := Fingerprint(body)
+
+	tests := []struct {
+		name        string
+		body        string
+		fingerprint string
+		want        bool
+	}{
+		{"matching body", body, recorded, true},
+		{"matching body with CRLF endings", "# Design\r\n\r\nContent under approval.\r\n", recorded, true},
+		{"edited body", body + "\nInjected line.\n", recorded, false},
+		{"malformed fingerprint fails closed", body, "sha256:not-a-digest", false},
+		{"empty fingerprint fails closed", body, "", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := BodyMatchesFingerprint(test.body, test.fingerprint); got != test.want {
+				t.Fatalf("BodyMatchesFingerprint(%q, %q) = %t, want %t", test.body, test.fingerprint, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/spec/freshness.go
+++ b/internal/spec/freshness.go
@@ -1,0 +1,107 @@
+package spec
+
+// Stale cause strings are stable identifiers shared by blockers, validation
+// errors, and JSON output. Changing them is a contract change.
+const (
+	CauseFingerprintMissing   = "approval fingerprint missing"
+	CauseFingerprintMalformed = "approval fingerprint malformed"
+	CauseContentMismatch      = "content does not match approval fingerprint"
+	CauseSourceMismatch       = "source fingerprint mismatch"
+	CauseUpstreamStale        = "upstream document is stale"
+	CauseUpstreamNotApproved  = "upstream document is not approved"
+)
+
+// DocumentFreshness is the fingerprint-based verdict for one document.
+// Non-approved documents are vacuously intact and fresh: they are not yet
+// bound to any approved content.
+type DocumentFreshness struct {
+	Intact bool
+	Fresh  bool
+	Causes []string
+}
+
+// FreshnessReport is the single verdict source for workflow state, review
+// gates, validation, and reconciliation.
+type FreshnessReport struct {
+	Requirements DocumentFreshness
+	Design       DocumentFreshness
+	Tasks        DocumentFreshness
+}
+
+// EvaluateFreshness computes fingerprint-based integrity and chain freshness
+// for a feature. Fingerprint comparison alone decides every verdict;
+// timestamp fields are not consulted.
+func EvaluateFreshness(feature Feature) FreshnessReport {
+	report := FreshnessReport{
+		Requirements: documentIntegrity(feature.Requirements),
+		Design:       documentIntegrity(feature.Design),
+		Tasks:        documentIntegrity(feature.Tasks),
+	}
+
+	evaluateChainLink(
+		&report.Design,
+		feature.Design,
+		feature.Design.SourceRequirementsFingerprint,
+		feature.Requirements,
+		report.Requirements,
+	)
+	evaluateChainLink(
+		&report.Tasks,
+		feature.Tasks,
+		feature.Tasks.SourceDesignFingerprint,
+		feature.Design,
+		report.Design,
+	)
+
+	// Cascade: a stale approved design invalidates tasks regardless of the
+	// tasks document's own link.
+	if feature.Design.Exists && feature.Design.Status == "approved" && !report.Design.Fresh {
+		if feature.Tasks.Exists && report.Tasks.Fresh {
+			report.Tasks.Fresh = false
+			report.Tasks.Causes = append(report.Tasks.Causes, CauseUpstreamStale)
+		}
+	}
+
+	return report
+}
+
+// documentIntegrity verifies an approved document's body against its own
+// approval fingerprint. Missing, malformed, and mismatching fingerprints all
+// fail closed with a distinct cause.
+func documentIntegrity(document Document) DocumentFreshness {
+	if !document.Exists || document.Status != "approved" {
+		return DocumentFreshness{Intact: true, Fresh: true}
+	}
+
+	switch {
+	case document.ApprovedFingerprint == "":
+		return DocumentFreshness{Causes: []string{CauseFingerprintMissing}}
+	case !ValidFingerprint(document.ApprovedFingerprint):
+		return DocumentFreshness{Causes: []string{CauseFingerprintMalformed}}
+	case !BodyMatchesFingerprint(document.Body, document.ApprovedFingerprint):
+		return DocumentFreshness{Causes: []string{CauseContentMismatch}}
+	default:
+		return DocumentFreshness{Intact: true, Fresh: true}
+	}
+}
+
+// evaluateChainLink binds an approved downstream document to its upstream:
+// the recorded source fingerprint must equal the upstream's current approval
+// fingerprint, and the upstream itself must be approved and intact.
+func evaluateChainLink(verdict *DocumentFreshness, downstream Document, sourceFingerprint string, upstream Document, upstreamVerdict DocumentFreshness) {
+	if !downstream.Exists || downstream.Status != "approved" || !verdict.Intact {
+		return
+	}
+
+	switch {
+	case upstream.Status != "approved":
+		verdict.Fresh = false
+		verdict.Causes = append(verdict.Causes, CauseUpstreamNotApproved)
+	case !upstreamVerdict.Intact:
+		verdict.Fresh = false
+		verdict.Causes = append(verdict.Causes, CauseUpstreamStale)
+	case sourceFingerprint != upstream.ApprovedFingerprint:
+		verdict.Fresh = false
+		verdict.Causes = append(verdict.Causes, CauseSourceMismatch)
+	}
+}

--- a/internal/spec/freshness_test.go
+++ b/internal/spec/freshness_test.go
@@ -1,0 +1,192 @@
+package spec
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	reqBody    = "# Requirements Document\n\n1. `R1.AC1` WHEN x, the system SHALL y.\n"
+	designBody = "# Feature Design\n\nArchitecture.\n"
+	tasksBody  = "# Implementation Plan\n\n- [ ] 1. Objective\n"
+)
+
+func approvedDocument(name, body string) Document {
+	return Document{
+		Path:                name,
+		Status:              "approved",
+		ApprovedAt:          "2026-07-02T08:00:00Z",
+		LastModified:        "2026-07-02T08:00:00Z",
+		ApprovedFingerprint: Fingerprint(body),
+		Fields:              map[string]string{},
+		Exists:              true,
+		Body:                body,
+	}
+}
+
+func approvedChain() Feature {
+	requirements := approvedDocument("requirements.md", reqBody)
+	design := approvedDocument("design.md", designBody)
+	design.SourceRequirementsFingerprint = requirements.ApprovedFingerprint
+	tasks := approvedDocument("tasks.md", tasksBody)
+	tasks.SourceDesignFingerprint = design.ApprovedFingerprint
+
+	return Feature{
+		Name:         "example",
+		Requirements: requirements,
+		Design:       design,
+		Tasks:        tasks,
+	}
+}
+
+func TestEvaluateFreshnessApprovedChainIsFresh(t *testing.T) {
+	report := EvaluateFreshness(approvedChain())
+
+	for name, verdict := range map[string]DocumentFreshness{
+		"requirements": report.Requirements,
+		"design":       report.Design,
+		"tasks":        report.Tasks,
+	} {
+		if !verdict.Intact || !verdict.Fresh || len(verdict.Causes) != 0 {
+			t.Fatalf("%s: expected intact+fresh with no causes, got %+v", name, verdict)
+		}
+	}
+}
+
+func TestEvaluateFreshnessDraftsAreVacuouslyFresh(t *testing.T) {
+	feature := approvedChain()
+	feature.Design.Status = "draft"
+	feature.Design.ApprovedFingerprint = ""
+	feature.Tasks.Status = "draft"
+	feature.Tasks.ApprovedFingerprint = ""
+
+	report := EvaluateFreshness(feature)
+	if !report.Design.Intact || !report.Design.Fresh {
+		t.Fatalf("draft design should be vacuously fresh, got %+v", report.Design)
+	}
+	if !report.Tasks.Intact || !report.Tasks.Fresh {
+		t.Fatalf("draft tasks should be vacuously fresh, got %+v", report.Tasks)
+	}
+}
+
+func TestEvaluateFreshnessMissingFingerprint(t *testing.T) {
+	feature := approvedChain()
+	feature.Requirements.ApprovedFingerprint = ""
+
+	report := EvaluateFreshness(feature)
+	if report.Requirements.Intact || report.Requirements.Fresh {
+		t.Fatalf("approved document without fingerprint must be stale, got %+v", report.Requirements)
+	}
+	if got := strings.Join(report.Requirements.Causes, ";"); got != CauseFingerprintMissing {
+		t.Fatalf("causes = %q, want %q", got, CauseFingerprintMissing)
+	}
+	if report.Design.Fresh {
+		t.Fatalf("design must not be fresh over a stale upstream, got %+v", report.Design)
+	}
+}
+
+func TestEvaluateFreshnessMalformedFingerprint(t *testing.T) {
+	feature := approvedChain()
+	feature.Requirements.ApprovedFingerprint = "sha256:not-a-digest"
+
+	report := EvaluateFreshness(feature)
+	if report.Requirements.Intact {
+		t.Fatalf("malformed fingerprint must fail closed, got %+v", report.Requirements)
+	}
+	if got := strings.Join(report.Requirements.Causes, ";"); got != CauseFingerprintMalformed {
+		t.Fatalf("causes = %q, want %q", got, CauseFingerprintMalformed)
+	}
+}
+
+func TestEvaluateFreshnessTamperedBody(t *testing.T) {
+	feature := approvedChain()
+	feature.Requirements.Body += "\nInjected requirement.\n"
+
+	report := EvaluateFreshness(feature)
+	if report.Requirements.Intact || report.Requirements.Fresh {
+		t.Fatalf("tampered approved document must be stale, got %+v", report.Requirements)
+	}
+	if got := strings.Join(report.Requirements.Causes, ";"); got != CauseContentMismatch {
+		t.Fatalf("causes = %q, want %q", got, CauseContentMismatch)
+	}
+	if report.Design.Fresh || report.Tasks.Fresh {
+		t.Fatalf("downstream must not stay fresh over a tampered upstream: design=%+v tasks=%+v", report.Design, report.Tasks)
+	}
+}
+
+func TestEvaluateFreshnessChainMismatch(t *testing.T) {
+	feature := approvedChain()
+	feature.Design.SourceRequirementsFingerprint = Fingerprint("some other requirements content")
+
+	report := EvaluateFreshness(feature)
+	if !report.Design.Intact {
+		t.Fatalf("design integrity should hold, got %+v", report.Design)
+	}
+	if report.Design.Fresh {
+		t.Fatalf("design must be stale on source fingerprint mismatch, got %+v", report.Design)
+	}
+	if got := strings.Join(report.Design.Causes, ";"); got != CauseSourceMismatch {
+		t.Fatalf("causes = %q, want %q", got, CauseSourceMismatch)
+	}
+	if report.Tasks.Fresh {
+		t.Fatalf("tasks must cascade stale when design is stale, got %+v", report.Tasks)
+	}
+	if got := strings.Join(report.Tasks.Causes, ";"); got != CauseUpstreamStale {
+		t.Fatalf("tasks causes = %q, want %q", got, CauseUpstreamStale)
+	}
+}
+
+func TestEvaluateFreshnessFingerprintComparisonAloneDecides(t *testing.T) {
+	// Content-identical re-approval: approved_at diverges from the recorded
+	// source timestamp, but fingerprints match. The chain must stay fresh.
+	feature := approvedChain()
+	feature.Requirements.ApprovedAt = "2026-07-09T10:00:00Z"
+	feature.Requirements.LastModified = "2026-07-09T10:00:00Z"
+	feature.Design.SourceRequirementsApprovedAt = "2026-07-02T08:00:00Z"
+
+	report := EvaluateFreshness(feature)
+	if !report.Design.Fresh {
+		t.Fatalf("fingerprint match must keep design fresh regardless of timestamps, got %+v", report.Design)
+	}
+	if !report.Tasks.Fresh {
+		t.Fatalf("fingerprint match must keep tasks fresh regardless of timestamps, got %+v", report.Tasks)
+	}
+}
+
+func TestEvaluateFreshnessUpstreamNotApproved(t *testing.T) {
+	feature := approvedChain()
+	feature.Requirements.Status = "draft"
+	feature.Requirements.ApprovedFingerprint = ""
+
+	report := EvaluateFreshness(feature)
+	if report.Design.Fresh {
+		t.Fatalf("approved design over unapproved requirements must be stale, got %+v", report.Design)
+	}
+	if got := strings.Join(report.Design.Causes, ";"); got != CauseUpstreamNotApproved {
+		t.Fatalf("causes = %q, want %q", got, CauseUpstreamNotApproved)
+	}
+}
+
+func TestEvaluateFreshnessLegacyChainFullyStale(t *testing.T) {
+	// A pre-fingerprint feature: everything approved, no fingerprints anywhere.
+	feature := approvedChain()
+	feature.Requirements.ApprovedFingerprint = ""
+	feature.Design.ApprovedFingerprint = ""
+	feature.Design.SourceRequirementsFingerprint = ""
+	feature.Tasks.ApprovedFingerprint = ""
+	feature.Tasks.SourceDesignFingerprint = ""
+
+	report := EvaluateFreshness(feature)
+	for name, verdict := range map[string]DocumentFreshness{
+		"requirements": report.Requirements,
+		"design":       report.Design,
+		"tasks":        report.Tasks,
+	} {
+		if verdict.Fresh {
+			t.Fatalf("%s: legacy approved document must be stale under strict migration, got %+v", name, verdict)
+		}
+		if len(verdict.Causes) == 0 || verdict.Causes[0] != CauseFingerprintMissing {
+			t.Fatalf("%s: first cause must be %q, got %v", name, CauseFingerprintMissing, verdict.Causes)
+		}
+	}
+}

--- a/internal/spec/frontmatter.go
+++ b/internal/spec/frontmatter.go
@@ -10,12 +10,15 @@ import (
 var frontmatterPattern = regexp.MustCompile(`(?s)\A---\n(.*?)\n---\n?`)
 
 type frontmatter struct {
-	Status                       string
-	ApprovedAt                   string
-	LastModified                 string
-	SourceRequirementsApprovedAt string
-	SourceDesignApprovedAt       string
-	Fields                       map[string]string
+	Status                        string
+	ApprovedAt                    string
+	LastModified                  string
+	ApprovedFingerprint           string
+	SourceRequirementsApprovedAt  string
+	SourceDesignApprovedAt        string
+	SourceRequirementsFingerprint string
+	SourceDesignFingerprint       string
+	Fields                        map[string]string
 }
 
 func parseFrontmatter(text string) (frontmatter, string, error) {
@@ -46,10 +49,16 @@ func parseFrontmatter(text string) (frontmatter, string, error) {
 			values.ApprovedAt = value
 		case "last_modified":
 			values.LastModified = value
+		case "approved_fingerprint":
+			values.ApprovedFingerprint = value
 		case "source_requirements_approved_at":
 			values.SourceRequirementsApprovedAt = value
 		case "source_design_approved_at":
 			values.SourceDesignApprovedAt = value
+		case "source_requirements_fingerprint":
+			values.SourceRequirementsFingerprint = value
+		case "source_design_fingerprint":
+			values.SourceDesignFingerprint = value
 		}
 	}
 

--- a/internal/spec/reconcile.go
+++ b/internal/spec/reconcile.go
@@ -5,30 +5,6 @@ import (
 	"path/filepath"
 )
 
-// DowngradeDocumentToInReview clears invalid approval metadata on a document while preserving upstream source references.
-func DowngradeDocumentToInReview(document Document, lastModified string) (Document, error) {
-	if !document.Exists {
-		return Document{}, fmt.Errorf("document does not exist")
-	}
-	if lastModified == "" {
-		return Document{}, fmt.Errorf("last_modified is required")
-	}
-
-	updated, err := cloneDocument(document)
-	if err != nil {
-		return Document{}, err
-	}
-
-	updated.Status = "in-review"
-	updated.ApprovedAt = ""
-	updated.LastModified = lastModified
-	updated.Fields["status"] = updated.Status
-	updated.Fields["approved_at"] = updated.ApprovedAt
-	updated.Fields["last_modified"] = updated.LastModified
-
-	return updated, nil
-}
-
 // ResetDocumentToDraft clears invalid approval metadata and returns the document to draft.
 func ResetDocumentToDraft(document Document, lastModified string) (Document, error) {
 	if !document.Exists {
@@ -46,20 +22,26 @@ func ResetDocumentToDraft(document Document, lastModified string) (Document, err
 	updated.Status = "draft"
 	updated.ApprovedAt = ""
 	updated.LastModified = lastModified
+	updated.ApprovedFingerprint = ""
 	updated.Fields["status"] = updated.Status
 	updated.Fields["approved_at"] = updated.ApprovedAt
 	updated.Fields["last_modified"] = updated.LastModified
+	updated.Fields["approved_fingerprint"] = updated.ApprovedFingerprint
 
 	switch filepath.Base(document.Path) {
 	case "requirements.md":
 		return updated, nil
 	case "design.md":
 		updated.SourceRequirementsApprovedAt = ""
+		updated.SourceRequirementsFingerprint = ""
 		updated.Fields["source_requirements_approved_at"] = updated.SourceRequirementsApprovedAt
+		updated.Fields["source_requirements_fingerprint"] = updated.SourceRequirementsFingerprint
 		return updated, nil
 	case "tasks.md":
 		updated.SourceDesignApprovedAt = ""
+		updated.SourceDesignFingerprint = ""
 		updated.Fields["source_design_approved_at"] = updated.SourceDesignApprovedAt
+		updated.Fields["source_design_fingerprint"] = updated.SourceDesignFingerprint
 		return updated, nil
 	default:
 		return Document{}, fmt.Errorf("unsupported document path %q", document.Path)

--- a/internal/spec/reconcile_test.go
+++ b/internal/spec/reconcile_test.go
@@ -2,48 +2,37 @@ package spec
 
 import "testing"
 
-func TestDowngradeDocumentToInReviewClearsApprovalMetadataAndPreservesSourceFields(t *testing.T) {
+func TestResetDocumentToDraftClearsFingerprintFields(t *testing.T) {
 	document := Document{
-		Path:                         "design.md",
-		Status:                       "approved",
-		ApprovedAt:                   "2026-03-21T14:10:00Z",
-		LastModified:                 "2026-03-21T14:10:00Z",
-		SourceRequirementsApprovedAt: "2026-03-21T14:00:00Z",
-		Exists:                       true,
-		Body:                         "# Feature Design\n",
+		Path:                          "design.md",
+		Status:                        "approved",
+		ApprovedAt:                    "2026-03-21T14:10:00Z",
+		LastModified:                  "2026-03-21T14:10:00Z",
+		ApprovedFingerprint:           Fingerprint("# Feature Design\n"),
+		SourceRequirementsApprovedAt:  "2026-03-21T14:00:00Z",
+		SourceRequirementsFingerprint: Fingerprint("# Requirements Document\n"),
+		Exists:                        true,
+		Body:                          "# Feature Design\n",
 		Fields: map[string]string{
 			"status":                          "approved",
 			"approved_at":                     "2026-03-21T14:10:00Z",
 			"last_modified":                   "2026-03-21T14:10:00Z",
+			"approved_fingerprint":            Fingerprint("# Feature Design\n"),
 			"source_requirements_approved_at": "2026-03-21T14:00:00Z",
+			"source_requirements_fingerprint": Fingerprint("# Requirements Document\n"),
 		},
 	}
 
-	updated, err := DowngradeDocumentToInReview(document, "2026-03-21T18:50:00Z")
+	updated, err := ResetDocumentToDraft(document, "2026-03-21T18:50:00Z")
 	if err != nil {
-		t.Fatalf("expected downgrade to succeed, got %v", err)
+		t.Fatalf("expected reset to draft to succeed, got %v", err)
 	}
 
-	if updated.Status != "in-review" {
-		t.Fatalf("expected in-review status, got %q", updated.Status)
+	if updated.ApprovedFingerprint != "" || updated.Fields["approved_fingerprint"] != "" {
+		t.Fatalf("expected approval fingerprint to be cleared, got %q / %q", updated.ApprovedFingerprint, updated.Fields["approved_fingerprint"])
 	}
-	if updated.ApprovedAt != "" {
-		t.Fatalf("expected cleared approved_at, got %q", updated.ApprovedAt)
-	}
-	if updated.LastModified != "2026-03-21T18:50:00Z" {
-		t.Fatalf("unexpected last_modified: %q", updated.LastModified)
-	}
-	if updated.SourceRequirementsApprovedAt != "2026-03-21T14:00:00Z" {
-		t.Fatalf("expected source requirements timestamp to be preserved, got %q", updated.SourceRequirementsApprovedAt)
-	}
-	if updated.Fields["status"] != "in-review" {
-		t.Fatalf("unexpected status field: %q", updated.Fields["status"])
-	}
-	if updated.Fields["approved_at"] != "" {
-		t.Fatalf("expected empty approved_at field, got %q", updated.Fields["approved_at"])
-	}
-	if updated.Fields["source_requirements_approved_at"] != "2026-03-21T14:00:00Z" {
-		t.Fatalf("expected source requirements field to be preserved, got %q", updated.Fields["source_requirements_approved_at"])
+	if updated.SourceRequirementsFingerprint != "" || updated.Fields["source_requirements_fingerprint"] != "" {
+		t.Fatalf("expected source fingerprint to be cleared, got %q / %q", updated.SourceRequirementsFingerprint, updated.Fields["source_requirements_fingerprint"])
 	}
 }
 

--- a/internal/spec/write.go
+++ b/internal/spec/write.go
@@ -47,11 +47,11 @@ func SaveDocument(document Document) error {
 func orderedFrontmatterKeys(path string) ([]string, error) {
 	switch filepath.Base(path) {
 	case "requirements.md":
-		return []string{"status", "approved_at", "last_modified"}, nil
+		return []string{"status", "approved_at", "last_modified", "approved_fingerprint"}, nil
 	case "design.md":
-		return []string{"status", "approved_at", "last_modified", "source_requirements_approved_at"}, nil
+		return []string{"status", "approved_at", "last_modified", "approved_fingerprint", "source_requirements_approved_at", "source_requirements_fingerprint"}, nil
 	case "tasks.md":
-		return []string{"status", "approved_at", "last_modified", "source_design_approved_at"}, nil
+		return []string{"status", "approved_at", "last_modified", "approved_fingerprint", "source_design_approved_at", "source_design_fingerprint"}, nil
 	default:
 		return nil, fmt.Errorf("unsupported document path %q", path)
 	}

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -35,15 +35,15 @@ var (
 
 // Result is the deterministic outcome of a validation run.
 type Result struct {
-	Feature         string
-	SpecDir         string
-	Valid           bool
-	Message         string
-	Scope           Scope
-	ValidatedPhases []string
-	SkippedPhases   []string
-	Warnings        []string
-	EARSResults     []EARSCriterion
+	Feature          string
+	SpecDir          string
+	Valid            bool
+	Message          string
+	Scope            Scope
+	ValidatedPhases  []string
+	SkippedPhases    []string
+	Warnings         []string
+	EARSResults      []EARSCriterion
 	Coverage         *CoverageReport
 	EARSDistribution *EARSDistribution
 }
@@ -582,32 +582,30 @@ func validatePrerequisites(feature spec.Feature) error {
 }
 
 func validateFreshness(feature spec.Feature, plan validationPlan) error {
-	if plan.validateDesign && feature.Design.Exists && feature.Design.Status == "approved" {
-		equal, err := timestampsEqual(feature.Requirements.ApprovedAt, feature.Design.SourceRequirementsApprovedAt)
-		if err != nil {
-			return fmt.Errorf("design.md freshness check: %w", err)
-		}
-		if !equal {
-			return fmt.Errorf("design.md is stale relative to requirements.md")
-		}
+	report := spec.EvaluateFreshness(feature)
+
+	if plan.validateRequirements && feature.Requirements.Exists &&
+		feature.Requirements.Status == "approved" && !report.Requirements.Fresh {
+		return fmt.Errorf("requirements.md is stale: %s", strings.Join(report.Requirements.Causes, "; "))
 	}
-	if plan.validateTasks && feature.Tasks.Exists && feature.Tasks.Status == "approved" {
-		equal, err := timestampsEqual(feature.Design.ApprovedAt, feature.Tasks.SourceDesignApprovedAt)
-		if err != nil {
-			return fmt.Errorf("tasks.md freshness check: %w", err)
-		}
-		if !equal {
-			return fmt.Errorf("tasks.md is stale relative to design.md")
-		}
+	if plan.validateDesign && feature.Design.Exists &&
+		feature.Design.Status == "approved" && !report.Design.Fresh {
+		return staleValidationError("design.md", "requirements.md", report.Design)
+	}
+	if plan.validateTasks && feature.Tasks.Exists &&
+		feature.Tasks.Status == "approved" && !report.Tasks.Fresh {
+		return staleValidationError("tasks.md", "design.md", report.Tasks)
 	}
 	return nil
 }
 
-func timestampsEqual(a, b string) (bool, error) {
-	if a == "" || b == "" {
-		return a == b, nil
+// staleValidationError distinguishes a document whose own content changed
+// from one whose upstream moved: both are stale, with different phrasing.
+func staleValidationError(name, upstream string, verdict spec.DocumentFreshness) error {
+	if !verdict.Intact {
+		return fmt.Errorf("%s is stale: %s", name, strings.Join(verdict.Causes, "; "))
 	}
-	return spec.TimestampsEqual(a, b)
+	return fmt.Errorf("%s is stale relative to %s: %s", name, upstream, strings.Join(verdict.Causes, "; "))
 }
 
 func validateRequirementReferences(feature spec.Feature, plan validationPlan) error {

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/andrearaponi/walden/internal/spec"
 )
 
 func TestValidateFeatureReturnsValidResultForRepresentativeSpec(t *testing.T) {
@@ -1084,42 +1086,51 @@ source_design_approved_at:
 	}
 }
 
-func TestParseWaldenTimestampValidation(t *testing.T) {
-	tests := []struct {
-		name    string
-		a, b    string
-		wantEq  bool
-		wantErr bool
-	}{
-		{"canonical equal", "2026-03-21T14:00:00Z", "2026-03-21T14:00:00Z", true, false},
-		{"canonical different", "2026-03-21T14:00:00Z", "2026-03-21T15:00:00Z", false, false},
-		{"offset equivalent", "2026-03-21T14:00:00Z", "2026-03-21T15:00:00+01:00", true, false},
-		{"fractional seconds", "2026-03-21T14:00:00Z", "2026-03-21T14:00:00.000Z", true, false},
-		{"malformed left", "not-a-timestamp", "2026-03-21T14:00:00Z", false, true},
-		{"malformed right", "2026-03-21T14:00:00Z", "not-a-timestamp", false, true},
-		{"both empty", "", "", true, false},
+func TestValidateFreshnessReportsTamperedRequirements(t *testing.T) {
+	root := t.TempDir()
+	writeValidFeature(t, root, "tamper-test")
+
+	// Edit the approved requirements body without re-approval: the recorded
+	// fingerprint no longer matches.
+	path := filepath.Join(root, ".walden", "specs", "tamper-test", "requirements.md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected requirements read to succeed, got %v", err)
+	}
+	if err := os.WriteFile(path, append(content, []byte("\nInjected after approval.\n")...), 0o644); err != nil {
+		t.Fatalf("expected tampered write to succeed, got %v", err)
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := timestampsEqual(tc.a, tc.b)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if got != tc.wantEq {
-				t.Fatalf("expected equal=%v, got %v", tc.wantEq, got)
-			}
-		})
+	result, err := ValidateFeatureWithScope(root, "tamper-test", ScopeFullSpec)
+	if err != nil {
+		t.Fatalf("expected validation to run, got %v", err)
+	}
+	if result.Valid {
+		t.Fatalf("expected validation failure for tampered requirements, got %#v", result)
+	}
+	if !strings.Contains(result.Message, "requirements.md is stale: content does not match approval fingerprint") {
+		t.Fatalf("unexpected validation message: %q", result.Message)
 	}
 }
 
-func TestValidateFreshnessWithEquivalentTimestampFormats(t *testing.T) {
+func TestValidateFreshnessReportsMissingFingerprintCause(t *testing.T) {
+	root := t.TempDir()
+	// Legacy fixture: approved before fingerprints existed.
+	writeFeatureFileRaw(t, root, "legacy-test", "requirements.md", validRequirements)
+
+	result, err := ValidateFeatureWithScope(root, "legacy-test", ScopeFullSpec)
+	if err != nil {
+		t.Fatalf("expected validation to run, got %v", err)
+	}
+	if result.Valid {
+		t.Fatalf("expected validation failure for legacy approved document, got %#v", result)
+	}
+	if !strings.Contains(result.Message, "requirements.md is stale: approval fingerprint missing") {
+		t.Fatalf("unexpected validation message: %q", result.Message)
+	}
+}
+
+func TestValidateFreshnessFingerprintDecidesDespiteTimestampDivergence(t *testing.T) {
 	root := t.TempDir()
 	writeFeatureFile(t, root, "ts-test", "requirements.md", `---
 status: approved
@@ -1153,7 +1164,7 @@ last_modified: 2026-03-21T14:00:00Z
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
-source_requirements_approved_at: 2026-03-21T15:00:00+01:00
+source_requirements_approved_at: 2026-03-20T09:00:00Z
 ---
 
 # Feature Design
@@ -1250,6 +1261,13 @@ func writeValidFeature(t *testing.T, root, feature string) {
 func writeFeatureFile(t *testing.T, root, feature, name, content string) {
 	t.Helper()
 
+	writeFeatureFileRaw(t, root, feature, name, content)
+	stampFixtureFingerprint(t, root, feature, name)
+}
+
+func writeFeatureFileRaw(t *testing.T, root, feature, name, content string) {
+	t.Helper()
+
 	featureDir := filepath.Join(root, ".walden", "specs", feature)
 	if err := os.MkdirAll(featureDir, 0o755); err != nil {
 		t.Fatalf("expected feature directory creation to succeed, got %v", err)
@@ -1257,5 +1275,61 @@ func writeFeatureFile(t *testing.T, root, feature, name, content string) {
 	content = strings.ReplaceAll(content, "__BT__", "`")
 	if err := os.WriteFile(filepath.Join(featureDir, name), []byte(content), 0o644); err != nil {
 		t.Fatalf("expected %s write to succeed, got %v", name, err)
+	}
+}
+
+// stampFixtureFingerprint keeps approved fixtures fingerprint-fresh: it
+// records the document's own approval fingerprint and binds it to the
+// upstream's, mirroring what `review approve` does in production.
+func stampFixtureFingerprint(t *testing.T, root, featureName, name string) {
+	t.Helper()
+
+	feature, err := spec.LoadFeature(root, featureName)
+	if err != nil {
+		t.Fatalf("expected fixture feature load to succeed, got %v", err)
+	}
+
+	var document *spec.Document
+	switch name {
+	case "requirements.md":
+		document = &feature.Requirements
+	case "design.md":
+		document = &feature.Design
+	case "tasks.md":
+		document = &feature.Tasks
+	default:
+		return
+	}
+
+	if !document.Exists || document.Status != "approved" {
+		return
+	}
+
+	document.ApprovedFingerprint = spec.Fingerprint(document.Body)
+	document.Fields["approved_fingerprint"] = document.ApprovedFingerprint
+
+	switch name {
+	case "design.md":
+		if feature.Requirements.Status == "approved" {
+			fingerprint := feature.Requirements.ApprovedFingerprint
+			if fingerprint == "" {
+				fingerprint = spec.Fingerprint(feature.Requirements.Body)
+			}
+			document.SourceRequirementsFingerprint = fingerprint
+			document.Fields["source_requirements_fingerprint"] = fingerprint
+		}
+	case "tasks.md":
+		if feature.Design.Status == "approved" {
+			fingerprint := feature.Design.ApprovedFingerprint
+			if fingerprint == "" {
+				fingerprint = spec.Fingerprint(feature.Design.Body)
+			}
+			document.SourceDesignFingerprint = fingerprint
+			document.Fields["source_design_fingerprint"] = fingerprint
+		}
+	}
+
+	if err := spec.SaveDocument(*document); err != nil {
+		t.Fatalf("expected fixture fingerprint stamp to succeed, got %v", err)
 	}
 }

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -34,6 +34,10 @@ type ExecutionReadiness struct {
 	NextTask         *ExecutableTask
 	Blockers         []string
 	NextAction       string
+	// GateBlocked distinguishes approval/freshness gate blockers from an
+	// exhausted implementation plan: gates must fail commands, a finished
+	// plan must not.
+	GateBlocked bool
 }
 
 // TaskStartContext is the deterministic execution context returned when a task starts.
@@ -88,6 +92,7 @@ func ResolveExecutionReadiness(feature spec.Feature) (ExecutionReadiness, error)
 	if blockingDocument, blockers := executionBlockers(state); len(blockers) > 0 {
 		readiness.BlockingDocument = blockingDocument
 		readiness.Blockers = blockers
+		readiness.GateBlocked = true
 		return readiness, nil
 	}
 
@@ -129,18 +134,20 @@ func executionBlockers(state FeatureState) (string, []string) {
 		return "requirements.md", []string{"requirements.md must be approved and fresh before execution"}
 	case state.Requirements.Status != "approved":
 		return "requirements.md", []string{"requirements.md must be approved and fresh before execution"}
+	case !state.Requirements.Fresh:
+		return "requirements.md", []string{staleDocumentMessage("requirements.md", state.Requirements)}
 	case !state.Design.Exists:
 		return "design.md", []string{"design.md must be approved and fresh before execution"}
 	case state.Design.Status != "approved":
 		return "design.md", []string{"design.md must be approved and fresh before execution"}
 	case !state.Design.Fresh:
-		return "design.md", []string{"design.md is stale relative to requirements.md"}
+		return "design.md", []string{staleChainMessage("design.md", "requirements.md", state.Design)}
 	case !state.Tasks.Exists:
 		return "tasks.md", []string{"tasks.md must be approved and fresh before execution"}
 	case state.Tasks.Status != "approved":
 		return "tasks.md", []string{"tasks.md must be approved and fresh before execution"}
 	case !state.Tasks.Fresh:
-		return "tasks.md", []string{"tasks.md is stale relative to design.md"}
+		return "tasks.md", []string{staleChainMessage("tasks.md", "design.md", state.Tasks)}
 	default:
 		return "", nil
 	}
@@ -317,6 +324,16 @@ func CompleteAllTasks(ctx context.Context, root, featureName string, runner shel
 			return BatchCompletionResult{}, err
 		}
 		if !readiness.Runnable || readiness.NextTask == nil {
+			if readiness.GateBlocked && len(readiness.Blockers) > 0 {
+				return BatchCompletionResult{
+					Feature:                readiness.Feature,
+					CurrentPhase:           readiness.CurrentPhase,
+					CompletedTasks:         completedTasks,
+					CompletedLeafTasks:     completedLeafTasks,
+					AutoCompletedParentIDs: autoCompletedParentIDs,
+					NextAction:             readiness.NextAction,
+				}, fmt.Errorf("%s", readiness.Blockers[0])
+			}
 			return BatchCompletionResult{
 				Feature:                readiness.Feature,
 				CurrentPhase:           readiness.CurrentPhase,

--- a/internal/workflow/execution_test.go
+++ b/internal/workflow/execution_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestLoadExecutionReadinessReturnsNextUncheckedLeafTask(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -19,7 +19,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
@@ -28,7 +28,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: approved
 approved_at: 2026-03-21T14:20:00Z
 last_modified: 2026-03-21T14:20:00Z
@@ -87,7 +87,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 func TestLoadExecutionReadinessBlocksWhenTasksAreNotApproved(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -95,7 +95,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
@@ -104,7 +104,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: in-review
 approved_at:
 last_modified: 2026-03-21T14:20:00Z
@@ -142,7 +142,7 @@ source_design_approved_at:
 
 func TestLoadExecutionReadinessBlocksWhenTasksAreStale(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -150,7 +150,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:30:00Z
 last_modified: 2026-03-21T14:30:00Z
@@ -159,7 +159,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: approved
 approved_at: 2026-03-21T14:20:00Z
 last_modified: 2026-03-21T14:20:00Z
@@ -175,6 +175,9 @@ source_design_approved_at: 2026-03-21T14:10:00Z
     - Verification: `+"`go test ./internal/spec`"+`
 `)
 
+	// The tasks approval was recorded against different design content.
+	overrideFrontmatterField(t, root, "todo-app-demo", "tasks.md", "source_design_fingerprint", spec.Fingerprint("some earlier design content"))
+
 	readiness, err := LoadExecutionReadiness(root, "todo-app-demo")
 	if err != nil {
 		t.Fatalf("expected readiness load to succeed, got %v", err)
@@ -186,7 +189,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 	if readiness.BlockingDocument != "tasks.md" {
 		t.Fatalf("expected tasks.md as blocking document, got %q", readiness.BlockingDocument)
 	}
-	assertContains(t, readiness.Blockers, "tasks.md is stale relative to design.md")
+	assertContains(t, readiness.Blockers, "tasks.md is stale relative to design.md: source fingerprint mismatch")
 	if readiness.NextAction != "Update tasks.md to match the latest approved design and return it to in-review" {
 		t.Fatalf("unexpected next action: %q", readiness.NextAction)
 	}
@@ -194,7 +197,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 func TestLoadExecutionReadinessReportsNoRemainingRunnableTasks(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -202,7 +205,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
@@ -211,7 +214,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: approved
 approved_at: 2026-03-21T14:20:00Z
 last_modified: 2026-03-21T14:20:00Z
@@ -249,7 +252,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 func TestStartTaskSelectsNextLeafTaskByDefault(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -257,7 +260,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
@@ -266,7 +269,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: approved
 approved_at: 2026-03-21T14:20:00Z
 last_modified: 2026-03-21T14:20:00Z
@@ -304,7 +307,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 func TestStartTaskAllowsExplicitCurrentNextLeafTask(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -312,7 +315,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
@@ -321,7 +324,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: approved
 approved_at: 2026-03-21T14:20:00Z
 last_modified: 2026-03-21T14:20:00Z
@@ -349,7 +352,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 func TestStartTaskRejectsMissingTask(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -357,7 +360,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
@@ -366,7 +369,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: approved
 approved_at: 2026-03-21T14:20:00Z
 last_modified: 2026-03-21T14:20:00Z
@@ -391,7 +394,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 func TestStartTaskRejectsCompletedLeafTask(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -399,7 +402,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
@@ -408,7 +411,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: approved
 approved_at: 2026-03-21T14:20:00Z
 last_modified: 2026-03-21T14:20:00Z
@@ -433,7 +436,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 func TestStartTaskRejectsParentTask(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -441,7 +444,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
@@ -450,7 +453,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: approved
 approved_at: 2026-03-21T14:20:00Z
 last_modified: 2026-03-21T14:20:00Z
@@ -475,7 +478,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 func TestStartTaskRejectsBlockedExplicitTaskWhenEarlierLeafIsIncomplete(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -483,7 +486,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
@@ -492,7 +495,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: approved
 approved_at: 2026-03-21T14:20:00Z
 last_modified: 2026-03-21T14:20:00Z
@@ -521,7 +524,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 func TestCompleteTaskRunsProofAndMarksLeafTaskComplete(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -529,7 +532,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
@@ -538,7 +541,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: approved
 approved_at: 2026-03-21T14:20:00Z
 last_modified: 2026-03-21T14:20:00Z
@@ -601,7 +604,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 func TestCompleteTaskRunsStructuredProofStepsWithoutShellInterpolation(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -609,7 +612,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
@@ -618,7 +621,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: approved
 approved_at: 2026-03-21T14:20:00Z
 last_modified: 2026-03-21T14:20:00Z
@@ -664,7 +667,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 func TestCompleteTaskLeavesTaskUncheckedWhenProofFails(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -672,7 +675,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
@@ -681,7 +684,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: approved
 approved_at: 2026-03-21T14:20:00Z
 last_modified: 2026-03-21T14:20:00Z
@@ -724,7 +727,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 func TestCompleteTaskLeavesTaskUncheckedWhenStructuredProofFails(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -732,7 +735,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
@@ -741,7 +744,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: approved
 approved_at: 2026-03-21T14:20:00Z
 last_modified: 2026-03-21T14:20:00Z
@@ -789,7 +792,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 func TestCompleteTaskReturnsParentAutoCompletionWhenLastChildCloses(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -797,7 +800,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
@@ -806,7 +809,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: approved
 approved_at: 2026-03-21T14:20:00Z
 last_modified: 2026-03-21T14:20:00Z
@@ -859,7 +862,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 func TestCompleteAllTasksRunsLeafTasksInOrderUntilPlanExhausts(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -867,7 +870,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
@@ -876,7 +879,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: approved
 approved_at: 2026-03-21T14:20:00Z
 last_modified: 2026-03-21T14:20:00Z
@@ -930,7 +933,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 func TestCompleteAllTasksStopsOnFirstFailedTaskAndPreservesEarlierCompletions(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
 last_modified: 2026-03-21T14:00:00Z
@@ -938,7 +941,7 @@ last_modified: 2026-03-21T14:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: approved
 approved_at: 2026-03-21T14:10:00Z
 last_modified: 2026-03-21T14:10:00Z
@@ -947,7 +950,7 @@ source_requirements_approved_at: 2026-03-21T14:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: approved
 approved_at: 2026-03-21T14:20:00Z
 last_modified: 2026-03-21T14:20:00Z
@@ -1010,7 +1013,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 
 func setupApprovedFeature(t *testing.T, root, feature, tasksBody string) {
 	t.Helper()
-	writeFeatureDoc(t, root, feature, "requirements.md", `---
+	writeFreshFeatureDoc(t, root, feature, "requirements.md", `---
 status: approved
 approved_at: 2026-03-23T09:00:00Z
 last_modified: 2026-03-23T09:00:00Z
@@ -1018,7 +1021,7 @@ last_modified: 2026-03-23T09:00:00Z
 
 # Requirements Document
 `)
-	writeFeatureDoc(t, root, feature, "design.md", `---
+	writeFreshFeatureDoc(t, root, feature, "design.md", `---
 status: approved
 approved_at: 2026-03-23T09:30:00Z
 last_modified: 2026-03-23T09:30:00Z
@@ -1027,7 +1030,7 @@ source_requirements_approved_at: 2026-03-23T09:00:00Z
 
 # Feature Design
 `)
-	writeFeatureDoc(t, root, feature, "tasks.md", tasksBody)
+	writeFreshFeatureDoc(t, root, feature, "tasks.md", tasksBody)
 }
 
 func TestCompleteTaskSucceedsWhenExitCodeMatchesExpectExit(t *testing.T) {

--- a/internal/workflow/fixtures_test.go
+++ b/internal/workflow/fixtures_test.go
@@ -1,0 +1,140 @@
+package workflow
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/spec"
+)
+
+const (
+	approveReqBody    = "# Requirements Document\n"
+	approveDesignBody = "# Feature Design\n"
+	approveTasksBody  = "# Implementation Plan\n"
+)
+
+func approvedRequirementsContent(body, approvedAt string) string {
+	return fmt.Sprintf(`---
+status: approved
+approved_at: %s
+last_modified: %s
+approved_fingerprint: %s
+---
+
+%s`, approvedAt, approvedAt, spec.Fingerprint(body), body)
+}
+
+func approvedDesignContent(body, approvedAt, sourceApprovedAt, sourceFingerprint string) string {
+	return fmt.Sprintf(`---
+status: approved
+approved_at: %s
+last_modified: %s
+approved_fingerprint: %s
+source_requirements_approved_at: %s
+source_requirements_fingerprint: %s
+---
+
+%s`, approvedAt, approvedAt, spec.Fingerprint(body), sourceApprovedAt, sourceFingerprint, body)
+}
+
+func approvedTasksContent(body, approvedAt, sourceApprovedAt, sourceFingerprint string) string {
+	return fmt.Sprintf(`---
+status: approved
+approved_at: %s
+last_modified: %s
+approved_fingerprint: %s
+source_design_approved_at: %s
+source_design_fingerprint: %s
+---
+
+%s`, approvedAt, approvedAt, spec.Fingerprint(body), sourceApprovedAt, sourceFingerprint, body)
+}
+
+// writeFreshFeatureDoc writes a fixture document and, when it is approved,
+// stamps a matching approval fingerprint plus the source fingerprint of its
+// upstream, keeping legacy fixtures fingerprint-fresh. Tests that need
+// staleness inject a mismatch afterwards via overrideFrontmatterField.
+func writeFreshFeatureDoc(t *testing.T, root, featureName, name, content string) {
+	t.Helper()
+
+	writeFeatureDoc(t, root, featureName, name, content)
+
+	feature, err := spec.LoadFeature(root, featureName)
+	if err != nil {
+		t.Fatalf("expected fixture feature load to succeed, got %v", err)
+	}
+
+	document := fixtureDocumentByName(&feature, name)
+	if document == nil || !document.Exists || document.Status != "approved" {
+		return
+	}
+
+	document.ApprovedFingerprint = spec.Fingerprint(document.Body)
+	document.Fields["approved_fingerprint"] = document.ApprovedFingerprint
+
+	switch name {
+	case "design.md":
+		if feature.Requirements.Status == "approved" {
+			fingerprint := feature.Requirements.ApprovedFingerprint
+			if fingerprint == "" {
+				fingerprint = spec.Fingerprint(feature.Requirements.Body)
+			}
+			document.SourceRequirementsFingerprint = fingerprint
+			document.Fields["source_requirements_fingerprint"] = fingerprint
+		}
+	case "tasks.md":
+		if feature.Design.Status == "approved" {
+			fingerprint := feature.Design.ApprovedFingerprint
+			if fingerprint == "" {
+				fingerprint = spec.Fingerprint(feature.Design.Body)
+			}
+			document.SourceDesignFingerprint = fingerprint
+			document.Fields["source_design_fingerprint"] = fingerprint
+		}
+	}
+
+	if err := spec.SaveDocument(*document); err != nil {
+		t.Fatalf("expected fixture fingerprint stamp to succeed, got %v", err)
+	}
+}
+
+func overrideFrontmatterField(t *testing.T, root, featureName, name, key, value string) {
+	t.Helper()
+
+	feature, err := spec.LoadFeature(root, featureName)
+	if err != nil {
+		t.Fatalf("expected fixture feature load to succeed, got %v", err)
+	}
+
+	document := fixtureDocumentByName(&feature, name)
+	if document == nil || !document.Exists {
+		t.Fatalf("fixture document %q does not exist", name)
+	}
+
+	document.Fields[key] = value
+	switch key {
+	case "approved_fingerprint":
+		document.ApprovedFingerprint = value
+	case "source_requirements_fingerprint":
+		document.SourceRequirementsFingerprint = value
+	case "source_design_fingerprint":
+		document.SourceDesignFingerprint = value
+	}
+
+	if err := spec.SaveDocument(*document); err != nil {
+		t.Fatalf("expected fixture override save to succeed, got %v", err)
+	}
+}
+
+func fixtureDocumentByName(feature *spec.Feature, name string) *spec.Document {
+	switch name {
+	case "requirements.md":
+		return &feature.Requirements
+	case "design.md":
+		return &feature.Design
+	case "tasks.md":
+		return &feature.Tasks
+	default:
+		return nil
+	}
+}

--- a/internal/workflow/reconcile.go
+++ b/internal/workflow/reconcile.go
@@ -54,67 +54,59 @@ func reconcileFeatureAt(root, featureName, reconciledAt string) (ReconcileResult
 func reconcileFeature(feature spec.Feature, reconciledAt string) (spec.Feature, []string, error) {
 	changedDocs := map[string]struct{}{}
 
-	if err := downgradeIfModified(&feature.Requirements, reconciledAt, changedDocs); err != nil {
+	// Pass 1: approved documents whose own content no longer matches their
+	// approval fingerprint — or that lack one — lose their approval.
+	// Changed content is unreviewed content: draft is the honest state.
+	report := spec.EvaluateFreshness(feature)
+	if err := resetIfNotIntact(&feature.Requirements, report.Requirements, reconciledAt, changedDocs); err != nil {
 		return spec.Feature{}, nil, err
 	}
-	if err := downgradeIfModified(&feature.Design, reconciledAt, changedDocs); err != nil {
+	if err := resetIfNotIntact(&feature.Design, report.Design, reconciledAt, changedDocs); err != nil {
 		return spec.Feature{}, nil, err
 	}
-	if err := downgradeIfModified(&feature.Tasks, reconciledAt, changedDocs); err != nil {
+	if err := resetIfNotIntact(&feature.Tasks, report.Tasks, reconciledAt, changedDocs); err != nil {
 		return spec.Feature{}, nil, err
 	}
 
-	effectiveRequirementsApprovedAt := effectiveApprovedAt(feature.Requirements)
-	if feature.Design.Exists && feature.Design.SourceRequirementsApprovedAt != effectiveRequirementsApprovedAt {
-		updatedDesign, err := spec.ResetDocumentToDraft(feature.Design, reconciledAt)
-		if err != nil {
+	// Pass 2: chain repair — a downstream document bound to an upstream
+	// approval fingerprint that differs (or no longer exists) resets to
+	// draft, cascading design -> tasks.
+	effectiveRequirements := effectiveApprovedFingerprint(feature.Requirements)
+	if feature.Design.Exists && feature.Design.SourceRequirementsFingerprint != effectiveRequirements {
+		if err := resetToDraft(&feature.Design, reconciledAt, changedDocs); err != nil {
 			return spec.Feature{}, nil, err
-		}
-		if documentChanged(feature.Design, updatedDesign) {
-			feature.Design = updatedDesign
-			changedDocs["design.md"] = struct{}{}
 		}
 		if feature.Tasks.Exists {
-			updatedTasks, err := spec.ResetDocumentToDraft(feature.Tasks, reconciledAt)
-			if err != nil {
+			if err := resetToDraft(&feature.Tasks, reconciledAt, changedDocs); err != nil {
 				return spec.Feature{}, nil, err
-			}
-			if documentChanged(feature.Tasks, updatedTasks) {
-				feature.Tasks = updatedTasks
-				changedDocs["tasks.md"] = struct{}{}
 			}
 		}
 	}
 
-	effectiveDesignApprovedAt := effectiveApprovedAt(feature.Design)
-	if feature.Tasks.Exists && feature.Tasks.SourceDesignApprovedAt != effectiveDesignApprovedAt {
-		updatedTasks, err := spec.ResetDocumentToDraft(feature.Tasks, reconciledAt)
-		if err != nil {
+	effectiveDesign := effectiveApprovedFingerprint(feature.Design)
+	if feature.Tasks.Exists && feature.Tasks.SourceDesignFingerprint != effectiveDesign {
+		if err := resetToDraft(&feature.Tasks, reconciledAt, changedDocs); err != nil {
 			return spec.Feature{}, nil, err
-		}
-		if documentChanged(feature.Tasks, updatedTasks) {
-			feature.Tasks = updatedTasks
-			changedDocs["tasks.md"] = struct{}{}
 		}
 	}
 
 	return feature, orderedChangedDocs(changedDocs), nil
 }
 
-func downgradeIfModified(document *spec.Document, reconciledAt string, changedDocs map[string]struct{}) error {
-	if !document.Exists || document.Status != "approved" {
+func resetIfNotIntact(document *spec.Document, verdict spec.DocumentFreshness, reconciledAt string, changedDocs map[string]struct{}) error {
+	if !document.Exists || document.Status != "approved" || verdict.Intact {
 		return nil
 	}
 
-	modified, err := modifiedAfterApproval(*document)
-	if err != nil {
-		return err
-	}
-	if !modified {
+	return resetToDraft(document, reconciledAt, changedDocs)
+}
+
+func resetToDraft(document *spec.Document, reconciledAt string, changedDocs map[string]struct{}) error {
+	if !document.Exists {
 		return nil
 	}
 
-	updated, err := spec.DowngradeDocumentToInReview(*document, reconciledAt)
+	updated, err := spec.ResetDocumentToDraft(*document, reconciledAt)
 	if err != nil {
 		return err
 	}
@@ -126,39 +118,9 @@ func downgradeIfModified(document *spec.Document, reconciledAt string, changedDo
 	return nil
 }
 
-func modifiedAfterApproval(document spec.Document) (bool, error) {
-	if document.Status != "approved" {
-		return false, nil
-	}
-
-	approvedAt, err := parseTimestamp(document.Path, "approved_at", document.ApprovedAt)
-	if err != nil {
-		return false, err
-	}
-	lastModified, err := parseTimestamp(document.Path, "last_modified", document.LastModified)
-	if err != nil {
-		return false, err
-	}
-
-	return lastModified.After(approvedAt), nil
-}
-
-func parseTimestamp(path, field, raw string) (time.Time, error) {
-	if raw == "" {
-		return time.Time{}, fmt.Errorf("%s: %s is required", filepath.Base(path), field)
-	}
-
-	parsed, err := time.Parse("2006-01-02T15:04:05Z", raw)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("%s: invalid %s %q", filepath.Base(path), field, raw)
-	}
-
-	return parsed, nil
-}
-
-func effectiveApprovedAt(document spec.Document) string {
+func effectiveApprovedFingerprint(document spec.Document) string {
 	if document.Exists && document.Status == "approved" {
-		return document.ApprovedAt
+		return document.ApprovedFingerprint
 	}
 
 	return ""
@@ -168,8 +130,11 @@ func documentChanged(before, after spec.Document) bool {
 	return before.Status != after.Status ||
 		before.ApprovedAt != after.ApprovedAt ||
 		before.LastModified != after.LastModified ||
+		before.ApprovedFingerprint != after.ApprovedFingerprint ||
 		before.SourceRequirementsApprovedAt != after.SourceRequirementsApprovedAt ||
-		before.SourceDesignApprovedAt != after.SourceDesignApprovedAt
+		before.SourceDesignApprovedAt != after.SourceDesignApprovedAt ||
+		before.SourceRequirementsFingerprint != after.SourceRequirementsFingerprint ||
+		before.SourceDesignFingerprint != after.SourceDesignFingerprint
 }
 
 func orderedChangedDocs(changed map[string]struct{}) []string {

--- a/internal/workflow/reconcile_test.go
+++ b/internal/workflow/reconcile_test.go
@@ -6,12 +6,143 @@ import (
 	"github.com/andrearaponi/walden/internal/spec"
 )
 
-func TestReconcileFeatureDowngradesModifiedRequirementsAndResetsDownstream(t *testing.T) {
+func TestReconcileFeatureResetsTamperedRequirementsAndDownstream(t *testing.T) {
 	root := t.TempDir()
+	// Approved requirements whose body was edited after approval: the
+	// recorded fingerprint no longer matches the content.
+	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md",
+		approvedRequirementsContent(approveReqBody, "2026-03-21T14:00:00Z")+"\nInjected after approval.\n")
+	writeFeatureDoc(t, root, "todo-app-demo", "design.md",
+		approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint(approveReqBody)))
+	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md",
+		approvedTasksContent(approveTasksBody, "2026-03-21T14:20:00Z", "2026-03-21T14:10:00Z", spec.Fingerprint(approveDesignBody)))
+
+	result, err := reconcileFeatureAt(root, "todo-app-demo", "2026-03-21T18:55:00Z")
+	if err != nil {
+		t.Fatalf("expected reconcile to succeed, got %v", err)
+	}
+
+	if result.CurrentPhase != PhaseRequirements {
+		t.Fatalf("expected requirements phase after reconcile, got %q", result.CurrentPhase)
+	}
+	if result.NextAction != "Edit requirements.md and move it to in-review" {
+		t.Fatalf("unexpected next action: %q", result.NextAction)
+	}
+	if len(result.ChangedDocs) != 3 {
+		t.Fatalf("expected 3 changed docs, got %#v", result.ChangedDocs)
+	}
+
+	feature, err := spec.LoadFeature(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("expected feature reload to succeed, got %v", err)
+	}
+
+	if feature.Requirements.Status != "draft" {
+		t.Fatalf("expected tampered requirements to reset to draft, got %q", feature.Requirements.Status)
+	}
+	if feature.Requirements.ApprovedAt != "" || feature.Requirements.ApprovedFingerprint != "" {
+		t.Fatalf("expected requirements approval metadata to be cleared, got approved_at=%q fingerprint=%q", feature.Requirements.ApprovedAt, feature.Requirements.ApprovedFingerprint)
+	}
+	if feature.Design.Status != "draft" {
+		t.Fatalf("expected design to reset to draft, got %q", feature.Design.Status)
+	}
+	if feature.Design.ApprovedFingerprint != "" || feature.Design.SourceRequirementsFingerprint != "" {
+		t.Fatalf("expected design fingerprints to be cleared, got own=%q source=%q", feature.Design.ApprovedFingerprint, feature.Design.SourceRequirementsFingerprint)
+	}
+	if feature.Tasks.Status != "draft" {
+		t.Fatalf("expected tasks to reset to draft, got %q", feature.Tasks.Status)
+	}
+	if feature.Tasks.ApprovedFingerprint != "" || feature.Tasks.SourceDesignFingerprint != "" {
+		t.Fatalf("expected tasks fingerprints to be cleared, got own=%q source=%q", feature.Tasks.ApprovedFingerprint, feature.Tasks.SourceDesignFingerprint)
+	}
+}
+
+func TestReconcileFeatureResetsDesignAndTasksOnSourceFingerprintMismatch(t *testing.T) {
+	root := t.TempDir()
+	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md",
+		approvedRequirementsContent(approveReqBody, "2026-03-21T14:30:00Z"))
+	// Design was approved against different requirements content.
+	writeFeatureDoc(t, root, "todo-app-demo", "design.md",
+		approvedDesignContent(approveDesignBody, "2026-03-21T14:40:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("some earlier requirements content")))
+	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md",
+		approvedTasksContent(approveTasksBody, "2026-03-21T14:50:00Z", "2026-03-21T14:40:00Z", spec.Fingerprint(approveDesignBody)))
+
+	result, err := reconcileFeatureAt(root, "todo-app-demo", "2026-03-21T18:55:00Z")
+	if err != nil {
+		t.Fatalf("expected reconcile to succeed, got %v", err)
+	}
+
+	if result.CurrentPhase != PhaseDesign {
+		t.Fatalf("expected design phase after reconcile, got %q", result.CurrentPhase)
+	}
+	if result.NextAction != "Edit design.md and move it to in-review" {
+		t.Fatalf("unexpected next action: %q", result.NextAction)
+	}
+
+	feature, err := spec.LoadFeature(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("expected feature reload to succeed, got %v", err)
+	}
+
+	if feature.Requirements.Status != "approved" {
+		t.Fatalf("expected requirements to remain approved, got %q", feature.Requirements.Status)
+	}
+	if feature.Design.Status != "draft" {
+		t.Fatalf("expected design to reset to draft, got %q", feature.Design.Status)
+	}
+	if feature.Design.ApprovedAt != "" || feature.Design.SourceRequirementsFingerprint != "" {
+		t.Fatalf("expected design approval metadata to be cleared, got approved_at=%q source=%q", feature.Design.ApprovedAt, feature.Design.SourceRequirementsFingerprint)
+	}
+	if feature.Tasks.Status != "draft" {
+		t.Fatalf("expected tasks to reset to draft, got %q", feature.Tasks.Status)
+	}
+}
+
+func TestReconcileFeatureResetsTasksOnSourceFingerprintMismatch(t *testing.T) {
+	root := t.TempDir()
+	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md",
+		approvedRequirementsContent(approveReqBody, "2026-03-21T14:00:00Z"))
+	writeFeatureDoc(t, root, "todo-app-demo", "design.md",
+		approvedDesignContent(approveDesignBody, "2026-03-21T14:30:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint(approveReqBody)))
+	// Tasks were approved against different design content.
+	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md",
+		approvedTasksContent(approveTasksBody, "2026-03-21T14:50:00Z", "2026-03-21T14:10:00Z", spec.Fingerprint("some earlier design content")))
+
+	result, err := reconcileFeatureAt(root, "todo-app-demo", "2026-03-21T18:55:00Z")
+	if err != nil {
+		t.Fatalf("expected reconcile to succeed, got %v", err)
+	}
+
+	if result.CurrentPhase != PhaseTasks {
+		t.Fatalf("expected tasks phase after reconcile, got %q", result.CurrentPhase)
+	}
+	if result.NextAction != "Edit tasks.md and move it to in-review" {
+		t.Fatalf("unexpected next action: %q", result.NextAction)
+	}
+
+	feature, err := spec.LoadFeature(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("expected feature reload to succeed, got %v", err)
+	}
+
+	if feature.Design.Status != "approved" {
+		t.Fatalf("expected design to remain approved, got %q", feature.Design.Status)
+	}
+	if feature.Tasks.Status != "draft" {
+		t.Fatalf("expected tasks to reset to draft, got %q", feature.Tasks.Status)
+	}
+	if feature.Tasks.ApprovedAt != "" || feature.Tasks.SourceDesignFingerprint != "" {
+		t.Fatalf("expected tasks approval metadata to be cleared, got approved_at=%q source=%q", feature.Tasks.ApprovedAt, feature.Tasks.SourceDesignFingerprint)
+	}
+}
+
+func TestReconcileFeatureMigratesLegacyChainToDraft(t *testing.T) {
+	root := t.TempDir()
+	// A pre-fingerprint feature: everything approved, no fingerprints anywhere.
 	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: approved
 approved_at: 2026-03-21T14:00:00Z
-last_modified: 2026-03-21T14:30:00Z
+last_modified: 2026-03-21T14:00:00Z
 ---
 
 # Requirements Document
@@ -40,14 +171,8 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 		t.Fatalf("expected reconcile to succeed, got %v", err)
 	}
 
-	if result.CurrentPhase != PhaseRequirements {
-		t.Fatalf("expected requirements phase after reconcile, got %q", result.CurrentPhase)
-	}
-	if result.NextAction != "Approve requirements.md" {
-		t.Fatalf("unexpected next action: %q", result.NextAction)
-	}
 	if len(result.ChangedDocs) != 3 {
-		t.Fatalf("expected 3 changed docs, got %#v", result.ChangedDocs)
+		t.Fatalf("expected the whole legacy chain to reset, got %#v", result.ChangedDocs)
 	}
 
 	feature, err := spec.LoadFeature(root, "todo-app-demo")
@@ -55,142 +180,35 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 		t.Fatalf("expected feature reload to succeed, got %v", err)
 	}
 
-	if feature.Requirements.Status != "in-review" {
-		t.Fatalf("expected requirements to move to in-review, got %q", feature.Requirements.Status)
-	}
-	if feature.Requirements.ApprovedAt != "" {
-		t.Fatalf("expected requirements approved_at to be cleared, got %q", feature.Requirements.ApprovedAt)
-	}
-	if feature.Design.Status != "draft" {
-		t.Fatalf("expected design to reset to draft, got %q", feature.Design.Status)
-	}
-	if feature.Design.ApprovedAt != "" || feature.Design.SourceRequirementsApprovedAt != "" {
-		t.Fatalf("expected design approval metadata to be cleared, got approved_at=%q source=%q", feature.Design.ApprovedAt, feature.Design.SourceRequirementsApprovedAt)
-	}
-	if feature.Tasks.Status != "draft" {
-		t.Fatalf("expected tasks to reset to draft, got %q", feature.Tasks.Status)
-	}
-	if feature.Tasks.ApprovedAt != "" || feature.Tasks.SourceDesignApprovedAt != "" {
-		t.Fatalf("expected tasks approval metadata to be cleared, got approved_at=%q source=%q", feature.Tasks.ApprovedAt, feature.Tasks.SourceDesignApprovedAt)
+	for name, status := range map[string]string{
+		"requirements.md": feature.Requirements.Status,
+		"design.md":       feature.Design.Status,
+		"tasks.md":        feature.Tasks.Status,
+	} {
+		if status != "draft" {
+			t.Fatalf("%s: expected legacy approved document to reset to draft, got %q", name, status)
+		}
 	}
 }
 
-func TestReconcileFeatureResetsDesignAndTasksWhenRequirementsApprovalTimestampMismatch(t *testing.T) {
+func TestReconcileFeatureLeavesFreshChainUntouched(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
-status: approved
-approved_at: 2026-03-21T14:30:00Z
-last_modified: 2026-03-21T14:30:00Z
----
-
-# Requirements Document
-`)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
-status: approved
-approved_at: 2026-03-21T14:40:00Z
-last_modified: 2026-03-21T14:40:00Z
-source_requirements_approved_at: 2026-03-21T14:00:00Z
----
-
-# Feature Design
-`)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
-status: approved
-approved_at: 2026-03-21T14:50:00Z
-last_modified: 2026-03-21T14:50:00Z
-source_design_approved_at: 2026-03-21T14:40:00Z
----
-
-# Implementation Plan
-`)
+	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md",
+		approvedRequirementsContent(approveReqBody, "2026-03-21T14:00:00Z"))
+	writeFeatureDoc(t, root, "todo-app-demo", "design.md",
+		approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint(approveReqBody)))
+	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md",
+		approvedTasksContent(approveTasksBody, "2026-03-21T14:20:00Z", "2026-03-21T14:10:00Z", spec.Fingerprint(approveDesignBody)))
 
 	result, err := reconcileFeatureAt(root, "todo-app-demo", "2026-03-21T18:55:00Z")
 	if err != nil {
 		t.Fatalf("expected reconcile to succeed, got %v", err)
 	}
 
-	if result.CurrentPhase != PhaseDesign {
-		t.Fatalf("expected design phase after reconcile, got %q", result.CurrentPhase)
+	if len(result.ChangedDocs) != 0 {
+		t.Fatalf("expected no changes on a fresh chain, got %#v", result.ChangedDocs)
 	}
-	if result.NextAction != "Edit design.md and move it to in-review" {
-		t.Fatalf("unexpected next action: %q", result.NextAction)
-	}
-
-	feature, err := spec.LoadFeature(root, "todo-app-demo")
-	if err != nil {
-		t.Fatalf("expected feature reload to succeed, got %v", err)
-	}
-
-	if feature.Requirements.Status != "approved" {
-		t.Fatalf("expected requirements to remain approved, got %q", feature.Requirements.Status)
-	}
-	if feature.Design.Status != "draft" {
-		t.Fatalf("expected design to reset to draft, got %q", feature.Design.Status)
-	}
-	if feature.Design.ApprovedAt != "" || feature.Design.SourceRequirementsApprovedAt != "" {
-		t.Fatalf("expected design approval metadata to be cleared, got approved_at=%q source=%q", feature.Design.ApprovedAt, feature.Design.SourceRequirementsApprovedAt)
-	}
-	if feature.Tasks.Status != "draft" {
-		t.Fatalf("expected tasks to reset to draft, got %q", feature.Tasks.Status)
-	}
-	if feature.Tasks.ApprovedAt != "" || feature.Tasks.SourceDesignApprovedAt != "" {
-		t.Fatalf("expected tasks approval metadata to be cleared, got approved_at=%q source=%q", feature.Tasks.ApprovedAt, feature.Tasks.SourceDesignApprovedAt)
-	}
-}
-
-func TestReconcileFeatureResetsTasksWhenDesignApprovalTimestampMismatch(t *testing.T) {
-	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
-status: approved
-approved_at: 2026-03-21T14:00:00Z
-last_modified: 2026-03-21T14:00:00Z
----
-
-# Requirements Document
-`)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
-status: approved
-approved_at: 2026-03-21T14:30:00Z
-last_modified: 2026-03-21T14:30:00Z
-source_requirements_approved_at: 2026-03-21T14:00:00Z
----
-
-# Feature Design
-`)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
-status: approved
-approved_at: 2026-03-21T14:50:00Z
-last_modified: 2026-03-21T14:50:00Z
-source_design_approved_at: 2026-03-21T14:10:00Z
----
-
-# Implementation Plan
-`)
-
-	result, err := reconcileFeatureAt(root, "todo-app-demo", "2026-03-21T18:55:00Z")
-	if err != nil {
-		t.Fatalf("expected reconcile to succeed, got %v", err)
-	}
-
 	if result.CurrentPhase != PhaseTasks {
-		t.Fatalf("expected tasks phase after reconcile, got %q", result.CurrentPhase)
-	}
-	if result.NextAction != "Edit tasks.md and move it to in-review" {
-		t.Fatalf("unexpected next action: %q", result.NextAction)
-	}
-
-	feature, err := spec.LoadFeature(root, "todo-app-demo")
-	if err != nil {
-		t.Fatalf("expected feature reload to succeed, got %v", err)
-	}
-
-	if feature.Design.Status != "approved" {
-		t.Fatalf("expected design to remain approved, got %q", feature.Design.Status)
-	}
-	if feature.Tasks.Status != "draft" {
-		t.Fatalf("expected tasks to reset to draft, got %q", feature.Tasks.Status)
-	}
-	if feature.Tasks.ApprovedAt != "" || feature.Tasks.SourceDesignApprovedAt != "" {
-		t.Fatalf("expected tasks approval metadata to be cleared, got approved_at=%q source=%q", feature.Tasks.ApprovedAt, feature.Tasks.SourceDesignApprovedAt)
+		t.Fatalf("expected tasks phase on a fresh chain, got %q", result.CurrentPhase)
 	}
 }

--- a/internal/workflow/review.go
+++ b/internal/workflow/review.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/andrearaponi/walden/internal/spec"
@@ -34,7 +35,8 @@ func OpenReview(root, featureName string, phase Phase) (ReviewContext, error) {
 	}
 
 	state := ResolveFeatureState(feature)
-	if err := validateOpenReview(state, phase); err != nil {
+	report := spec.EvaluateFreshness(feature)
+	if err := validateOpenReview(state, report, phase); err != nil {
 		return ReviewContext{}, err
 	}
 
@@ -75,7 +77,8 @@ func ApproveReview(root, featureName string, phase Phase) (ApprovalResult, error
 	}
 
 	state := ResolveFeatureState(feature)
-	if err := validateApproveReview(state, phase); err != nil {
+	report := spec.EvaluateFreshness(feature)
+	if err := validateApproveReview(state, report, phase); err != nil {
 		return ApprovalResult{}, err
 	}
 
@@ -88,17 +91,23 @@ func ApproveReview(root, featureName string, phase Phase) (ApprovalResult, error
 	document.Status = "approved"
 	document.ApprovedAt = approvedAt
 	document.LastModified = approvedAt
+	document.ApprovedFingerprint = spec.Fingerprint(document.Body)
 	document.Fields["status"] = document.Status
 	document.Fields["approved_at"] = document.ApprovedAt
 	document.Fields["last_modified"] = document.LastModified
+	document.Fields["approved_fingerprint"] = document.ApprovedFingerprint
 
 	switch phase {
 	case PhaseDesign:
 		document.SourceRequirementsApprovedAt = feature.Requirements.ApprovedAt
+		document.SourceRequirementsFingerprint = feature.Requirements.ApprovedFingerprint
 		document.Fields["source_requirements_approved_at"] = document.SourceRequirementsApprovedAt
+		document.Fields["source_requirements_fingerprint"] = document.SourceRequirementsFingerprint
 	case PhaseTasks:
 		document.SourceDesignApprovedAt = feature.Design.ApprovedAt
+		document.SourceDesignFingerprint = feature.Design.ApprovedFingerprint
 		document.Fields["source_design_approved_at"] = document.SourceDesignApprovedAt
+		document.Fields["source_design_fingerprint"] = document.SourceDesignFingerprint
 	}
 
 	if err := spec.SaveDocument(*document); err != nil {
@@ -121,7 +130,7 @@ func ApproveReview(root, featureName string, phase Phase) (ApprovalResult, error
 	}, nil
 }
 
-func validateOpenReview(state FeatureState, phase Phase) error {
+func validateOpenReview(state FeatureState, report spec.FreshnessReport, phase Phase) error {
 	switch phase {
 	case PhaseRequirements:
 		if !state.Requirements.Exists {
@@ -132,8 +141,11 @@ func validateOpenReview(state FeatureState, phase Phase) error {
 		if state.Requirements.Status != "approved" {
 			return fmt.Errorf("requirements.md must be approved before opening design review")
 		}
-		if state.Design.Status == "approved" && !state.Design.Fresh {
-			return fmt.Errorf("design.md is stale relative to requirements.md")
+		if err := staleDocumentError("requirements.md", report.Requirements); err != nil {
+			return err
+		}
+		if state.Design.Status == "approved" && !report.Design.Fresh {
+			return staleChainError("design.md", "requirements.md", report.Design)
 		}
 		if !state.Design.Exists {
 			return fmt.Errorf("design.md does not exist")
@@ -143,14 +155,17 @@ func validateOpenReview(state FeatureState, phase Phase) error {
 		if state.Requirements.Status != "approved" {
 			return fmt.Errorf("requirements.md must be approved before opening tasks review")
 		}
+		if err := staleDocumentError("requirements.md", report.Requirements); err != nil {
+			return err
+		}
 		if state.Design.Status != "approved" {
 			return fmt.Errorf("design.md must be approved before opening tasks review")
 		}
-		if !state.Design.Fresh {
-			return fmt.Errorf("design.md is stale relative to requirements.md")
+		if !report.Design.Fresh {
+			return staleChainError("design.md", "requirements.md", report.Design)
 		}
-		if state.Tasks.Status == "approved" && !state.Tasks.Fresh {
-			return fmt.Errorf("tasks.md is stale relative to design.md")
+		if state.Tasks.Status == "approved" && !report.Tasks.Fresh {
+			return staleChainError("tasks.md", "design.md", report.Tasks)
 		}
 		if !state.Tasks.Exists {
 			return fmt.Errorf("tasks.md does not exist")
@@ -161,7 +176,7 @@ func validateOpenReview(state FeatureState, phase Phase) error {
 	}
 }
 
-func validateApproveReview(state FeatureState, phase Phase) error {
+func validateApproveReview(state FeatureState, report spec.FreshnessReport, phase Phase) error {
 	switch phase {
 	case PhaseRequirements:
 		if !state.Requirements.Exists {
@@ -178,6 +193,9 @@ func validateApproveReview(state FeatureState, phase Phase) error {
 		if state.Requirements.Status != "approved" {
 			return fmt.Errorf("requirements.md must be approved before approving design review")
 		}
+		if err := staleDocumentError("requirements.md", report.Requirements); err != nil {
+			return err
+		}
 		if state.Design.Status != "in-review" {
 			return fmt.Errorf("design.md must be in-review before approval")
 		}
@@ -189,11 +207,14 @@ func validateApproveReview(state FeatureState, phase Phase) error {
 		if state.Requirements.Status != "approved" {
 			return fmt.Errorf("requirements.md must be approved before approving tasks review")
 		}
+		if err := staleDocumentError("requirements.md", report.Requirements); err != nil {
+			return err
+		}
 		if state.Design.Status != "approved" {
 			return fmt.Errorf("design.md must be approved before approving tasks review")
 		}
-		if !state.Design.Fresh {
-			return fmt.Errorf("design.md is stale relative to requirements.md")
+		if !report.Design.Fresh {
+			return staleChainError("design.md", "requirements.md", report.Design)
 		}
 		if state.Tasks.Status != "in-review" {
 			return fmt.Errorf("tasks.md must be in-review before approval")
@@ -202,6 +223,21 @@ func validateApproveReview(state FeatureState, phase Phase) error {
 	default:
 		return fmt.Errorf("invalid phase %q", phase)
 	}
+}
+
+// staleDocumentError reports an approved document whose own content no longer
+// matches its approval fingerprint (or that lacks one).
+func staleDocumentError(name string, verdict spec.DocumentFreshness) error {
+	if verdict.Fresh {
+		return nil
+	}
+	return fmt.Errorf("%s is stale: %s (run walden reconcile)", name, strings.Join(verdict.Causes, "; "))
+}
+
+// staleChainError reports a downstream document whose approval no longer
+// binds to the upstream's current approved content.
+func staleChainError(name, upstream string, verdict spec.DocumentFreshness) error {
+	return fmt.Errorf("%s is stale relative to %s: %s (run walden reconcile)", name, upstream, strings.Join(verdict.Causes, "; "))
 }
 
 func documentForPhase(feature *spec.Feature, phase Phase) *spec.Document {

--- a/internal/workflow/review_approve_test.go
+++ b/internal/workflow/review_approve_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -10,7 +11,7 @@ import (
 	"github.com/andrearaponi/walden/internal/spec"
 )
 
-func TestApproveReviewRequirementsSetsApprovedTimestamp(t *testing.T) {
+func TestApproveReviewRequirementsSetsApprovedTimestampAndFingerprint(t *testing.T) {
 	root := t.TempDir()
 	writeApproveFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
 status: in-review
@@ -40,6 +41,12 @@ last_modified: 2026-03-21T14:00:00Z
 	if feature.Requirements.LastModified != feature.Requirements.ApprovedAt {
 		t.Fatalf("expected last_modified to match approved_at, got %q vs %q", feature.Requirements.LastModified, feature.Requirements.ApprovedAt)
 	}
+	if !spec.ValidFingerprint(feature.Requirements.ApprovedFingerprint) {
+		t.Fatalf("expected a valid approval fingerprint, got %q", feature.Requirements.ApprovedFingerprint)
+	}
+	if !spec.BodyMatchesFingerprint(feature.Requirements.Body, feature.Requirements.ApprovedFingerprint) {
+		t.Fatal("recorded approval fingerprint does not match the approved body")
+	}
 	if result.Document != ".walden/specs/todo-app-demo/requirements.md" {
 		t.Fatalf("unexpected approved document %q", result.Document)
 	}
@@ -48,16 +55,9 @@ last_modified: 2026-03-21T14:00:00Z
 	}
 }
 
-func TestApproveReviewDesignCopiesUpstreamApprovalTimestamp(t *testing.T) {
+func TestApproveReviewDesignCopiesUpstreamApprovalTimestampAndFingerprint(t *testing.T) {
 	root := t.TempDir()
-	writeApproveFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
-status: approved
-approved_at: 2026-03-21T14:00:00Z
-last_modified: 2026-03-21T14:00:00Z
----
-
-# Requirements Document
-`)
+	writeApproveFeatureDoc(t, root, "todo-app-demo", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T14:00:00Z"))
 	writeApproveFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: in-review
 approved_at:
@@ -84,6 +84,12 @@ source_requirements_approved_at:
 	if feature.Design.SourceRequirementsApprovedAt != "2026-03-21T14:00:00Z" {
 		t.Fatalf("unexpected source requirements approval timestamp %q", feature.Design.SourceRequirementsApprovedAt)
 	}
+	if feature.Design.SourceRequirementsFingerprint != spec.Fingerprint(approveReqBody) {
+		t.Fatalf("source requirements fingerprint %q does not match upstream approval fingerprint", feature.Design.SourceRequirementsFingerprint)
+	}
+	if !spec.BodyMatchesFingerprint(feature.Design.Body, feature.Design.ApprovedFingerprint) {
+		t.Fatal("recorded design approval fingerprint does not match the approved body")
+	}
 	if !timestampLike(feature.Design.ApprovedAt) {
 		t.Fatalf("expected approved_at timestamp, got %q", feature.Design.ApprovedAt)
 	}
@@ -92,25 +98,10 @@ source_requirements_approved_at:
 	}
 }
 
-func TestApproveReviewTasksCopiesUpstreamApprovalTimestamp(t *testing.T) {
+func TestApproveReviewTasksCopiesUpstreamApprovalTimestampAndFingerprint(t *testing.T) {
 	root := t.TempDir()
-	writeApproveFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
-status: approved
-approved_at: 2026-03-21T14:00:00Z
-last_modified: 2026-03-21T14:00:00Z
----
-
-# Requirements Document
-`)
-	writeApproveFeatureDoc(t, root, "todo-app-demo", "design.md", `---
-status: approved
-approved_at: 2026-03-21T14:10:00Z
-last_modified: 2026-03-21T14:10:00Z
-source_requirements_approved_at: 2026-03-21T14:00:00Z
----
-
-# Feature Design
-`)
+	writeApproveFeatureDoc(t, root, "todo-app-demo", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T14:00:00Z"))
+	writeApproveFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint(approveReqBody)))
 	writeApproveFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: in-review
 approved_at:
@@ -136,6 +127,9 @@ source_design_approved_at:
 	}
 	if feature.Tasks.SourceDesignApprovedAt != "2026-03-21T14:10:00Z" {
 		t.Fatalf("unexpected source design approval timestamp %q", feature.Tasks.SourceDesignApprovedAt)
+	}
+	if feature.Tasks.SourceDesignFingerprint != spec.Fingerprint(approveDesignBody) {
+		t.Fatalf("source design fingerprint %q does not match upstream approval fingerprint", feature.Tasks.SourceDesignFingerprint)
 	}
 	if result.NextAction != "Start execution from the next unchecked task" {
 		t.Fatalf("unexpected next action %q", result.NextAction)
@@ -173,23 +167,9 @@ source_requirements_approved_at:
 
 func TestApproveReviewBlocksWhenDesignIsStaleForTasksApproval(t *testing.T) {
 	root := t.TempDir()
-	writeApproveFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
-status: approved
-approved_at: 2026-03-21T15:00:00Z
-last_modified: 2026-03-21T15:00:00Z
----
-
-# Requirements Document
-`)
-	writeApproveFeatureDoc(t, root, "todo-app-demo", "design.md", `---
-status: approved
-approved_at: 2026-03-21T14:10:00Z
-last_modified: 2026-03-21T14:10:00Z
-source_requirements_approved_at: 2026-03-21T14:00:00Z
----
-
-# Feature Design
-`)
+	writeApproveFeatureDoc(t, root, "todo-app-demo", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T15:00:00Z"))
+	// Design was approved against different requirements content: chain mismatch.
+	writeApproveFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("some earlier requirements content")))
 	writeApproveFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: in-review
 approved_at:
@@ -206,6 +186,76 @@ source_design_approved_at:
 	}
 	if !strings.Contains(err.Error(), "design.md is stale relative to requirements.md") {
 		t.Fatalf("unexpected error %v", err)
+	}
+	if !strings.Contains(err.Error(), spec.CauseSourceMismatch) {
+		t.Fatalf("expected cause %q in error, got %v", spec.CauseSourceMismatch, err)
+	}
+}
+
+func TestApproveReviewBlocksTamperedUpstream(t *testing.T) {
+	root := t.TempDir()
+	// Approved requirements whose body was edited after approval: the
+	// recorded fingerprint no longer matches the content.
+	tampered := fmt.Sprintf(`---
+status: approved
+approved_at: 2026-03-21T14:00:00Z
+last_modified: 2026-03-21T14:00:00Z
+approved_fingerprint: %s
+---
+
+# Requirements Document
+
+Injected after approval.
+`, spec.Fingerprint(approveReqBody))
+	writeApproveFeatureDoc(t, root, "todo-app-demo", "requirements.md", tampered)
+	writeApproveFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+status: in-review
+approved_at:
+last_modified: 2026-03-21T14:10:00Z
+source_requirements_approved_at:
+---
+
+# Feature Design
+`)
+
+	_, err := ApproveReview(root, "todo-app-demo", PhaseDesign)
+	if err == nil {
+		t.Fatal("expected design approval over a tampered upstream to fail")
+	}
+	if !strings.Contains(err.Error(), spec.CauseContentMismatch) {
+		t.Fatalf("expected cause %q in error, got %v", spec.CauseContentMismatch, err)
+	}
+	if !strings.Contains(err.Error(), "walden reconcile") {
+		t.Fatalf("expected reconcile hint in error, got %v", err)
+	}
+}
+
+func TestApproveReviewBlocksLegacyUpstreamWithoutFingerprint(t *testing.T) {
+	root := t.TempDir()
+	writeApproveFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+status: approved
+approved_at: 2026-03-21T14:00:00Z
+last_modified: 2026-03-21T14:00:00Z
+---
+
+# Requirements Document
+`)
+	writeApproveFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+status: in-review
+approved_at:
+last_modified: 2026-03-21T14:10:00Z
+source_requirements_approved_at:
+---
+
+# Feature Design
+`)
+
+	_, err := ApproveReview(root, "todo-app-demo", PhaseDesign)
+	if err == nil {
+		t.Fatal("expected design approval over a legacy upstream to fail")
+	}
+	if !strings.Contains(err.Error(), spec.CauseFingerprintMissing) {
+		t.Fatalf("expected cause %q in error, got %v", spec.CauseFingerprintMissing, err)
 	}
 }
 

--- a/internal/workflow/review_test.go
+++ b/internal/workflow/review_test.go
@@ -5,18 +5,13 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/andrearaponi/walden/internal/spec"
 )
 
 func TestOpenReviewTransitionsDocumentToInReviewAndReturnsContext(t *testing.T) {
 	root := t.TempDir()
-	writeReviewFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
-status: approved
-approved_at: 2026-03-21T14:00:00Z
-last_modified: 2026-03-21T14:00:00Z
----
-
-# Requirements Document
-`)
+	writeReviewFeatureDoc(t, root, "todo-app-demo", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T14:00:00Z"))
 	writeReviewFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: draft
 approved_at:
@@ -79,23 +74,9 @@ source_requirements_approved_at:
 
 func TestOpenReviewBlocksStaleUpstreamArtifact(t *testing.T) {
 	root := t.TempDir()
-	writeReviewFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
-status: approved
-approved_at: 2026-03-21T15:00:00Z
-last_modified: 2026-03-21T15:00:00Z
----
-
-# Requirements Document
-`)
-	writeReviewFeatureDoc(t, root, "todo-app-demo", "design.md", `---
-status: approved
-approved_at: 2026-03-21T14:10:00Z
-last_modified: 2026-03-21T14:10:00Z
-source_requirements_approved_at: 2026-03-21T14:00:00Z
----
-
-# Feature Design
-`)
+	writeReviewFeatureDoc(t, root, "todo-app-demo", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T15:00:00Z"))
+	// Approved against different requirements content: chain mismatch.
+	writeReviewFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("some earlier requirements content")))
 	writeReviewFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: draft
 approved_at:

--- a/internal/workflow/state_test.go
+++ b/internal/workflow/state_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/andrearaponi/walden/internal/spec"
 )
 
 func TestLoadFeatureStateReturnsRequirementsPhaseForDraftRequirements(t *testing.T) {
@@ -38,32 +40,11 @@ last_modified: 2026-03-21T14:00:00Z
 
 func TestLoadFeatureStateMarksDesignAndTasksStaleAfterRequirementsChange(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
-status: approved
-approved_at: 2026-03-21T15:00:00Z
-last_modified: 2026-03-21T15:00:00Z
----
-
-# Requirements Document
-`)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
-status: approved
-approved_at: 2026-03-21T14:30:00Z
-last_modified: 2026-03-21T14:30:00Z
-source_requirements_approved_at: 2026-03-21T14:00:00Z
----
-
-# Feature Design
-`)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
-status: approved
-approved_at: 2026-03-21T14:40:00Z
-last_modified: 2026-03-21T14:40:00Z
-source_design_approved_at: 2026-03-21T14:30:00Z
----
-
-# Implementation Plan
-`)
+	// Requirements were re-approved with different content: the design's
+	// recorded source fingerprint no longer matches.
+	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T15:00:00Z"))
+	writeFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:30:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("some earlier requirements content")))
+	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", approvedTasksContent(approveTasksBody, "2026-03-21T14:40:00Z", "2026-03-21T14:30:00Z", spec.Fingerprint(approveDesignBody)))
 
 	state, err := LoadFeatureState(root, "todo-app-demo")
 	if err != nil {
@@ -85,8 +66,34 @@ source_design_approved_at: 2026-03-21T14:30:00Z
 	if state.NextAction != "Update design.md to match requirements.md and return it to in-review" {
 		t.Fatalf("unexpected next action: %q", state.NextAction)
 	}
-	assertContains(t, state.Blockers, "design.md is stale relative to requirements.md")
+	assertContains(t, state.Blockers, "design.md is stale relative to requirements.md: source fingerprint mismatch")
 	assertContains(t, state.Blockers, "tasks.md is stale because design.md is stale")
+}
+
+func TestLoadFeatureStateMarksTamperedRequirementsStale(t *testing.T) {
+	root := t.TempDir()
+	tampered := approvedRequirementsContent(approveReqBody, "2026-03-21T15:00:00Z") + "\nInjected after approval.\n"
+	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", tampered)
+	writeFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T15:10:00Z", "2026-03-21T15:00:00Z", spec.Fingerprint(approveReqBody)))
+
+	state, err := LoadFeatureState(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("expected feature state load to succeed, got %v", err)
+	}
+
+	if state.Requirements.Fresh {
+		t.Fatal("expected tampered requirements to be stale")
+	}
+	if !state.IsStale {
+		t.Fatal("expected feature to be stale")
+	}
+	if state.CurrentPhase != PhaseRequirements {
+		t.Fatalf("expected requirements phase for tampered requirements, got %q", state.CurrentPhase)
+	}
+	if state.NextAction != "Run walden reconcile to repair the approval chain" {
+		t.Fatalf("unexpected next action: %q", state.NextAction)
+	}
+	assertContains(t, state.Blockers, "requirements.md is stale: content does not match approval fingerprint")
 }
 
 func TestLoadFeatureStateReportsInvalidTopologyBlockers(t *testing.T) {
@@ -117,32 +124,9 @@ source_requirements_approved_at:
 
 func TestLoadFeatureStateReturnsExecutionNextActionWhenAllSpecsAreApproved(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
-status: approved
-approved_at: 2026-03-21T14:00:00Z
-last_modified: 2026-03-21T14:00:00Z
----
-
-# Requirements Document
-`)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
-status: approved
-approved_at: 2026-03-21T14:10:00Z
-last_modified: 2026-03-21T14:10:00Z
-source_requirements_approved_at: 2026-03-21T14:00:00Z
----
-
-# Feature Design
-`)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
-status: approved
-approved_at: 2026-03-21T14:20:00Z
-last_modified: 2026-03-21T14:20:00Z
-source_design_approved_at: 2026-03-21T14:10:00Z
----
-
-# Implementation Plan
-`)
+	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T14:00:00Z"))
+	writeFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint(approveReqBody)))
+	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", approvedTasksContent(approveTasksBody, "2026-03-21T14:20:00Z", "2026-03-21T14:10:00Z", spec.Fingerprint(approveDesignBody)))
 
 	state, err := LoadFeatureState(root, "todo-app-demo")
 	if err != nil {
@@ -187,25 +171,13 @@ func assertContains(t *testing.T, values []string, want string) {
 	t.Fatalf("expected %#v to contain %q", values, want)
 }
 
-func TestTimestampFreshnessWithEquivalentFormats(t *testing.T) {
+func TestFingerprintComparisonDecidesFreshnessDespiteTimestampDivergence(t *testing.T) {
+	// Content-identical re-approval: approved_at moved forward while the
+	// recorded source timestamp stayed behind, but fingerprints match.
+	// The chain must stay fresh — fingerprint comparison alone decides.
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "ts-test", "requirements.md", `---
-status: approved
-approved_at: 2026-03-21T14:00:00Z
-last_modified: 2026-03-21T14:00:00Z
----
-
-# Requirements Document
-`)
-	writeFeatureDoc(t, root, "ts-test", "design.md", `---
-status: approved
-approved_at: 2026-03-21T14:10:00Z
-last_modified: 2026-03-21T14:10:00Z
-source_requirements_approved_at: 2026-03-21T15:00:00+01:00
----
-
-# Feature Design
-`)
+	writeFeatureDoc(t, root, "ts-test", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T18:00:00Z"))
+	writeFeatureDoc(t, root, "ts-test", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint(approveReqBody)))
 
 	state, err := LoadFeatureState(root, "ts-test")
 	if err != nil {
@@ -213,47 +185,26 @@ source_requirements_approved_at: 2026-03-21T15:00:00+01:00
 	}
 
 	if !state.Design.Fresh {
-		t.Fatal("expected design to be fresh when source_requirements_approved_at is equivalent offset timestamp")
+		t.Fatal("expected design to stay fresh when fingerprints match, regardless of timestamps")
 	}
 	if state.IsStale {
-		t.Fatal("expected state not to be stale with equivalent timestamps")
+		t.Fatal("expected state not to be stale when fingerprints match")
 	}
 }
 
 func TestLoadFeatureStateReportsCompletedImplementationPlan(t *testing.T) {
 	root := t.TempDir()
-	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
-status: approved
-approved_at: 2026-03-21T14:00:00Z
-last_modified: 2026-03-21T14:00:00Z
----
-
-# Requirements Document
-`)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", `---
-status: approved
-approved_at: 2026-03-21T14:10:00Z
-last_modified: 2026-03-21T14:10:00Z
-source_requirements_approved_at: 2026-03-21T14:00:00Z
----
-
-# Feature Design
-`)
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
-status: approved
-approved_at: 2026-03-21T14:20:00Z
-last_modified: 2026-03-21T14:20:00Z
-source_design_approved_at: 2026-03-21T14:10:00Z
----
-
-# Implementation Plan
+	completedPlanBody := `# Implementation Plan
 
 - [x] 1. Build parser
   - [x] 1.1 Implement parser
-    - Requirements: `+"`R1`"+`
+    - Requirements: ` + "`R1`" + `
     - Design: Task Store
-    - Verification: `+"`go test ./internal/spec`"+`
-`)
+    - Verification: ` + "`go test ./internal/spec`" + `
+`
+	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T14:00:00Z"))
+	writeFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint(approveReqBody)))
+	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", approvedTasksContent(completedPlanBody, "2026-03-21T14:20:00Z", "2026-03-21T14:10:00Z", spec.Fingerprint(approveDesignBody)))
 
 	state, err := LoadFeatureState(root, "todo-app-demo")
 	if err != nil {

--- a/internal/workflow/status.go
+++ b/internal/workflow/status.go
@@ -1,6 +1,11 @@
 package workflow
 
-import "github.com/andrearaponi/walden/internal/spec"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/andrearaponi/walden/internal/spec"
+)
 
 // DocumentState is the workflow-oriented view of a loaded document.
 type DocumentState struct {
@@ -8,10 +13,13 @@ type DocumentState struct {
 	Status                       string
 	ApprovedAt                   string
 	LastModified                 string
+	ApprovedFingerprint          string
 	SourceRequirementsApprovedAt string
 	SourceDesignApprovedAt       string
 	Exists                       bool
 	Fresh                        bool
+	Intact                       bool
+	StaleCauses                  []string
 }
 
 // FeatureState describes the current workflow state of a feature.
@@ -47,9 +55,10 @@ func ResolveFeatureState(feature spec.Feature) FeatureState {
 		Tasks:        toDocumentState(feature.Tasks),
 	}
 
-	evaluateFreshness(&state)
+	evaluateFreshness(&state, spec.EvaluateFreshness(feature))
 	state.Blockers = collectBlockers(state)
-	state.IsStale = !state.Design.Fresh && state.Design.Exists && state.Design.Status == "approved" ||
+	state.IsStale = !state.Requirements.Fresh && state.Requirements.Exists && state.Requirements.Status == "approved" ||
+		!state.Design.Fresh && state.Design.Exists && state.Design.Status == "approved" ||
 		!state.Tasks.Fresh && state.Tasks.Exists && state.Tasks.Status == "approved"
 	state.CurrentPhase, state.NextAction = resolveCurrentPhaseAndAction(feature, state)
 
@@ -62,42 +71,42 @@ func toDocumentState(document spec.Document) DocumentState {
 		Status:                       document.Status,
 		ApprovedAt:                   document.ApprovedAt,
 		LastModified:                 document.LastModified,
+		ApprovedFingerprint:          document.ApprovedFingerprint,
 		SourceRequirementsApprovedAt: document.SourceRequirementsApprovedAt,
 		SourceDesignApprovedAt:       document.SourceDesignApprovedAt,
 		Exists:                       document.Exists,
 		Fresh:                        document.Exists,
+		Intact:                       true,
 	}
 }
 
-func evaluateFreshness(state *FeatureState) {
-	if state.Design.Exists && state.Design.Status == "approved" {
-		state.Design.Fresh = state.Requirements.Status == "approved" &&
-			state.Requirements.ApprovedAt != "" &&
-			timestampsMatch(state.Design.SourceRequirementsApprovedAt, state.Requirements.ApprovedAt)
-	}
+func evaluateFreshness(state *FeatureState, report spec.FreshnessReport) {
+	applyVerdict(&state.Requirements, report.Requirements)
+	applyVerdict(&state.Design, report.Design)
+	applyVerdict(&state.Tasks, report.Tasks)
+}
 
-	if state.Tasks.Exists && state.Tasks.Status == "approved" {
-		state.Tasks.Fresh = state.Design.Status == "approved" &&
-			state.Design.ApprovedAt != "" &&
-			timestampsMatch(state.Tasks.SourceDesignApprovedAt, state.Design.ApprovedAt)
-	}
-
-	if state.Design.Exists && state.Design.Status == "approved" && !state.Design.Fresh {
-		if state.Tasks.Exists {
-			state.Tasks.Fresh = false
-		}
+func applyVerdict(document *DocumentState, verdict spec.DocumentFreshness) {
+	document.Intact = verdict.Intact
+	document.StaleCauses = verdict.Causes
+	if document.Exists {
+		document.Fresh = verdict.Fresh
 	}
 }
 
-func timestampsMatch(a, b string) bool {
-	if a == "" || b == "" {
-		return a == b
+// staleDocumentMessage describes an approved document whose own content no
+// longer matches its approval fingerprint.
+func staleDocumentMessage(name string, document DocumentState) string {
+	return fmt.Sprintf("%s is stale: %s", name, strings.Join(document.StaleCauses, "; "))
+}
+
+// staleChainMessage describes a downstream document whose approval no longer
+// binds to the upstream's current approved content.
+func staleChainMessage(name, upstream string, document DocumentState) string {
+	if !document.Intact {
+		return staleDocumentMessage(name, document)
 	}
-	equal, err := spec.TimestampsEqual(a, b)
-	if err != nil {
-		return a == b
-	}
-	return equal
+	return fmt.Sprintf("%s is stale relative to %s: %s", name, upstream, strings.Join(document.StaleCauses, "; "))
 }
 
 func collectBlockers(state FeatureState) []string {
@@ -120,8 +129,12 @@ func collectBlockers(state FeatureState) []string {
 		blockers = append(blockers, "tasks.md requires approved design.md")
 	}
 
+	if state.Requirements.Exists && state.Requirements.Status == "approved" && !state.Requirements.Fresh {
+		blockers = append(blockers, staleDocumentMessage("requirements.md", state.Requirements))
+	}
+
 	if state.Design.Exists && state.Design.Status == "approved" && !state.Design.Fresh {
-		blockers = append(blockers, "design.md is stale relative to requirements.md")
+		blockers = append(blockers, staleChainMessage("design.md", "requirements.md", state.Design))
 	}
 
 	if state.Tasks.Exists {
@@ -129,7 +142,7 @@ func collectBlockers(state FeatureState) []string {
 		case state.Design.Exists && state.Design.Status == "approved" && !state.Design.Fresh:
 			blockers = append(blockers, "tasks.md is stale because design.md is stale")
 		case state.Tasks.Status == "approved" && !state.Tasks.Fresh:
-			blockers = append(blockers, "tasks.md is stale relative to design.md")
+			blockers = append(blockers, staleChainMessage("tasks.md", "design.md", state.Tasks))
 		}
 	}
 
@@ -146,7 +159,12 @@ func resolveCurrentPhaseAndAction(feature spec.Feature, state FeatureState) (Pha
 		return PhaseRequirements, "Approve requirements.md"
 	case state.Requirements.Status != "approved":
 		return PhaseRequirements, "Resolve requirements.md status"
+	case !state.Requirements.Fresh:
+		return PhaseRequirements, "Run walden reconcile to repair the approval chain"
 	case state.Design.Exists && state.Design.Status == "approved" && !state.Design.Fresh:
+		if !state.Design.Intact {
+			return PhaseDesign, "Run walden reconcile to repair the approval chain"
+		}
 		return PhaseDesign, "Update design.md to match requirements.md and return it to in-review"
 	case !state.Design.Exists:
 		return PhaseDesign, "Create design.md"
@@ -157,6 +175,9 @@ func resolveCurrentPhaseAndAction(feature spec.Feature, state FeatureState) (Pha
 	case state.Design.Status != "approved":
 		return PhaseDesign, "Resolve design.md status"
 	case state.Tasks.Exists && state.Tasks.Status == "approved" && !state.Tasks.Fresh:
+		if !state.Tasks.Intact {
+			return PhaseTasks, "Run walden reconcile to repair the approval chain"
+		}
 		return PhaseTasks, "Update tasks.md to match the latest approved design and return it to in-review"
 	case !state.Tasks.Exists:
 		return PhaseTasks, "Create tasks.md"

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,9 @@ detect_platform() {
 # --- Version detection ---
 
 detect_version() {
-  VERSION="$(git -C "$SCRIPT_DIR" describe --tags --abbrev=0 2>/dev/null || echo "dev")"
+  # Full describe: clean tag on release commits (v0.3.0), honest suffix on
+  # dev builds (v0.3.0-9-g337b6b5) so installs from a branch are identifiable.
+  VERSION="$(git -C "$SCRIPT_DIR" describe --tags --dirty 2>/dev/null || echo "dev")"
   info "Version: ${VERSION}"
 }
 

--- a/skill/walden/SKILL.md
+++ b/skill/walden/SKILL.md
@@ -90,6 +90,7 @@ Every document must begin with YAML frontmatter.
 status: draft
 approved_at:
 last_modified: 2026-03-19T10:00:00Z
+approved_fingerprint:
 ---
 ```
 
@@ -100,7 +101,9 @@ last_modified: 2026-03-19T10:00:00Z
 status: draft
 approved_at:
 last_modified: 2026-03-19T10:00:00Z
+approved_fingerprint:
 source_requirements_approved_at:
+source_requirements_fingerprint:
 ---
 ```
 
@@ -111,7 +114,9 @@ source_requirements_approved_at:
 status: draft
 approved_at:
 last_modified: 2026-03-19T10:00:00Z
+approved_fingerprint:
 source_design_approved_at:
+source_design_fingerprint:
 ---
 ```
 
@@ -119,13 +124,12 @@ Apply these rules consistently:
 
 - Set `status: draft` when first creating a document.
 - Set `status: in-review` immediately before presenting a revision to the user.
-- Set `status: approved` and populate `approved_at` only after explicit approval.
+- Set `status: approved` and populate `approved_at` only after explicit approval — prefer `walden review approve`, which also records the approval fingerprints.
 - Update `last_modified` on every edit.
-- If an approved document is edited later, set it back to `in-review` until it is re-approved.
-- When approving `design.md`, copy the current `requirements.md.approved_at` into `source_requirements_approved_at`.
-- When approving `tasks.md`, copy the current `design.md.approved_at` into `source_design_approved_at`.
-- If `requirements.md.approved_at` no longer matches `design.md.source_requirements_approved_at`, `design.md` and `tasks.md` are stale.
-- If `design.md.approved_at` no longer matches `tasks.md.source_design_approved_at`, `tasks.md` is stale.
+- Never hand-edit fingerprint fields (`approved_fingerprint`, `source_*_fingerprint`): they are computed and verified by the CLI. A fingerprint that does not match its document's content makes the document stale.
+- Freshness is decided by fingerprint comparison: an approved document is stale when its body no longer matches its `approved_fingerprint`, and a downstream document is stale when its `source_*_fingerprint` differs from the upstream's current `approved_fingerprint`. Timestamps remain as human-readable context.
+- If an approved document is edited later, it is stale until the chain is repaired: run `walden reconcile` (the document resets to draft) and take it through review again.
+- Approved documents that lack fingerprints (created by pre-fingerprint CLI versions) are stale by definition; `walden reconcile` plus one re-approval cycle migrates them.
 
 ## Phase Router
 
@@ -281,7 +285,7 @@ Design starts only from approved and non-stale requirements.
 - Include `## Options Considered`, `## Simplicity And Elegance Review`, `## Failure Modes And Tradeoffs`, and `## Verification Plan`.
 - Challenge the first draft once before showing it: ask whether a simpler shape, lower coupling, or fewer moving parts would satisfy the same requirements.
 - Use diagrams only when they clarify decisions.
-- Record the current `requirements.md.approved_at` in `source_requirements_approved_at` when the design is approved.
+- Approve with `walden review approve`, which records the upstream approval timestamp and fingerprint (`source_requirements_approved_at`, `source_requirements_fingerprint`).
 - In the Requirement Coverage table, wrap every ID in backticks (e.g., `| `R1` |`, `| `NFR1` |`). The deterministic validator matches this exact format and will reject rows without backticks.
 
 ### `design.md` Template
@@ -291,7 +295,9 @@ Design starts only from approved and non-stale requirements.
 status: draft
 approved_at:
 last_modified: 2026-03-19T10:00:00Z
+approved_fingerprint:
 source_requirements_approved_at:
+source_requirements_fingerprint:
 ---
 
 # Feature Design
@@ -396,7 +402,7 @@ Task generation starts only from approved and non-stale design.
 - Reference design sections on every leaf task.
 - Add a `Verification:` block on every leaf task using the structured `command` format (Kubernetes pattern). The CLI executes commands via `exec.Command` without a shell, so use JSON arrays for exact argument control.
 - Optionally add a `covers:` field on proof steps to declare which acceptance criteria the proof demonstrates. The CLI tracks proof reference coverage separately from task reference coverage and reports both in `walden validate --json`.
-- Record the current `design.md.approved_at` in `source_design_approved_at` when the task list is approved.
+- Approve with `walden review approve`, which records the upstream approval timestamp and fingerprint (`source_design_approved_at`, `source_design_fingerprint`).
 
 ### Verification Format
 
@@ -449,7 +455,9 @@ Legacy single-line format (`Verification: go test ./...`) still works but does n
 status: draft
 approved_at:
 last_modified: 2026-03-19T10:00:00Z
+approved_fingerprint:
 source_design_approved_at:
+source_design_fingerprint:
 ---
 
 # Implementation Plan

--- a/templates/spec/design.md.tmpl
+++ b/templates/spec/design.md.tmpl
@@ -2,7 +2,9 @@
 status: draft
 approved_at:
 last_modified: {{ .Timestamp }}
+approved_fingerprint:
 source_requirements_approved_at:
+source_requirements_fingerprint:
 ---
 
 # Feature Design

--- a/templates/spec/requirements.md.tmpl
+++ b/templates/spec/requirements.md.tmpl
@@ -2,6 +2,7 @@
 status: draft
 approved_at:
 last_modified: {{ .Timestamp }}
+approved_fingerprint:
 ---
 
 # Requirements Document

--- a/templates/spec/tasks.md.tmpl
+++ b/templates/spec/tasks.md.tmpl
@@ -2,7 +2,9 @@
 status: draft
 approved_at:
 last_modified: {{ .Timestamp }}
+approved_fingerprint:
 source_design_approved_at:
+source_design_fingerprint:
 ---
 
 # Implementation Plan


### PR DESCRIPTION
## Summary

Freshness verdicts move from declarative timestamps to SHA-256 content fingerprints. \`review approve\` records a fingerprint of the approved body (\`approved_fingerprint\`) and binds downstream approvals to the upstream's fingerprint (\`source_requirements_fingerprint\`, \`source_design_fingerprint\`). Editing an approved document without re-approval, a missing fingerprint, or a malformed fingerprint all fail closed: the document reports stale with a named cause, execution blocks with a non-zero exit, and \`reconcile\` repairs deterministically.

Timestamps remain in frontmatter as human-readable context — fingerprints alone carry the verdict.

## What changed

- New pure modules in \`internal/spec\`: \`fingerprint.go\` (normalize → SHA-256, golden-value pinned) and \`freshness.go\` (single evaluator returning intact/fresh/causes per document)
- The three previously independent freshness implementations (workflow status, reconcile heuristic, validator) now consume the one evaluator; the \`last_modified > approved_at\` heuristic and \`DowngradeDocumentToInReview\` are deleted
- Review gates refuse design/tasks transitions over a non-intact or chain-stale upstream, with cause and reconcile hint
- \`reconcile\` resets tampered, malformed, and legacy (pre-fingerprint) approved documents to \`draft\` and clears fingerprint fields; chain resets cascade as before
- \`task complete-all\` on a gate-blocked feature now exits non-zero with the blocker (previously exit 0 with "no runnable tasks")
- Additive JSON within \`v0beta1\`: \`stale_causes\`, \`approved_fingerprint\` on document status
- Normalization treats line endings and task checkbox state as non-content (completing tasks does not stale the approved plan); pinned by golden tests
- Docs, spec templates, skill (\`SKILL.md\`), and CHANGELOG updated, including the strict migration note
- \`setup.sh\` dev builds now report the full \`git describe\` version instead of the bare last tag

## Behavior changes to be aware of

- **Strict migration:** documents approved by pre-fingerprint versions report stale (\`approval fingerprint missing\`) until one \`reconcile\` + re-approval cycle per feature
- A post-approval edit now resets to \`draft\` via reconcile (previously \`in-review\`)
- Content-identical re-approval no longer stales downstream documents (timestamp noise removed)

## How it was built and verified

Built through Walden's own gated ceremony (dogfooding). The gates caught two real defects during execution:

1. **Checkbox spec gap** — \`task complete\` mutates the approved \`tasks.md\` body; strict integrity flagged the plan as tampered after the first completion. Requirements were amended mid-execution (R1.AC4: checkbox state is execution progress, not content) with a full gate re-run.
2. **\`complete-all\` silent success** — the batch command reported success on a gate-blocked feature, violating the approved AC for non-zero exits.

Verification: full suite green (\`go build ./... && go test ./...\`), an end-to-end lifecycle test (approve → tamper → blocked with causes → reconcile → re-approve → execution restored), a cross-agent field test (a different coding agent ran the complete ceremony and 22 proof-gated completions against this build; chain fingerprints bound exactly, plan fresh after all checkbox mutations), and a proof-format torture battery (multi-step, shell pipes and \`&&\`, \`expect_exit\`, nested quotes, legacy single-line) all passing with the chain fresh afterwards.