### PR TITLE
release: prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,24 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Thi
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-02
+
 ### Added
 
 - **Freshness hardening: content fingerprints.** `walden review approve` now records a SHA-256 fingerprint of the approved document body (`approved_fingerprint`) and binds downstream approvals to the upstream's fingerprint (`source_requirements_fingerprint`, `source_design_fingerprint`). Staleness verdicts are decided by fingerprint comparison alone — editing an approved document without re-approval, a missing fingerprint, or a malformed fingerprint all fail closed and block execution with a named cause. Timestamps remain in frontmatter as human-readable context.
-- `stale_causes` and `approved_fingerprint` fields on document entries in `status`/`validate` JSON output (additive within `schema_version: v0beta1`).
+- `stale_causes` and `approved_fingerprint` fields on document entries in `status`/`validate` JSON output (additive within `schema_version: v0beta1` — the envelope is unchanged and existing integrations keep working).
 - Fingerprint normalization treats task checkbox state as execution progress, not content: completing tasks does not stale the approved plan.
 
 ### Changed
 
-- **Migration (strict):** documents approved by pre-fingerprint versions report stale with cause `approval fingerprint missing`. Run `walden reconcile <feature>` once and re-approve each phase to migrate.
+- **BREAKING (strict migration):** documents approved by pre-fingerprint versions report stale with cause `approval fingerprint missing`, and execution on them is blocked until migrated. Run `walden reconcile <feature>` once (documents reset to `draft`; task checkboxes are preserved) and re-approve each phase. This is deliberate: a grace mode that trusted fingerprint-less approvals would silently keep the old falsifiable behavior.
+- **BREAKING:** `walden task complete-all` on a gate-blocked feature now exits non-zero with the blocker (previously reported "no runnable tasks" with exit 0). CI scripts relying on the old exit code must be updated.
 - `walden reconcile` now resets a modified-after-approval document to `draft` (previously `in-review`): changed content is unreviewed content.
 - Content-identical re-approval of an upstream document no longer marks downstream documents stale (previously any re-approval staled the chain via timestamps).
-- `walden task complete-all` on a gate-blocked feature now exits non-zero with the blocker (previously reported "no runnable tasks" with exit 0).
+
+### Fixed
+
+- `setup.sh` dev builds now report the full `git describe` version (e.g. `v0.3.0-2-g153f439`) instead of the bare latest tag, so binaries built from a branch are identifiable.
 
 ## [0.3.0] - 2026-06-26
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,15 +1,44 @@
-## Walden v0.3.0
+## Walden v0.4.0
 
-A small, focused release: the JSON output contract graduates from alpha to beta.
+Freshness gets teeth. Approval now binds to the exact content that was reviewed: staleness is proven by SHA-256 content fingerprints, not asserted by timestamps.
 
-### Changed
+### ⚠️ Breaking — read before upgrading
 
-- **JSON contract: `v0alpha1` → `v0beta1`.** After sustained real-world use, the contract is no longer "alpha" — its shape has settled. `v0beta1` signals a maturing contract you can build integrations on with care: it may still change before the stable `v1` (which will land at v1.0.0, with a documented migration guide), but breaking changes are flagged in the changelog. The envelope shape is unchanged from v0.2.0 — only the version label advances. Consumers should match the `v0` prefix rather than the exact string.
+**Existing specs report stale after upgrading.** Documents approved by v0.3.0 and earlier carry no approval fingerprint, so the new binary treats them as stale (`approval fingerprint missing`) and blocks execution on them. Migration is one deterministic cycle per feature:
+
+```bash
+walden reconcile <feature>   # documents reset to draft; task checkboxes are preserved
+# then re-approve each phase:
+walden review open <feature> --phase requirements && walden review approve <feature> --phase requirements
+walden review open <feature> --phase design       && walden review approve <feature> --phase design
+walden review open <feature> --phase tasks        && walden review approve <feature> --phase tasks
+```
+
+This strictness is deliberate: a grace mode that trusted fingerprint-less approvals would silently keep the old, falsifiable behavior.
+
+**`task complete-all` exit code.** On a gate-blocked feature it now exits non-zero with the blocker (previously "no runnable tasks" with exit 0). Update CI scripts that relied on the old code.
+
+**Not breaking:** the JSON contract. The envelope is unchanged and the new fields (`stale_causes`, `approved_fingerprint`) are additive within `schema_version: v0beta1` — existing integrations keep working.
+
+### What fingerprints change
+
+- `walden review approve` records a SHA-256 fingerprint of the approved body (`approved_fingerprint`) and, on downstream documents, the upstream's approval fingerprint (`source_requirements_fingerprint`, `source_design_fingerprint`).
+- **Tamper detection:** editing an approved document without re-approval makes it stale — no matter what its metadata claims. Missing or malformed fingerprints fail closed. Every verdict carries a named cause, in human output and in `--json` (`stale_causes`).
+- **Chain freshness by content identity:** a downstream document is fresh when its recorded source fingerprint equals the upstream's current approval fingerprint. Corollary: re-approving an upstream document *without changing its content* no longer stales the chain — timestamp noise is gone.
+- **Execution progress is not content:** fingerprint normalization treats task checkbox state (and line endings) as non-content, so completing tasks never invalidates the approved plan.
+- `walden reconcile` repairs everything deterministically: tampered, malformed, and legacy documents reset to `draft`, chain resets cascade, re-approval records fresh fingerprints.
+- Timestamps stay in frontmatter as human-readable context; fingerprints alone carry the verdict.
+
+No new commands, no new dependencies: the hardening rides `review approve`, `validate`, `status`, `task *`, and `reconcile`, pure Go standard library.
+
+### Built the Walden way
+
+This release was specified and executed through Walden's own gated ceremony. The gates caught two real defects during execution: the checkbox mutation gap (fixed by amending the approved requirements mid-execution, with a full gate re-run) and the `complete-all` silent success on blocked features. Verified by the full test suite, an end-to-end tamper → block → reconcile → restore lifecycle test, and a cross-agent field test: a different coding agent ran the complete ceremony and 22 proof-gated task completions against this build.
 
 ### Install
 
 ```bash
-go install github.com/andrearaponi/walden/cmd/walden@v0.3.0
+go install github.com/andrearaponi/walden/cmd/walden@v0.4.0
 
 # or: build the binary and optionally install the AI skill
 git clone https://github.com/andrearaponi/walden.git
@@ -17,5 +46,7 @@ cd walden && ./setup.sh
 ```
 
 Pre-built binaries for linux/darwin × amd64/arm64 are attached to this release.
+
+**Skill update:** `SKILL.md` documents the fingerprint model — re-run `./setup.sh` (or re-copy the skill) for the agents you use.
 
 Still zero external dependencies.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,13 +2,14 @@
 
 This is the public roadmap for Walden. It distinguishes committed open source work from exploratory and enterprise-only work.
 
-## Current Release: v0.1.0
+## Current Release: v0.4.0
 
-The first public release includes:
+The open source core today includes:
 
 - Deterministic CLI with all core commands
-- Versioned JSON output contract (`v0alpha1`)
-- Public skill bundle for Claude, Codex, Copilot, and OpenCode
+- Content-fingerprint freshness chain: tamper detection and provable approval binding on every spec document
+- Versioned JSON output contract (`v0beta1`)
+- Public skill bundle for Claude Code, Codex, Copilot, and OpenCode (model-invoked Agent Skill on Claude Code)
 - Documentation pack (concepts, workflow, boundaries)
 - Example project with shell-safe verification
 - Repository bootstrap and feature scaffolding templates


### PR DESCRIPTION
Prepares the v0.4.0 release (freshness hardening):

- CHANGELOG: [Unreleased] → [0.4.0], with the strict migration and the `task complete-all` exit-code change marked **BREAKING**; JSON contract explicitly noted as additive (not breaking) within `v0beta1`
- RELEASE_NOTES.md rewritten for v0.4.0, leading with the breaking/migration section and the one-cycle repair path
- docs/roadmap.md: current-release section refreshed (was still v0.1.0)

After merge: tag `v0.4.0` on main to trigger the release workflow (binaries + GitHub Release from RELEASE_NOTES.md).