### PR TITLE
feat: embed the AI skill in the binary with a walden skill command group

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ The setup script builds the binary, installs it to `~/.local/bin/walden`, and op
 
 ```bash
 go install github.com/andrearaponi/walden/cmd/walden@latest
+walden skill install claude
 ```
 
-Requires Go 1.25.0 or later.
+Requires Go 1.25.0 or later. The skill ships inside the binary — `walden skill install` places it for your agent (`claude`, `codex`, `copilot`, `opencode`, or `--all`), always at the version matching the CLI.
 
 ### Build Locally
 
@@ -81,13 +82,18 @@ go build -o walden ./cmd/walden
 
 ```bash
 walden version
+walden skill status
 ```
+
+`walden skill status` reports where the skill is installed and whether it matches the binary's embedded copy.
 
 ### Uninstall
 
 ```bash
 ./setup.sh uninstall
 ```
+
+Or remove just the skill with `walden skill uninstall <agent>` (or `--all`).
 
 ## Quickstart
 
@@ -364,49 +370,33 @@ The optional AI skill handles non-deterministic authoring work while delegating 
 
 ### Install the Skill
 
-**Using setup.sh** (interactive prompt):
+The skill is embedded in the binary — no repository clone or manual copying needed:
 
 ```bash
-./setup.sh
+walden skill install claude      # or codex, copilot, opencode
+walden skill install --all       # every supported agent at once
 ```
 
-**For Claude Code** (project-level):
+Installs are user-scoped by default (available across all your projects). For Claude Code and Codex you can install at project scope instead, so teammates get the skill by cloning the repository:
 
 ```bash
-mkdir -p .claude/skills/walden
-cp skill/walden/SKILL.md .claude/skills/walden/SKILL.md
+walden skill install claude --project
+git add .claude/skills/walden/SKILL.md
 ```
 
-**For Claude Code** (user-level, available across all projects):
+Check installations and detect drift against the binary's embedded copy:
 
 ```bash
-mkdir -p ~/.claude/skills/walden
-cp skill/walden/SKILL.md ~/.claude/skills/walden/SKILL.md
+walden skill status
 ```
 
-Claude Code auto-activates the skill when your request matches its description. See `skill/walden/install-claude.md` for details.
-
-**For Codex:**
-
-See `skill/walden/install-codex.md` for Codex-specific instructions.
-
-**For Copilot:**
+For agents Walden does not model yet, print the skill and place it yourself:
 
 ```bash
-mkdir -p ~/.copilot/skills/walden
-cp skill/walden/SKILL.md ~/.copilot/skills/walden/SKILL.md
+walden skill show > wherever/your/agent/loads/it.md
 ```
 
-See `skill/walden/install-copilot.md` for Copilot-specific instructions.
-
-**For OpenCode:**
-
-```bash
-mkdir -p ~/.config/opencode/skills/walden
-cp skill/walden/SKILL.md ~/.config/opencode/skills/walden/SKILL.md
-```
-
-See `skill/walden/install-opencode.md` for OpenCode-specific instructions.
+Claude Code auto-activates the skill when your request matches its description. Per-agent notes: `skill/walden/install-claude.md`, `install-codex.md`, `install-copilot.md`, `install-opencode.md`.
 
 ### Prerequisite
 

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -43,6 +43,10 @@ var commandUsages = []commandUsage{
 	{"validate <feature> [--all] [--json]", "Check EARS, traceability, and freshness"},
 	{"review open <feature> --phase <phase> [--json]", "Open the review gate (move to in-review)"},
 	{"review approve <feature> --phase <phase> [--json]", "Approve the review gate (move to approved)"},
+	{"skill install <agent>|--all [--project] [--json]", "Install the embedded AI skill (claude|codex|copilot|opencode)"},
+	{"skill uninstall <agent>|--all [--project] [--json]", "Remove an installed AI skill"},
+	{"skill status [--json]", "Report installed skills and drift against the embedded copy"},
+	{"skill show [--json]", "Print the embedded SKILL.md"},
 }
 
 var commandRunner shell.Runner = shell.NewExecRunner()
@@ -76,6 +80,8 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 		return runValidate(args[1:], stdout, stderr)
 	case "review":
 		return runReview(args[1:], stdout, stderr)
+	case "skill":
+		return runSkill(args[1:], stdout, stderr)
 	}
 
 	_, _ = fmt.Fprintf(stderr, "unknown command: %s\n\n", strings.Join(args, " "))

--- a/internal/app/skill.go
+++ b/internal/app/skill.go
@@ -1,0 +1,306 @@
+package app
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/andrearaponi/walden/internal/output"
+	"github.com/andrearaponi/walden/internal/skilldist"
+	"github.com/andrearaponi/walden/skill"
+)
+
+func runSkill(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) > 0 && args[0] == "show" {
+		return runSkillShow(args[1:], stdout, stderr)
+	}
+	if len(args) > 0 && args[0] == "install" {
+		return runSkillInstall(args[1:], stdout, stderr)
+	}
+	if len(args) > 0 && args[0] == "uninstall" {
+		return runSkillUninstall(args[1:], stdout, stderr)
+	}
+	if len(args) > 0 && args[0] == "status" {
+		return runSkillStatus(args[1:], stdout, stderr)
+	}
+
+	_, _ = fmt.Fprintf(stderr, "unknown command: skill %s\n\n", strings.Join(args, " "))
+	printUsage(stderr)
+	return 1
+}
+
+func runSkillStatus(args []string, stdout io.Writer, stderr io.Writer) int {
+	jsonMode := false
+	for _, arg := range args {
+		if arg == "--json" {
+			jsonMode = true
+		}
+	}
+
+	opts, err := skillOptions()
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	statuses, warnings := skilldist.Status(opts)
+	skills := make([]output.SkillStatus, 0, len(statuses))
+	for _, status := range statuses {
+		skills = append(skills, output.SkillStatus{
+			Agent:     status.Agent,
+			Scope:     string(status.Scope),
+			Path:      status.Path,
+			Installed: status.Installed,
+			State:     status.State,
+			Version:   status.Version,
+		})
+	}
+
+	// Status is a report, not a gate: drift never changes the exit code.
+	result := output.Result{
+		Summary:  fmt.Sprintf("skill status against embedded version %s", Version),
+		Skills:   skills,
+		Warnings: warnings,
+		ExitCode: 0,
+	}
+
+	if jsonMode {
+		if err := output.PrintJSON(stdout, "skill-status", result); err != nil {
+			_, _ = fmt.Fprintf(stderr, "render json output: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	output.PrintText(stdout, result)
+	return 0
+}
+
+// skillFlags holds the parsed flag set shared by install and uninstall.
+type skillFlags struct {
+	jsonMode bool
+	project  bool
+	all      bool
+	agents   []string
+}
+
+func parseSkillFlags(args []string) skillFlags {
+	flags := skillFlags{}
+	for _, arg := range args {
+		switch arg {
+		case "--json":
+			flags.jsonMode = true
+		case "--project":
+			flags.project = true
+		case "--all":
+			flags.all = true
+		default:
+			flags.agents = append(flags.agents, arg)
+		}
+	}
+	return flags
+}
+
+// resolveSkillTarget validates the flag combination and returns the selected
+// agent (zero Agent when --all). A non-nil error is a usage error.
+func resolveSkillTarget(command string, flags skillFlags) (skilldist.Agent, error) {
+	supported := strings.Join(skilldist.AgentNames(), ", ")
+
+	if flags.all {
+		if flags.project || len(flags.agents) > 0 {
+			return skilldist.Agent{}, fmt.Errorf("skill %s --all cannot be combined with --project or an agent", command)
+		}
+		return skilldist.Agent{}, nil
+	}
+	if len(flags.agents) != 1 {
+		return skilldist.Agent{}, fmt.Errorf("skill %s requires exactly one agent: %s (or --all)", command, supported)
+	}
+
+	agent, err := skilldist.Lookup(flags.agents[0])
+	if err != nil {
+		return skilldist.Agent{}, fmt.Errorf("skill %s: %v", command, err)
+	}
+	if flags.project {
+		if _, ok := agent.ProjectTarget("."); !ok {
+			return skilldist.Agent{}, fmt.Errorf("agent %s supports only user scope; --project is not available", agent.Name)
+		}
+	}
+	return agent, nil
+}
+
+func skillOptions() (skilldist.Options, error) {
+	workDir, err := os.Getwd()
+	if err != nil {
+		return skilldist.Options{}, fmt.Errorf("resolve working directory: %w", err)
+	}
+	return skilldist.Options{
+		Version: Version,
+		WorkDir: workDir,
+		Env:     skilldist.EnvFromOS(),
+	}, nil
+}
+
+func runSkillInstall(args []string, stdout io.Writer, stderr io.Writer) int {
+	flags := parseSkillFlags(args)
+	agent, err := resolveSkillTarget("install", flags)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	opts, err := skillOptions()
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	var reports []skilldist.Report
+	if flags.all {
+		reports, err = skilldist.InstallAll(opts)
+	} else {
+		scope := skilldist.ScopeUser
+		if flags.project {
+			scope = skilldist.ScopeProject
+		}
+		var report skilldist.Report
+		report, err = skilldist.Install(agent, scope, opts)
+		reports = []skilldist.Report{report}
+	}
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	result := installResult(flags, reports)
+	if flags.jsonMode {
+		if err := output.PrintJSON(stdout, "skill-install", result); err != nil {
+			_, _ = fmt.Fprintf(stderr, "render json output: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	output.PrintText(stdout, result)
+	return 0
+}
+
+func installResult(flags skillFlags, reports []skilldist.Report) output.Result {
+	changed := make([]string, 0, len(reports))
+	for _, report := range reports {
+		changed = append(changed, report.Path)
+	}
+
+	result := output.Result{
+		Summary:      fmt.Sprintf("skill installed for %s (user scope)", reports[0].Agent),
+		ChangedFiles: changed,
+		ExitCode:     0,
+	}
+	if flags.all {
+		result.Summary = "skill installed for all supported agents (user scope)"
+	}
+	if flags.project {
+		result.Summary = fmt.Sprintf("skill installed for %s (project scope)", reports[0].Agent)
+		result.NextAction = fmt.Sprintf("Commit %s to share the skill with your team", reports[0].Path)
+	}
+	return result
+}
+
+func runSkillUninstall(args []string, stdout io.Writer, stderr io.Writer) int {
+	flags := parseSkillFlags(args)
+	agent, err := resolveSkillTarget("uninstall", flags)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	opts, err := skillOptions()
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	var reports []skilldist.Report
+	if flags.all {
+		reports, err = skilldist.UninstallAll(opts)
+	} else {
+		scope := skilldist.ScopeUser
+		if flags.project {
+			scope = skilldist.ScopeProject
+		}
+		var report skilldist.Report
+		report, err = skilldist.Uninstall(agent, scope, opts)
+		reports = []skilldist.Report{report}
+	}
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	result := uninstallResult(flags, reports)
+	if flags.jsonMode {
+		if err := output.PrintJSON(stdout, "skill-uninstall", result); err != nil {
+			_, _ = fmt.Fprintf(stderr, "render json output: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	output.PrintText(stdout, result)
+	return 0
+}
+
+func uninstallResult(flags skillFlags, reports []skilldist.Report) output.Result {
+	changed := []string{}
+	removedAny := false
+	for _, report := range reports {
+		if !report.NotInstalled {
+			changed = append(changed, report.Path)
+			removedAny = true
+		}
+	}
+
+	result := output.Result{ChangedFiles: changed, ExitCode: 0}
+	scope := "user scope"
+	if flags.project {
+		scope = "project scope"
+	}
+	switch {
+	case flags.all && removedAny:
+		result.Summary = "skill removed for all installed agents (user scope)"
+	case flags.all:
+		result.Summary = "skill not installed for any agent (user scope)"
+	case removedAny:
+		result.Summary = fmt.Sprintf("skill removed for %s (%s)", reports[0].Agent, scope)
+	default:
+		result.Summary = fmt.Sprintf("skill not installed for %s (%s)", reports[0].Agent, scope)
+	}
+	return result
+}
+
+func runSkillShow(args []string, stdout io.Writer, stderr io.Writer) int {
+	jsonMode := false
+	for _, arg := range args {
+		if arg == "--json" {
+			jsonMode = true
+		}
+	}
+
+	if jsonMode {
+		result := output.Result{
+			Summary:  "embedded walden skill",
+			Content:  string(skill.Content()),
+			ExitCode: 0,
+		}
+		if err := output.PrintJSON(stdout, "skill-show", result); err != nil {
+			_, _ = fmt.Fprintf(stderr, "render json output: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+
+	// Verbatim bytes with no framing, so `walden skill show > SKILL.md`
+	// yields a clean skill file.
+	if _, err := stdout.Write(skill.Content()); err != nil {
+		_, _ = fmt.Fprintf(stderr, "write skill content: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/internal/app/skill_install_test.go
+++ b/internal/app/skill_install_test.go
@@ -1,0 +1,208 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/skill"
+)
+
+func TestSkillInstallClaudeUserScope(t *testing.T) {
+	home := setSkillTestEnv(t)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skill", "install", "claude"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", code, stderr.String())
+	}
+
+	target := filepath.Join(home, ".claude", "skills", "walden", "SKILL.md")
+	installed, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read installed skill: %v", err)
+	}
+	if !bytes.HasPrefix(installed, skill.Content()) {
+		t.Fatal("installed skill must start with the embedded content")
+	}
+	if !bytes.Contains(installed, []byte("walden-skill-version")) {
+		t.Fatal("installed skill must carry the version stamp")
+	}
+	if !strings.Contains(stdout.String(), target) {
+		t.Fatalf("output must name the installed path, got:\n%s", stdout.String())
+	}
+}
+
+func TestSkillInstallReinstallSucceeds(t *testing.T) {
+	setSkillTestEnv(t)
+	for i := 0; i < 2; i++ {
+		var stdout, stderr bytes.Buffer
+		if code := Run([]string{"skill", "install", "claude"}, &stdout, &stderr); code != 0 {
+			t.Fatalf("run %d: expected exit 0, got %d (stderr: %s)", i, code, stderr.String())
+		}
+	}
+}
+
+func TestSkillInstallAllInstallsEveryAgent(t *testing.T) {
+	home := setSkillTestEnv(t)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skill", "install", "--all"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", code, stderr.String())
+	}
+	for _, suffix := range []string{
+		".claude/skills/walden/SKILL.md",
+		".codex/AGENTS.md",
+		".copilot/skills/walden/SKILL.md",
+		".config/opencode/skills/walden/SKILL.md",
+	} {
+		if _, err := os.Stat(filepath.Join(home, suffix)); err != nil {
+			t.Fatalf("expected %s to be installed: %v", suffix, err)
+		}
+	}
+}
+
+func TestSkillInstallProjectScopeEmitsCommitHint(t *testing.T) {
+	setSkillTestEnv(t)
+	work := t.TempDir()
+	t.Chdir(work)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skill", "install", "claude", "--project"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", code, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(work, ".claude", "skills", "walden", "SKILL.md")); err != nil {
+		t.Fatalf("expected project-scope skill under the working directory: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Commit") {
+		t.Fatalf("project install must hint at committing the file, got:\n%s", stdout.String())
+	}
+}
+
+func TestSkillInstallJSONEnvelope(t *testing.T) {
+	setSkillTestEnv(t)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skill", "install", "claude", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", code, stderr.String())
+	}
+	var envelope struct {
+		Command string `json:"command"`
+		OK      bool   `json:"ok"`
+		Result  struct {
+			ChangedFiles []string `json:"changed_files"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("parse envelope: %v", err)
+	}
+	if envelope.Command != "skill-install" || !envelope.OK {
+		t.Fatalf("unexpected envelope: %s", stdout.String())
+	}
+	if len(envelope.Result.ChangedFiles) != 1 {
+		t.Fatalf("expected one changed file, got %v", envelope.Result.ChangedFiles)
+	}
+}
+
+func TestSkillInstallRejectsMissingAndUnknownAgents(t *testing.T) {
+	setSkillTestEnv(t)
+	for _, args := range [][]string{
+		{"skill", "install"},
+		{"skill", "install", "cursor"},
+	} {
+		var stdout, stderr bytes.Buffer
+		code := Run(args, &stdout, &stderr)
+		if code != 1 {
+			t.Fatalf("%v: expected exit 1, got %d", args, code)
+		}
+		if !strings.Contains(stderr.String(), "claude, codex, copilot, opencode") {
+			t.Fatalf("%v: error must list the supported agents, got: %s", args, stderr.String())
+		}
+	}
+}
+
+func TestSkillInstallRejectsProjectForUserOnlyAgents(t *testing.T) {
+	setSkillTestEnv(t)
+	for _, agent := range []string{"copilot", "opencode"} {
+		var stdout, stderr bytes.Buffer
+		code := Run([]string{"skill", "install", agent, "--project"}, &stdout, &stderr)
+		if code != 1 {
+			t.Fatalf("%s: expected exit 1, got %d", agent, code)
+		}
+		if !strings.Contains(stderr.String(), "only user scope") {
+			t.Fatalf("%s: error must explain user-only support, got: %s", agent, stderr.String())
+		}
+	}
+}
+
+func TestSkillInstallRejectsAllWithProjectOrAgent(t *testing.T) {
+	setSkillTestEnv(t)
+	for _, args := range [][]string{
+		{"skill", "install", "--all", "--project"},
+		{"skill", "install", "--all", "claude"},
+	} {
+		var stdout, stderr bytes.Buffer
+		code := Run(args, &stdout, &stderr)
+		if code != 1 {
+			t.Fatalf("%v: expected exit 1, got %d", args, code)
+		}
+		if !strings.Contains(stderr.String(), "--all cannot be combined") {
+			t.Fatalf("%v: expected a flag-conflict error, got: %s", args, stderr.String())
+		}
+	}
+}
+
+func TestSkillUninstallRemovesInstalledSkill(t *testing.T) {
+	home := setSkillTestEnv(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"skill", "install", "claude"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("install: expected exit 0 (stderr: %s)", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"skill", "uninstall", "claude"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("uninstall: expected exit 0, got stderr: %s", stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "skills", "walden")); !os.IsNotExist(err) {
+		t.Fatal("uninstall must remove the skill directory")
+	}
+}
+
+func TestSkillUninstallAbsentSkillIsIdempotent(t *testing.T) {
+	setSkillTestEnv(t)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skill", "uninstall", "claude"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit 0 for an absent installation, got %d (stderr: %s)", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "not installed") {
+		t.Fatalf("expected a not-installed summary, got:\n%s", stdout.String())
+	}
+}
+
+func TestSkillUninstallAllRemovesEverything(t *testing.T) {
+	home := setSkillTestEnv(t)
+
+	var buf bytes.Buffer
+	if code := Run([]string{"skill", "install", "--all"}, &buf, &buf); code != 0 {
+		t.Fatalf("install --all failed:\n%s", buf.String())
+	}
+	buf.Reset()
+	if code := Run([]string{"skill", "uninstall", "--all"}, &buf, &buf); code != 0 {
+		t.Fatalf("uninstall --all failed:\n%s", buf.String())
+	}
+	for _, suffix := range []string{".claude/skills/walden", ".codex/AGENTS.md", ".copilot/skills/walden", ".config/opencode/skills/walden"} {
+		if _, err := os.Stat(filepath.Join(home, suffix)); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be removed", suffix)
+		}
+	}
+}

--- a/internal/app/skill_status_test.go
+++ b/internal/app/skill_status_test.go
@@ -1,0 +1,91 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSkillStatusFreshEnvironment(t *testing.T) {
+	setSkillTestEnv(t)
+	t.Chdir(t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skill", "status"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Skills:") {
+		t.Fatalf("expected a Skills block, got:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "not-installed") {
+		t.Fatalf("expected not-installed states, got:\n%s", stdout.String())
+	}
+}
+
+func TestSkillStatusJSONCarriesSkillsAndExitsZeroOnDrift(t *testing.T) {
+	home := setSkillTestEnv(t)
+	t.Chdir(t.TempDir())
+
+	var buf bytes.Buffer
+	if code := Run([]string{"skill", "install", "claude"}, &buf, &buf); code != 0 {
+		t.Fatalf("install failed:\n%s", buf.String())
+	}
+
+	// Drift the installation on purpose: status must still exit 0.
+	target := filepath.Join(home, ".claude", "skills", "walden", "SKILL.md")
+	if err := os.WriteFile(target, []byte("locally rewritten\n"), 0o644); err != nil {
+		t.Fatalf("edit installed skill: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skill", "status", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("status must exit 0 even with drift, got %d (stderr: %s)", code, stderr.String())
+	}
+
+	var envelope struct {
+		Command string `json:"command"`
+		OK      bool   `json:"ok"`
+		Result  struct {
+			Skills []struct {
+				Agent string `json:"agent"`
+				Scope string `json:"scope"`
+				State string `json:"state"`
+			} `json:"skills"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("parse envelope: %v", err)
+	}
+	if envelope.Command != "skill-status" || !envelope.OK {
+		t.Fatalf("unexpected envelope: %s", stdout.String())
+	}
+	if len(envelope.Result.Skills) == 0 {
+		t.Fatal("expected skills in the JSON envelope")
+	}
+	foundDrifted := false
+	for _, s := range envelope.Result.Skills {
+		if s.Agent == "claude" && s.Scope == "user" && s.State == "drifted" {
+			foundDrifted = true
+		}
+	}
+	if !foundDrifted {
+		t.Fatalf("expected the edited claude installation to read drifted: %s", stdout.String())
+	}
+}
+
+func TestUsageListsSkillCommands(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"--help"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("expected exit 0, got %d", code)
+	}
+	for _, needle := range []string{"skill install", "skill uninstall", "skill status", "skill show"} {
+		if !strings.Contains(stdout.String(), needle) {
+			t.Fatalf("usage must list %q, got:\n%s", needle, stdout.String())
+		}
+	}
+}

--- a/internal/app/skill_test.go
+++ b/internal/app/skill_test.go
@@ -1,0 +1,73 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/andrearaponi/walden/skill"
+)
+
+// setSkillTestEnv points every skill-relevant environment variable at
+// temporary directories so tests never touch the real user configuration.
+func setSkillTestEnv(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+	t.Setenv("COPILOT_HOME", "")
+	t.Setenv("OPENCODE_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	return home
+}
+
+func TestSkillShowWritesVerbatimContent(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skill", "show"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", code, stderr.String())
+	}
+	if !bytes.Equal(stdout.Bytes(), skill.Content()) {
+		t.Fatal("skill show must write the embedded skill verbatim, with no framing")
+	}
+}
+
+func TestSkillShowJSONCarriesContent(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skill", "show", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr: %s)", code, stderr.String())
+	}
+
+	var envelope struct {
+		SchemaVersion string `json:"schema_version"`
+		Command       string `json:"command"`
+		OK            bool   `json:"ok"`
+		Result        struct {
+			Content string `json:"content"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("parse envelope: %v", err)
+	}
+	if envelope.Command != "skill-show" {
+		t.Fatalf("expected command skill-show, got %s", envelope.Command)
+	}
+	if !envelope.OK {
+		t.Fatal("expected ok envelope")
+	}
+	if envelope.Result.Content != string(skill.Content()) {
+		t.Fatal("JSON content must equal the embedded skill")
+	}
+}
+
+func TestSkillUnknownSubcommandFails(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skill", "dance"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected exit 1, got %d", code)
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("unknown command")) {
+		t.Fatalf("expected an unknown-command error, got: %s", stderr.String())
+	}
+}

--- a/internal/output/result.go
+++ b/internal/output/result.go
@@ -31,7 +31,19 @@ type Result struct {
 	EARSValidation        []EARSCriterion   `json:"ears_validation,omitempty"`
 	Coverage              *CoverageReport   `json:"coverage,omitempty"`
 	EARSDistribution      *EARSDistribution `json:"ears_distribution,omitempty"`
+	Skills                []SkillStatus     `json:"skills,omitempty"`
+	Content               string            `json:"content,omitempty"`
 	ExitCode              int               `json:"exit_code"`
+}
+
+// SkillStatus is the shared output view for one skill installation slot.
+type SkillStatus struct {
+	Agent     string `json:"agent"`
+	Scope     string `json:"scope"`
+	Path      string `json:"path"`
+	Installed bool   `json:"installed"`
+	State     string `json:"state"`
+	Version   string `json:"version,omitempty"`
 }
 
 // EARSDistribution is the JSON output view of EARS form counts.
@@ -180,6 +192,20 @@ func PrintText(w io.Writer, result Result) {
 		}
 		if result.Task.Verification != "" {
 			_, _ = fmt.Fprintf(w, "Task verification: %s\n", result.Task.Verification)
+		}
+	}
+
+	if len(result.Skills) > 0 {
+		_, _ = fmt.Fprintln(w, "Skills:")
+		for _, skill := range result.Skills {
+			_, _ = fmt.Fprintf(w, "- %s (%s): %s", skill.Agent, skill.Scope, skill.State)
+			if skill.Version != "" {
+				_, _ = fmt.Fprintf(w, " version=%s", skill.Version)
+			}
+			if skill.Installed {
+				_, _ = fmt.Fprintf(w, " path=%s", skill.Path)
+			}
+			_, _ = fmt.Fprintln(w)
 		}
 	}
 

--- a/internal/output/skills_test.go
+++ b/internal/output/skills_test.go
@@ -1,0 +1,89 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSkillStatusJSONFieldNames(t *testing.T) {
+	status := SkillStatus{
+		Agent:     "claude",
+		Scope:     "user",
+		Path:      "/home/u/.claude/skills/walden/SKILL.md",
+		Installed: true,
+		State:     "in-sync",
+		Version:   "v1.0.0",
+	}
+	raw, err := json.Marshal(status)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"agent", "scope", "path", "installed", "state", "version"} {
+		if _, ok := decoded[key]; !ok {
+			t.Fatalf("expected JSON key %q, got %s", key, raw)
+		}
+	}
+}
+
+func TestResultSkillsAndContentAreAdditive(t *testing.T) {
+	// Empty skills/content must not appear in the envelope at all, so
+	// existing consumers see an unchanged shape.
+	raw, err := json.Marshal(Result{Summary: "s"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, forbidden := range []string{"\"skills\"", "\"content\""} {
+		if bytes.Contains(raw, []byte(forbidden)) {
+			t.Fatalf("empty %s must be omitted from the envelope: %s", forbidden, raw)
+		}
+	}
+
+	// Pre-existing envelope keys must remain present and unrenamed.
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"summary", "changed_files", "skipped_files", "warnings", "exit_code"} {
+		if _, ok := decoded[key]; !ok {
+			t.Fatalf("existing envelope key %q must remain, got %s", key, raw)
+		}
+	}
+
+	withSkills, err := json.Marshal(Result{Skills: []SkillStatus{{Agent: "claude"}}, Content: "body"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Contains(withSkills, []byte("\"skills\"")) || !bytes.Contains(withSkills, []byte("\"content\"")) {
+		t.Fatalf("populated skills/content must serialize: %s", withSkills)
+	}
+}
+
+func TestPrintTextRendersSkillsBlock(t *testing.T) {
+	var buf bytes.Buffer
+	PrintText(&buf, Result{
+		Summary: "skill status",
+		Skills: []SkillStatus{
+			{Agent: "claude", Scope: "user", Path: "/p/SKILL.md", Installed: true, State: "in-sync", Version: "v1"},
+			{Agent: "copilot", Scope: "user", Path: "/q/SKILL.md", Installed: false, State: "not-installed"},
+		},
+	})
+	text := buf.String()
+	if !strings.Contains(text, "Skills:") {
+		t.Fatalf("expected a Skills block, got:\n%s", text)
+	}
+	if !strings.Contains(text, "claude (user): in-sync version=v1 path=/p/SKILL.md") {
+		t.Fatalf("unexpected installed skill line:\n%s", text)
+	}
+	if !strings.Contains(text, "copilot (user): not-installed") {
+		t.Fatalf("unexpected not-installed skill line:\n%s", text)
+	}
+	if strings.Contains(text, "path=/q/SKILL.md") {
+		t.Fatalf("not-installed slots must not print a path:\n%s", text)
+	}
+}

--- a/internal/skilldist/block.go
+++ b/internal/skilldist/block.go
@@ -1,0 +1,106 @@
+package skilldist
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// Marker strings delimiting the Walden block in shared AGENTS.md files.
+// They MUST stay byte-identical to the markers historically written by
+// setup.sh, so existing installations are recognized and upgradable.
+const (
+	blockBegin = "# --- BEGIN WALDEN SKILL ---"
+	blockEnd   = "# --- END WALDEN SKILL ---"
+)
+
+// ErrCorruptBlock reports a BEGIN marker without a matching END marker.
+var ErrCorruptBlock = errors.New("corrupt walden skill block")
+
+// upsertBlock writes content as a marker-delimited block in target,
+// replacing an existing block in place or appending one when absent.
+func upsertBlock(target string, content []byte) (replaced bool, err error) {
+	existing, err := os.ReadFile(target)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("read %s: %w", target, err)
+	}
+
+	updated, replaced, err := spliceBlock(existing, buildBlock(content), target)
+	if err != nil {
+		return false, err
+	}
+	if _, err := writeFileAtomic(target, updated); err != nil {
+		return false, err
+	}
+	return replaced, nil
+}
+
+func buildBlock(content []byte) []byte {
+	var block bytes.Buffer
+	block.WriteString(blockBegin + "\n")
+	block.Write(content)
+	if len(content) > 0 && !bytes.HasSuffix(content, []byte("\n")) {
+		block.WriteString("\n")
+	}
+	block.WriteString(blockEnd + "\n")
+	return block.Bytes()
+}
+
+// spliceBlock returns existing with block replacing the current Walden block,
+// or appended (separated by a blank line) when no block is present.
+func spliceBlock(existing, block []byte, target string) ([]byte, bool, error) {
+	begin, end, err := blockBounds(existing, target)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if begin == -1 {
+		out := append([]byte(nil), existing...)
+		if len(out) > 0 {
+			if !bytes.HasSuffix(out, []byte("\n")) {
+				out = append(out, '\n')
+			}
+			out = append(out, '\n')
+		}
+		return append(out, block...), false, nil
+	}
+
+	out := append([]byte(nil), existing[:begin]...)
+	out = append(out, block...)
+	out = append(out, existing[end:]...)
+	return out, true, nil
+}
+
+// blockBounds locates the Walden block in data. It returns (-1, -1, nil)
+// when no block exists and ErrCorruptBlock when BEGIN has no matching END.
+// end points just past the END marker line's trailing newline when present.
+func blockBounds(data []byte, target string) (begin, end int, err error) {
+	begin = bytes.Index(data, []byte(blockBegin))
+	if begin == -1 {
+		return -1, -1, nil
+	}
+	endMarker := bytes.Index(data[begin:], []byte(blockEnd))
+	if endMarker == -1 {
+		return -1, -1, fmt.Errorf("%w: %s has a BEGIN marker without a matching END marker", ErrCorruptBlock, target)
+	}
+	end = begin + endMarker + len(blockEnd)
+	if end < len(data) && data[end] == '\n' {
+		end++
+	}
+	return begin, end, nil
+}
+
+// blockInterior extracts the content between the marker lines.
+func blockInterior(data []byte, target string) (interior []byte, found bool, err error) {
+	begin, end, err := blockBounds(data, target)
+	if err != nil || begin == -1 {
+		return nil, false, err
+	}
+	start := begin + len(blockBegin)
+	if start < len(data) && data[start] == '\n' {
+		start++
+	}
+	stop := bytes.Index(data[begin:end], []byte(blockEnd)) + begin
+	return data[start:stop], true, nil
+}

--- a/internal/skilldist/install.go
+++ b/internal/skilldist/install.go
@@ -1,0 +1,145 @@
+package skilldist
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/andrearaponi/walden/skill"
+)
+
+// Options carries the context every skill operation needs. Injecting it
+// keeps operations pure with respect to the process environment.
+type Options struct {
+	// Version is stamped into installed content (the binary's version).
+	Version string
+	// WorkDir anchors project-scope targets.
+	WorkDir string
+	// Env resolves user-scope targets.
+	Env Env
+}
+
+// Report describes the outcome of one install or uninstall operation.
+type Report struct {
+	Agent         string
+	Scope         Scope
+	Path          string
+	Replaced      bool
+	NotInstalled  bool
+	LegacyRemoved bool
+}
+
+// Install places the embedded skill for agent at scope, stamped with the
+// binary version. Existing installations are replaced, never duplicated.
+func Install(agent Agent, scope Scope, opts Options) (Report, error) {
+	target, err := resolveTarget(agent, scope, opts)
+	if err != nil {
+		return Report{}, err
+	}
+
+	report := Report{Agent: agent.Name, Scope: scope, Path: target}
+	content := Stamp(skill.Content(), opts.Version)
+
+	switch agent.Kind {
+	case KindFile:
+		replaced, err := writeFileAtomic(target, content)
+		if err != nil {
+			return Report{}, err
+		}
+		report.Replaced = replaced
+	case KindBlock:
+		replaced, err := upsertBlock(target, content)
+		if err != nil {
+			return Report{}, err
+		}
+		report.Replaced = replaced
+	default:
+		return Report{}, fmt.Errorf("agent %s: unsupported write kind %q", agent.Name, agent.Kind)
+	}
+
+	report.LegacyRemoved = cleanupLegacy(agent, scope, opts)
+	return report, nil
+}
+
+// InstallAll installs the skill at user scope for every supported agent in
+// registry order, stopping on the first failure. The returned reports cover
+// the agents that completed before the failure.
+func InstallAll(opts Options) ([]Report, error) {
+	reports := make([]Report, 0, len(agents))
+	for _, agent := range agents {
+		report, err := Install(agent, ScopeUser, opts)
+		if err != nil {
+			return reports, fmt.Errorf("install %s: %w", agent.Name, err)
+		}
+		reports = append(reports, report)
+	}
+	return reports, nil
+}
+
+func resolveTarget(agent Agent, scope Scope, opts Options) (string, error) {
+	switch scope {
+	case ScopeProject:
+		target, ok := agent.ProjectTarget(opts.WorkDir)
+		if !ok {
+			return "", fmt.Errorf("agent %s supports only user scope", agent.Name)
+		}
+		return target, nil
+	default:
+		return agent.UserTarget(opts.Env)
+	}
+}
+
+// writeFileAtomic writes content to target via a temp file and rename, so a
+// failure never leaves a partially written target.
+func writeFileAtomic(target string, content []byte) (replaced bool, err error) {
+	dir := filepath.Dir(target)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return false, fmt.Errorf("create target directory: %w", err)
+	}
+
+	_, statErr := os.Stat(target)
+	replaced = statErr == nil
+
+	tmp, err := os.CreateTemp(dir, ".walden-skill-*")
+	if err != nil {
+		return false, fmt.Errorf("create temp file: %w", err)
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return false, fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return false, fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Chmod(tmp.Name(), 0o644); err != nil {
+		return false, fmt.Errorf("set permissions: %w", err)
+	}
+	if err := os.Rename(tmp.Name(), target); err != nil {
+		return false, fmt.Errorf("replace target: %w", err)
+	}
+	return replaced, nil
+}
+
+// cleanupLegacy removes obsolete user-scope artifacts (e.g. the legacy
+// /walden command file) and reports whether anything was removed.
+func cleanupLegacy(agent Agent, scope Scope, opts Options) bool {
+	if scope != ScopeUser || agent.LegacyUserFiles == nil {
+		return false
+	}
+	removed := false
+	for _, legacy := range agent.LegacyUserFiles(opts.Env) {
+		if removeIfExists(legacy) {
+			removed = true
+		}
+	}
+	return removed
+}
+
+func removeIfExists(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	return os.Remove(path) == nil
+}

--- a/internal/skilldist/install_block_test.go
+++ b/internal/skilldist/install_block_test.go
@@ -1,0 +1,143 @@
+package skilldist
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/andrearaponi/walden/skill"
+)
+
+func TestInstallBlockMarkersMatchSetupScript(t *testing.T) {
+	if blockBegin != "# --- BEGIN WALDEN SKILL ---" {
+		t.Fatalf("BEGIN marker drifted from setup.sh: %q", blockBegin)
+	}
+	if blockEnd != "# --- END WALDEN SKILL ---" {
+		t.Fatalf("END marker drifted from setup.sh: %q", blockEnd)
+	}
+}
+
+func TestInstallBlockCreatesAgentsFile(t *testing.T) {
+	opts, home := testOptions(t)
+	report, err := Install(mustLookup(t, "codex"), ScopeUser, opts)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	want := filepath.Join(home, ".codex", "AGENTS.md")
+	if report.Path != want {
+		t.Fatalf("expected path %s, got %s", want, report.Path)
+	}
+	if report.Replaced {
+		t.Fatal("first install must not report replaced")
+	}
+
+	data, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	interior, found, err := blockInterior(data, want)
+	if err != nil || !found {
+		t.Fatalf("expected a walden block (found=%t err=%v)", found, err)
+	}
+	if !bytes.Equal(interior, Stamp(skill.Content(), "v9.9.9")) {
+		t.Fatal("block interior must be the stamped embedded skill")
+	}
+}
+
+func TestInstallBlockAppendsPreservingExistingContent(t *testing.T) {
+	opts, home := testOptions(t)
+	target := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	prior := "# My agents\n\npersonal notes\n"
+	if err := os.WriteFile(target, []byte(prior), 0o644); err != nil {
+		t.Fatalf("seed AGENTS.md: %v", err)
+	}
+
+	if _, err := Install(mustLookup(t, "codex"), ScopeUser, opts); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if !bytes.HasPrefix(data, []byte(prior)) {
+		t.Fatal("existing content must be preserved ahead of the appended block")
+	}
+	if !bytes.Contains(data, []byte(blockBegin)) || !bytes.Contains(data, []byte(blockEnd)) {
+		t.Fatal("appended block must carry both markers")
+	}
+}
+
+func TestInstallBlockReplacesExistingBlockInPlace(t *testing.T) {
+	opts, home := testOptions(t)
+	target := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	prefix := "# My agents\n\npersonal notes\n\n"
+	suffix := "trailing notes\n"
+	seeded := prefix + blockBegin + "\nOLD-SENTINEL-CONTENT\n" + blockEnd + "\n" + suffix
+	if err := os.WriteFile(target, []byte(seeded), 0o644); err != nil {
+		t.Fatalf("seed AGENTS.md: %v", err)
+	}
+
+	report, err := Install(mustLookup(t, "codex"), ScopeUser, opts)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !report.Replaced {
+		t.Fatal("installing over an existing block must report replaced")
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if !bytes.HasPrefix(data, []byte(prefix)) {
+		t.Fatal("content before the block must be preserved byte for byte")
+	}
+	if !bytes.HasSuffix(data, []byte(suffix)) {
+		t.Fatal("content after the block must be preserved byte for byte")
+	}
+	if bytes.Contains(data, []byte("OLD-SENTINEL-CONTENT")) {
+		t.Fatal("the old block interior must be fully replaced")
+	}
+	if bytes.Count(data, []byte(blockBegin)) != 1 {
+		t.Fatal("replacement must not duplicate the block")
+	}
+	interior, found, err := blockInterior(data, target)
+	if err != nil || !found {
+		t.Fatalf("expected a walden block (found=%t err=%v)", found, err)
+	}
+	if !bytes.Equal(interior, Stamp(skill.Content(), "v9.9.9")) {
+		t.Fatal("block interior must be the stamped embedded skill")
+	}
+}
+
+func TestInstallBlockCorruptMarkersAbortWithoutModifying(t *testing.T) {
+	opts, home := testOptions(t)
+	target := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	corrupt := "notes\n" + blockBegin + "\nno end marker\n"
+	if err := os.WriteFile(target, []byte(corrupt), 0o644); err != nil {
+		t.Fatalf("seed AGENTS.md: %v", err)
+	}
+
+	_, err := Install(mustLookup(t, "codex"), ScopeUser, opts)
+	if !errors.Is(err, ErrCorruptBlock) {
+		t.Fatalf("expected ErrCorruptBlock, got %v", err)
+	}
+	data, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Fatalf("read AGENTS.md: %v", readErr)
+	}
+	if !bytes.Equal(data, []byte(corrupt)) {
+		t.Fatal("a corrupt block must abort the operation without modifying the file")
+	}
+}

--- a/internal/skilldist/install_file_test.go
+++ b/internal/skilldist/install_file_test.go
@@ -1,0 +1,152 @@
+package skilldist
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/skill"
+)
+
+func testOptions(t *testing.T) (Options, string) {
+	t.Helper()
+	home := t.TempDir()
+	return Options{Version: "v9.9.9", WorkDir: t.TempDir(), Env: Env{Home: home}}, home
+}
+
+func mustLookup(t *testing.T, name string) Agent {
+	t.Helper()
+	agent, err := Lookup(name)
+	if err != nil {
+		t.Fatalf("Lookup(%s): %v", name, err)
+	}
+	return agent
+}
+
+func TestInstallFileUserScopeTargets(t *testing.T) {
+	cases := []struct {
+		agent  string
+		suffix string
+	}{
+		{"claude", ".claude/skills/walden/SKILL.md"},
+		{"copilot", ".copilot/skills/walden/SKILL.md"},
+		{"opencode", ".config/opencode/skills/walden/SKILL.md"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.agent, func(t *testing.T) {
+			opts, home := testOptions(t)
+			report, err := Install(mustLookup(t, tc.agent), ScopeUser, opts)
+			if err != nil {
+				t.Fatalf("Install: %v", err)
+			}
+			want := filepath.Join(home, tc.suffix)
+			if report.Path != want {
+				t.Fatalf("expected path %s, got %s", want, report.Path)
+			}
+			if report.Replaced {
+				t.Fatal("first install must not report replaced")
+			}
+			installed, err := os.ReadFile(want)
+			if err != nil {
+				t.Fatalf("read installed skill: %v", err)
+			}
+			if !bytes.Equal(installed, Stamp(skill.Content(), "v9.9.9")) {
+				t.Fatal("installed content must be the embedded skill plus the version stamp")
+			}
+		})
+	}
+}
+
+func TestInstallFileStampsVersionAndPreservesBody(t *testing.T) {
+	opts, home := testOptions(t)
+	if _, err := Install(mustLookup(t, "claude"), ScopeUser, opts); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	installed, err := os.ReadFile(filepath.Join(home, ".claude/skills/walden/SKILL.md"))
+	if err != nil {
+		t.Fatalf("read installed skill: %v", err)
+	}
+	body, version := Strip(installed)
+	if version != "v9.9.9" {
+		t.Fatalf("expected stamped version v9.9.9, got %q", version)
+	}
+	if !bytes.Equal(body, skill.Content()) {
+		t.Fatal("stripped body must equal the embedded skill")
+	}
+}
+
+func TestInstallFileReplacesExisting(t *testing.T) {
+	opts, home := testOptions(t)
+	target := filepath.Join(home, ".claude/skills/walden/SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("OLD-SENTINEL-CONTENT"), 0o644); err != nil {
+		t.Fatalf("seed stale skill: %v", err)
+	}
+
+	report, err := Install(mustLookup(t, "claude"), ScopeUser, opts)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !report.Replaced {
+		t.Fatal("reinstall over an existing file must report replaced")
+	}
+	installed, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read installed skill: %v", err)
+	}
+	if bytes.Contains(installed, []byte("OLD-SENTINEL-CONTENT")) {
+		t.Fatal("stale content must be fully replaced")
+	}
+}
+
+func TestInstallFileRemovesLegacyCommand(t *testing.T) {
+	opts, home := testOptions(t)
+	legacy := filepath.Join(home, ".claude", "commands", "walden.md")
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(legacy, []byte("old command"), 0o644); err != nil {
+		t.Fatalf("seed legacy command: %v", err)
+	}
+
+	report, err := Install(mustLookup(t, "claude"), ScopeUser, opts)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !report.LegacyRemoved {
+		t.Fatal("expected legacy removal to be reported")
+	}
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Fatal("legacy command file must be removed")
+	}
+}
+
+func TestInstallFileWriteFailureLeavesNoPartialFile(t *testing.T) {
+	opts, home := testOptions(t)
+	dir := filepath.Join(home, ".claude", "skills", "walden")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	_, err := Install(mustLookup(t, "claude"), ScopeUser, opts)
+	if err == nil {
+		t.Fatal("expected install to fail on a read-only directory")
+	}
+	entries, readErr := os.ReadDir(dir)
+	if readErr != nil {
+		t.Fatalf("read target dir: %v", readErr)
+	}
+	for _, entry := range entries {
+		if strings.Contains(entry.Name(), "walden-skill") || entry.Name() == "SKILL.md" {
+			t.Fatalf("failed install must leave no partial file, found %s", entry.Name())
+		}
+	}
+}

--- a/internal/skilldist/install_project_test.go
+++ b/internal/skilldist/install_project_test.go
@@ -1,0 +1,144 @@
+package skilldist
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/skill"
+)
+
+func TestInstallProjectClaudeWritesUnderWorkDir(t *testing.T) {
+	opts, _ := testOptions(t)
+	report, err := Install(mustLookup(t, "claude"), ScopeProject, opts)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	want := filepath.Join(opts.WorkDir, ".claude", "skills", "walden", "SKILL.md")
+	if report.Path != want {
+		t.Fatalf("expected path %s, got %s", want, report.Path)
+	}
+	installed, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("read installed skill: %v", err)
+	}
+	if !bytes.Equal(installed, Stamp(skill.Content(), "v9.9.9")) {
+		t.Fatal("project install must place the stamped embedded skill")
+	}
+}
+
+func TestInstallProjectCodexWritesAgentsFileUnderWorkDir(t *testing.T) {
+	opts, _ := testOptions(t)
+	report, err := Install(mustLookup(t, "codex"), ScopeProject, opts)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	want := filepath.Join(opts.WorkDir, "AGENTS.md")
+	if report.Path != want {
+		t.Fatalf("expected path %s, got %s", want, report.Path)
+	}
+	data, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	interior, found, err := blockInterior(data, want)
+	if err != nil || !found {
+		t.Fatalf("expected a walden block (found=%t err=%v)", found, err)
+	}
+	if !bytes.Equal(interior, Stamp(skill.Content(), "v9.9.9")) {
+		t.Fatal("block interior must be the stamped embedded skill")
+	}
+}
+
+func TestInstallProjectUnsupportedAgentsFail(t *testing.T) {
+	opts, _ := testOptions(t)
+	for _, name := range []string{"copilot", "opencode"} {
+		_, err := Install(mustLookup(t, name), ScopeProject, opts)
+		if err == nil {
+			t.Fatalf("%s: expected project-scope install to fail", name)
+		}
+		if !strings.Contains(err.Error(), "only user scope") {
+			t.Fatalf("%s: error must explain user-only support, got: %v", name, err)
+		}
+	}
+}
+
+func TestInstallProjectSkipsLegacyCleanup(t *testing.T) {
+	opts, home := testOptions(t)
+	legacy := filepath.Join(home, ".claude", "commands", "walden.md")
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(legacy, []byte("old command"), 0o644); err != nil {
+		t.Fatalf("seed legacy command: %v", err)
+	}
+
+	report, err := Install(mustLookup(t, "claude"), ScopeProject, opts)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if report.LegacyRemoved {
+		t.Fatal("project-scope installs must not touch user-scope legacy files")
+	}
+	if _, err := os.Stat(legacy); err != nil {
+		t.Fatal("legacy user file must remain untouched by project installs")
+	}
+}
+
+func TestInstallAllCoversEveryAgentInOrder(t *testing.T) {
+	opts, home := testOptions(t)
+	reports, err := InstallAll(opts)
+	if err != nil {
+		t.Fatalf("InstallAll: %v", err)
+	}
+	wantOrder := []string{"claude", "codex", "copilot", "opencode"}
+	if len(reports) != len(wantOrder) {
+		t.Fatalf("expected %d reports, got %d", len(wantOrder), len(reports))
+	}
+	for i, name := range wantOrder {
+		if reports[i].Agent != name {
+			t.Fatalf("report %d: expected agent %s, got %s", i, name, reports[i].Agent)
+		}
+		if reports[i].Scope != ScopeUser {
+			t.Fatalf("report %d: expected user scope, got %s", i, reports[i].Scope)
+		}
+	}
+	for _, suffix := range []string{
+		".claude/skills/walden/SKILL.md",
+		".codex/AGENTS.md",
+		".copilot/skills/walden/SKILL.md",
+		".config/opencode/skills/walden/SKILL.md",
+	} {
+		if _, err := os.Stat(filepath.Join(home, suffix)); err != nil {
+			t.Fatalf("expected %s to be installed: %v", suffix, err)
+		}
+	}
+}
+
+func TestInstallAllStopsOnFirstFailure(t *testing.T) {
+	opts, home := testOptions(t)
+	// Make the codex target unwritable by occupying CODEX_HOME with a file.
+	blocker := filepath.Join(home, "codex-blocker")
+	if err := os.WriteFile(blocker, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("seed blocker: %v", err)
+	}
+	opts.Env.CodexHome = filepath.Join(blocker, "nested")
+
+	reports, err := InstallAll(opts)
+	if err == nil {
+		t.Fatal("expected InstallAll to fail on the codex step")
+	}
+	if !strings.Contains(err.Error(), "install codex") {
+		t.Fatalf("error must name the failing agent, got: %v", err)
+	}
+	if len(reports) != 1 || reports[0].Agent != "claude" {
+		t.Fatalf("expected exactly the claude report before the failure, got %+v", reports)
+	}
+	for _, suffix := range []string{".copilot/skills/walden/SKILL.md", ".config/opencode/skills/walden/SKILL.md"} {
+		if _, err := os.Stat(filepath.Join(home, suffix)); !os.IsNotExist(err) {
+			t.Fatalf("agents after the failure must not be installed: %s", suffix)
+		}
+	}
+}

--- a/internal/skilldist/paths.go
+++ b/internal/skilldist/paths.go
@@ -1,0 +1,36 @@
+package skilldist
+
+import (
+	"errors"
+	"os"
+)
+
+// Env carries the environment values that influence user-scope target paths.
+// Resolution is pure given an Env value, so tests never touch the process
+// environment.
+type Env struct {
+	Home          string
+	CodexHome     string
+	CopilotHome   string
+	OpencodeHome  string
+	XDGConfigHome string
+}
+
+// EnvFromOS captures the process environment for target resolution.
+func EnvFromOS() Env {
+	home, _ := os.UserHomeDir()
+	return Env{
+		Home:          home,
+		CodexHome:     os.Getenv("CODEX_HOME"),
+		CopilotHome:   os.Getenv("COPILOT_HOME"),
+		OpencodeHome:  os.Getenv("OPENCODE_HOME"),
+		XDGConfigHome: os.Getenv("XDG_CONFIG_HOME"),
+	}
+}
+
+func (e Env) home() (string, error) {
+	if e.Home == "" {
+		return "", errors.New("home directory is not resolvable")
+	}
+	return e.Home, nil
+}

--- a/internal/skilldist/paths_test.go
+++ b/internal/skilldist/paths_test.go
@@ -1,0 +1,132 @@
+package skilldist
+
+import (
+	"testing"
+)
+
+func TestPathsUserTargets(t *testing.T) {
+	cases := []struct {
+		name  string
+		agent string
+		env   Env
+		want  string
+	}{
+		{
+			name:  "claude under home",
+			agent: "claude",
+			env:   Env{Home: "/home/u"},
+			want:  "/home/u/.claude/skills/walden/SKILL.md",
+		},
+		{
+			name:  "codex default home",
+			agent: "codex",
+			env:   Env{Home: "/home/u"},
+			want:  "/home/u/.codex/AGENTS.md",
+		},
+		{
+			name:  "codex honors CODEX_HOME",
+			agent: "codex",
+			env:   Env{Home: "/home/u", CodexHome: "/custom/codex"},
+			want:  "/custom/codex/AGENTS.md",
+		},
+		{
+			name:  "copilot default home",
+			agent: "copilot",
+			env:   Env{Home: "/home/u"},
+			want:  "/home/u/.copilot/skills/walden/SKILL.md",
+		},
+		{
+			name:  "copilot honors COPILOT_HOME",
+			agent: "copilot",
+			env:   Env{Home: "/home/u", CopilotHome: "/custom/copilot"},
+			want:  "/custom/copilot/skills/walden/SKILL.md",
+		},
+		{
+			name:  "opencode default home",
+			agent: "opencode",
+			env:   Env{Home: "/home/u"},
+			want:  "/home/u/.config/opencode/skills/walden/SKILL.md",
+		},
+		{
+			name:  "opencode honors XDG_CONFIG_HOME",
+			agent: "opencode",
+			env:   Env{Home: "/home/u", XDGConfigHome: "/xdg"},
+			want:  "/xdg/opencode/skills/walden/SKILL.md",
+		},
+		{
+			name:  "opencode honors OPENCODE_HOME over XDG",
+			agent: "opencode",
+			env:   Env{Home: "/home/u", XDGConfigHome: "/xdg", OpencodeHome: "/custom/opencode"},
+			want:  "/custom/opencode/skills/walden/SKILL.md",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agent, err := Lookup(tc.agent)
+			if err != nil {
+				t.Fatalf("Lookup(%s): %v", tc.agent, err)
+			}
+			got, err := agent.UserTarget(tc.env)
+			if err != nil {
+				t.Fatalf("UserTarget: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %s, got %s", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestPathsUserTargetsRequireHome(t *testing.T) {
+	for _, name := range AgentNames() {
+		agent, err := Lookup(name)
+		if err != nil {
+			t.Fatalf("Lookup(%s): %v", name, err)
+		}
+		if _, err := agent.UserTarget(Env{}); err == nil {
+			t.Fatalf("%s: expected error for unresolvable home", name)
+		}
+	}
+}
+
+func TestPathsCustomHomesSkipHomeRequirement(t *testing.T) {
+	cases := []struct {
+		agent string
+		env   Env
+	}{
+		{"codex", Env{CodexHome: "/custom/codex"}},
+		{"copilot", Env{CopilotHome: "/custom/copilot"}},
+		{"opencode", Env{OpencodeHome: "/custom/opencode"}},
+		{"opencode", Env{XDGConfigHome: "/xdg"}},
+	}
+	for _, tc := range cases {
+		agent, err := Lookup(tc.agent)
+		if err != nil {
+			t.Fatalf("Lookup(%s): %v", tc.agent, err)
+		}
+		if _, err := agent.UserTarget(tc.env); err != nil {
+			t.Fatalf("%s: expected resolution without home, got %v", tc.agent, err)
+		}
+	}
+}
+
+func TestPathsLegacyUserFiles(t *testing.T) {
+	claude, err := Lookup("claude")
+	if err != nil {
+		t.Fatalf("Lookup(claude): %v", err)
+	}
+	legacy := claude.LegacyUserFiles(Env{Home: "/home/u"})
+	if len(legacy) != 1 || legacy[0] != "/home/u/.claude/commands/walden.md" {
+		t.Fatalf("unexpected legacy files: %v", legacy)
+	}
+	for _, name := range []string{"codex", "copilot", "opencode"} {
+		agent, err := Lookup(name)
+		if err != nil {
+			t.Fatalf("Lookup(%s): %v", name, err)
+		}
+		if agent.LegacyUserFiles != nil {
+			t.Fatalf("%s: expected no legacy files", name)
+		}
+	}
+}

--- a/internal/skilldist/registry.go
+++ b/internal/skilldist/registry.go
@@ -1,0 +1,149 @@
+// Package skilldist places, removes, and inspects the embedded Walden skill
+// across supported coding agents. All operations are offline and
+// deterministic: targets come from a static registry resolved against an
+// explicit environment snapshot.
+package skilldist
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// Scope selects where a skill installation lives.
+type Scope string
+
+const (
+	// ScopeUser installs under the user's home configuration.
+	ScopeUser Scope = "user"
+	// ScopeProject installs under the current working directory.
+	ScopeProject Scope = "project"
+)
+
+// WriteKind selects the placement strategy for an agent.
+type WriteKind string
+
+const (
+	// KindFile writes SKILL.md as a standalone file.
+	KindFile WriteKind = "file"
+	// KindBlock maintains a marker-delimited block inside a shared file.
+	KindBlock WriteKind = "block"
+)
+
+// ErrUnknownAgent reports an agent name outside the registry.
+var ErrUnknownAgent = errors.New("unknown agent")
+
+// Agent describes one supported coding agent.
+type Agent struct {
+	Name string
+	Kind WriteKind
+	// UserTarget resolves the user-scope target path from the environment.
+	UserTarget func(Env) (string, error)
+	// ProjectTarget resolves the project-scope target path under workDir.
+	// The second return is false when the agent supports only user scope.
+	ProjectTarget func(workDir string) (string, bool)
+	// LegacyUserFiles lists obsolete artifacts removed on user-scope
+	// install and uninstall.
+	LegacyUserFiles func(Env) []string
+}
+
+var agents = []Agent{
+	{
+		Name: "claude",
+		Kind: KindFile,
+		UserTarget: func(env Env) (string, error) {
+			home, err := env.home()
+			if err != nil {
+				return "", err
+			}
+			return filepath.Join(home, ".claude", "skills", "walden", "SKILL.md"), nil
+		},
+		ProjectTarget: func(workDir string) (string, bool) {
+			return filepath.Join(workDir, ".claude", "skills", "walden", "SKILL.md"), true
+		},
+		LegacyUserFiles: func(env Env) []string {
+			home, err := env.home()
+			if err != nil {
+				return nil
+			}
+			return []string{filepath.Join(home, ".claude", "commands", "walden.md")}
+		},
+	},
+	{
+		Name: "codex",
+		Kind: KindBlock,
+		UserTarget: func(env Env) (string, error) {
+			if env.CodexHome != "" {
+				return filepath.Join(env.CodexHome, "AGENTS.md"), nil
+			}
+			home, err := env.home()
+			if err != nil {
+				return "", err
+			}
+			return filepath.Join(home, ".codex", "AGENTS.md"), nil
+		},
+		ProjectTarget: func(workDir string) (string, bool) {
+			return filepath.Join(workDir, "AGENTS.md"), true
+		},
+	},
+	{
+		Name: "copilot",
+		Kind: KindFile,
+		UserTarget: func(env Env) (string, error) {
+			if env.CopilotHome != "" {
+				return filepath.Join(env.CopilotHome, "skills", "walden", "SKILL.md"), nil
+			}
+			home, err := env.home()
+			if err != nil {
+				return "", err
+			}
+			return filepath.Join(home, ".copilot", "skills", "walden", "SKILL.md"), nil
+		},
+		ProjectTarget: func(string) (string, bool) { return "", false },
+	},
+	{
+		Name: "opencode",
+		Kind: KindFile,
+		UserTarget: func(env Env) (string, error) {
+			base := env.OpencodeHome
+			if base == "" {
+				if env.XDGConfigHome != "" {
+					base = filepath.Join(env.XDGConfigHome, "opencode")
+				} else {
+					home, err := env.home()
+					if err != nil {
+						return "", err
+					}
+					base = filepath.Join(home, ".config", "opencode")
+				}
+			}
+			return filepath.Join(base, "skills", "walden", "SKILL.md"), nil
+		},
+		ProjectTarget: func(string) (string, bool) { return "", false },
+	},
+}
+
+// Agents returns the supported agents in deterministic registry order.
+func Agents() []Agent {
+	return append([]Agent(nil), agents...)
+}
+
+// AgentNames returns the supported agent names in registry order.
+func AgentNames() []string {
+	names := make([]string, 0, len(agents))
+	for _, agent := range agents {
+		names = append(names, agent.Name)
+	}
+	return names
+}
+
+// Lookup returns the agent registered under name.
+func Lookup(name string) (Agent, error) {
+	for _, agent := range agents {
+		if agent.Name == name {
+			return agent, nil
+		}
+	}
+	return Agent{}, fmt.Errorf("%w: %q (supported: %s)", ErrUnknownAgent, name, strings.Join(AgentNames(), ", "))
+}

--- a/internal/skilldist/registry_test.go
+++ b/internal/skilldist/registry_test.go
@@ -1,0 +1,74 @@
+package skilldist
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRegistryOrderAndNames(t *testing.T) {
+	want := []string{"claude", "codex", "copilot", "opencode"}
+	got := AgentNames()
+	if len(got) != len(want) {
+		t.Fatalf("expected %d agents, got %d", len(want), len(got))
+	}
+	for i, name := range want {
+		if got[i] != name {
+			t.Fatalf("agent %d: expected %s, got %s", i, name, got[i])
+		}
+	}
+}
+
+func TestRegistryLookupKnownAgents(t *testing.T) {
+	kinds := map[string]WriteKind{
+		"claude":   KindFile,
+		"codex":    KindBlock,
+		"copilot":  KindFile,
+		"opencode": KindFile,
+	}
+	for name, kind := range kinds {
+		agent, err := Lookup(name)
+		if err != nil {
+			t.Fatalf("Lookup(%s): %v", name, err)
+		}
+		if agent.Kind != kind {
+			t.Fatalf("Lookup(%s): expected kind %s, got %s", name, kind, agent.Kind)
+		}
+	}
+}
+
+func TestRegistryLookupUnknownAgent(t *testing.T) {
+	_, err := Lookup("cursor")
+	if !errors.Is(err, ErrUnknownAgent) {
+		t.Fatalf("expected ErrUnknownAgent, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "claude, codex, copilot, opencode") {
+		t.Fatalf("error must list supported agents, got: %v", err)
+	}
+}
+
+func TestRegistryProjectScopeSupport(t *testing.T) {
+	cases := []struct {
+		agent     string
+		supported bool
+		target    string
+	}{
+		{"claude", true, "/work/.claude/skills/walden/SKILL.md"},
+		{"codex", true, "/work/AGENTS.md"},
+		{"copilot", false, ""},
+		{"opencode", false, ""},
+	}
+	for _, tc := range cases {
+		agent, err := Lookup(tc.agent)
+		if err != nil {
+			t.Fatalf("Lookup(%s): %v", tc.agent, err)
+		}
+		target, ok := agent.ProjectTarget("/work")
+		if ok != tc.supported {
+			t.Fatalf("%s: expected project support %t, got %t", tc.agent, tc.supported, ok)
+		}
+		if ok && target != tc.target {
+			t.Fatalf("%s: expected project target %s, got %s", tc.agent, tc.target, target)
+		}
+	}
+}

--- a/internal/skilldist/stamp.go
+++ b/internal/skilldist/stamp.go
@@ -1,0 +1,38 @@
+package skilldist
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// The version marker records which binary version installed the skill. It is
+// an HTML comment appended as the final line, so agents ignore it and the
+// YAML frontmatter stays byte-identical to the embedded skill.
+const (
+	stampPrefix = "<!-- walden-skill-version: "
+	stampSuffix = " -->"
+)
+
+// Stamp appends a version marker recording the installing binary's version.
+// The original content is only ever extended, never modified.
+func Stamp(content []byte, version string) []byte {
+	stamped := append([]byte(nil), content...)
+	if len(stamped) > 0 && !bytes.HasSuffix(stamped, []byte("\n")) {
+		stamped = append(stamped, '\n')
+	}
+	return append(stamped, fmt.Sprintf("%s%s%s\n", stampPrefix, version, stampSuffix)...)
+}
+
+// Strip removes a trailing version marker, returning the body and the
+// recorded version. Content without a marker (legacy installs) is returned
+// unchanged with an empty version.
+func Strip(content []byte) ([]byte, string) {
+	trimmed := bytes.TrimSuffix(content, []byte("\n"))
+	idx := bytes.LastIndexByte(trimmed, '\n')
+	line := trimmed[idx+1:]
+	if !bytes.HasPrefix(line, []byte(stampPrefix)) || !bytes.HasSuffix(line, []byte(stampSuffix)) {
+		return content, ""
+	}
+	version := string(line[len(stampPrefix) : len(line)-len(stampSuffix)])
+	return content[:idx+1], version
+}

--- a/internal/skilldist/stamp_test.go
+++ b/internal/skilldist/stamp_test.go
@@ -1,0 +1,60 @@
+package skilldist
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestStampStripRoundTrip(t *testing.T) {
+	original := []byte("---\nname: walden\n---\n\n# Walden\n\nBody text.\n")
+	stamped := Stamp(original, "v1.2.3")
+
+	body, version := Strip(stamped)
+	if version != "v1.2.3" {
+		t.Fatalf("expected version v1.2.3, got %q", version)
+	}
+	if !bytes.Equal(body, original) {
+		t.Fatalf("round trip must restore the original content\noriginal: %q\nbody:     %q", original, body)
+	}
+}
+
+func TestStampOnlyAppends(t *testing.T) {
+	original := []byte("---\nname: walden\ndescription: test\n---\nbody\n")
+	stamped := Stamp(original, "v0.5.0")
+	if !bytes.HasPrefix(stamped, original) {
+		t.Fatal("stamping must only append: the original content, frontmatter included, must be an untouched prefix")
+	}
+}
+
+func TestStampContentWithoutTrailingNewline(t *testing.T) {
+	stamped := Stamp([]byte("no newline"), "v1")
+	body, version := Strip(stamped)
+	if version != "v1" {
+		t.Fatalf("expected version v1, got %q", version)
+	}
+	if !bytes.Equal(body, []byte("no newline\n")) {
+		t.Fatalf("unexpected body: %q", body)
+	}
+}
+
+func TestStripLegacyContentWithoutMarker(t *testing.T) {
+	legacy := []byte("---\nname: walden\n---\nbody\n")
+	body, version := Strip(legacy)
+	if version != "" {
+		t.Fatalf("legacy content must report an empty version, got %q", version)
+	}
+	if !bytes.Equal(body, legacy) {
+		t.Fatal("legacy content must be returned unchanged")
+	}
+}
+
+func TestStripMarkerOnlyContent(t *testing.T) {
+	stamped := Stamp(nil, "v2")
+	body, version := Strip(stamped)
+	if version != "v2" {
+		t.Fatalf("expected version v2, got %q", version)
+	}
+	if len(body) != 0 {
+		t.Fatalf("expected empty body, got %q", body)
+	}
+}

--- a/internal/skilldist/status.go
+++ b/internal/skilldist/status.go
@@ -1,0 +1,123 @@
+package skilldist
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/andrearaponi/walden/skill"
+)
+
+// Installation states reported by Status.
+const (
+	StateNotInstalled = "not-installed"
+	StateInSync       = "in-sync"
+	StateDrifted      = "drifted"
+)
+
+// SkillStatus describes one agent×scope installation slot.
+type SkillStatus struct {
+	Agent     string
+	Scope     Scope
+	Path      string
+	Installed bool
+	State     string
+	Version   string
+}
+
+// Status scans every agent and scope combination and classifies each
+// installation against the embedded skill. The second return carries
+// warnings (dual-scope divergence, unresolvable targets). Status never
+// mutates anything: it is a report, not a gate.
+func Status(opts Options) ([]SkillStatus, []string) {
+	embedded := normalizeBody(skill.Content())
+	statuses := make([]SkillStatus, 0, len(agents)*2)
+	warnings := []string{}
+
+	for _, agent := range agents {
+		bodies := map[Scope][]byte{}
+
+		for _, scope := range []Scope{ScopeUser, ScopeProject} {
+			status, body, warning := statusFor(agent, scope, opts, embedded)
+			if warning != "" {
+				warnings = append(warnings, warning)
+			}
+			if status == nil {
+				continue
+			}
+			statuses = append(statuses, *status)
+			if status.Installed {
+				bodies[scope] = body
+			}
+		}
+
+		userBody, hasUser := bodies[ScopeUser]
+		projectBody, hasProject := bodies[ScopeProject]
+		if hasUser && hasProject && !bytes.Equal(userBody, projectBody) {
+			warnings = append(warnings, fmt.Sprintf("agent %s: user-scope and project-scope installations differ; the agent will load only one of them", agent.Name))
+		}
+	}
+
+	return statuses, warnings
+}
+
+// statusFor classifies one agent×scope slot. It returns a nil status when
+// the scope is unsupported for the agent.
+func statusFor(agent Agent, scope Scope, opts Options, embedded []byte) (*SkillStatus, []byte, string) {
+	target, err := resolveTarget(agent, scope, opts)
+	if err != nil {
+		if scope == ScopeProject {
+			return nil, nil, ""
+		}
+		return nil, nil, fmt.Sprintf("agent %s: %v", agent.Name, err)
+	}
+
+	status := SkillStatus{Agent: agent.Name, Scope: scope, Path: target, State: StateNotInstalled}
+
+	raw, found, err := readInstalled(agent, target)
+	if err != nil {
+		// A corrupt block is an installation we cannot equate with the
+		// embedded skill: report it as drifted rather than erroring.
+		status.Installed = true
+		status.State = StateDrifted
+		return &status, nil, fmt.Sprintf("agent %s: %v", agent.Name, err)
+	}
+	if !found {
+		return &status, nil, ""
+	}
+
+	body, version := Strip(raw)
+	normalized := normalizeBody(body)
+	status.Installed = true
+	status.Version = version
+	if bytes.Equal(normalized, embedded) {
+		status.State = StateInSync
+	} else {
+		status.State = StateDrifted
+	}
+	return &status, normalized, ""
+}
+
+// readInstalled returns the comparable installed content for the slot: the
+// whole file for file-kind agents, the block interior for block-kind ones.
+func readInstalled(agent Agent, target string) (raw []byte, found bool, err error) {
+	data, err := os.ReadFile(target)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	if agent.Kind == KindBlock {
+		return blockInterior(data, target)
+	}
+	return data, true, nil
+}
+
+// normalizeBody strips trailing newlines so cosmetic differences (such as
+// the extra newline legacy setup.sh blocks carry) do not read as drift.
+func normalizeBody(body []byte) []byte {
+	return bytes.TrimRight(body, "\n")
+}

--- a/internal/skilldist/status_test.go
+++ b/internal/skilldist/status_test.go
@@ -1,0 +1,174 @@
+package skilldist
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/skill"
+)
+
+func statusByAgentScope(statuses []SkillStatus, agent string, scope Scope) *SkillStatus {
+	for i := range statuses {
+		if statuses[i].Agent == agent && statuses[i].Scope == scope {
+			return &statuses[i]
+		}
+	}
+	return nil
+}
+
+func TestStatusCoversEveryAgentAndSupportedScope(t *testing.T) {
+	opts, _ := testOptions(t)
+	statuses, _ := Status(opts)
+
+	// claude and codex expose both scopes; copilot and opencode user only.
+	if len(statuses) != 6 {
+		t.Fatalf("expected 6 slots (2+2+1+1), got %d", len(statuses))
+	}
+	for _, name := range AgentNames() {
+		if statusByAgentScope(statuses, name, ScopeUser) == nil {
+			t.Fatalf("missing user-scope slot for %s", name)
+		}
+	}
+	for _, name := range []string{"claude", "codex"} {
+		if statusByAgentScope(statuses, name, ScopeProject) == nil {
+			t.Fatalf("missing project-scope slot for %s", name)
+		}
+	}
+}
+
+func TestStatusFreshEnvironmentReportsNotInstalled(t *testing.T) {
+	opts, _ := testOptions(t)
+	statuses, warnings := Status(opts)
+	for _, status := range statuses {
+		if status.Installed || status.State != StateNotInstalled {
+			t.Fatalf("%s/%s: expected not-installed, got %+v", status.Agent, status.Scope, status)
+		}
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", warnings)
+	}
+}
+
+func TestStatusInSyncAfterInstallWithVersion(t *testing.T) {
+	opts, _ := testOptions(t)
+	if _, err := InstallAll(opts); err != nil {
+		t.Fatalf("InstallAll: %v", err)
+	}
+
+	statuses, warnings := Status(opts)
+	for _, name := range AgentNames() {
+		status := statusByAgentScope(statuses, name, ScopeUser)
+		if status == nil || !status.Installed {
+			t.Fatalf("%s: expected installed user-scope slot", name)
+		}
+		if status.State != StateInSync {
+			t.Fatalf("%s: expected in-sync, got %s", name, status.State)
+		}
+		if status.Version != "v9.9.9" {
+			t.Fatalf("%s: expected version v9.9.9, got %q", name, status.Version)
+		}
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", warnings)
+	}
+}
+
+func TestStatusDriftedAfterLocalEdit(t *testing.T) {
+	opts, home := testOptions(t)
+	agent := mustLookup(t, "claude")
+	if _, err := Install(agent, ScopeUser, opts); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	target := filepath.Join(home, ".claude", "skills", "walden", "SKILL.md")
+	edited := append(Stamp(skill.Content(), "v9.9.9"), []byte("\nlocal customization\n")...)
+	if err := os.WriteFile(target, edited, 0o644); err != nil {
+		t.Fatalf("edit installed skill: %v", err)
+	}
+
+	statuses, _ := Status(opts)
+	status := statusByAgentScope(statuses, "claude", ScopeUser)
+	if status == nil || status.State != StateDrifted {
+		t.Fatalf("expected drifted claude user slot, got %+v", status)
+	}
+}
+
+func TestStatusLegacyInstallWithoutMarker(t *testing.T) {
+	opts, home := testOptions(t)
+	target := filepath.Join(home, ".claude", "skills", "walden", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A legacy setup.sh install: the raw skill, no version marker.
+	if err := os.WriteFile(target, skill.Content(), 0o644); err != nil {
+		t.Fatalf("seed legacy install: %v", err)
+	}
+
+	statuses, _ := Status(opts)
+	status := statusByAgentScope(statuses, "claude", ScopeUser)
+	if status == nil || !status.Installed {
+		t.Fatal("expected an installed legacy slot")
+	}
+	if status.Version != "" {
+		t.Fatalf("legacy installs carry no version, got %q", status.Version)
+	}
+	if status.State != StateInSync {
+		t.Fatalf("an identical legacy install must read in-sync, got %s", status.State)
+	}
+}
+
+func TestStatusDualScopeDivergenceWarns(t *testing.T) {
+	opts, _ := testOptions(t)
+	agent := mustLookup(t, "claude")
+	if _, err := Install(agent, ScopeUser, opts); err != nil {
+		t.Fatalf("Install user: %v", err)
+	}
+	if _, err := Install(agent, ScopeProject, opts); err != nil {
+		t.Fatalf("Install project: %v", err)
+	}
+
+	// Identical installations: no divergence warning expected.
+	_, warnings := Status(opts)
+	if len(warnings) != 0 {
+		t.Fatalf("identical dual-scope installs must not warn, got %v", warnings)
+	}
+
+	projectTarget := filepath.Join(opts.WorkDir, ".claude", "skills", "walden", "SKILL.md")
+	edited := append(Stamp(skill.Content(), "v9.9.9"), []byte("\nproject tweak\n")...)
+	if err := os.WriteFile(projectTarget, edited, 0o644); err != nil {
+		t.Fatalf("edit project skill: %v", err)
+	}
+
+	_, warnings = Status(opts)
+	foundDivergence := false
+	for _, warning := range warnings {
+		if strings.Contains(warning, "claude") && strings.Contains(warning, "differ") {
+			foundDivergence = true
+		}
+	}
+	if !foundDivergence {
+		t.Fatalf("expected a divergence warning naming claude, got %v", warnings)
+	}
+}
+
+func TestStatusCorruptBlockReportsDriftedWithWarning(t *testing.T) {
+	opts, home := testOptions(t)
+	target := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("notes\n"+blockBegin+"\nno end\n"), 0o644); err != nil {
+		t.Fatalf("seed corrupt AGENTS.md: %v", err)
+	}
+
+	statuses, warnings := Status(opts)
+	status := statusByAgentScope(statuses, "codex", ScopeUser)
+	if status == nil || status.State != StateDrifted {
+		t.Fatalf("expected drifted codex slot for a corrupt block, got %+v", status)
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected a warning describing the corrupt block")
+	}
+}

--- a/internal/skilldist/uninstall.go
+++ b/internal/skilldist/uninstall.go
@@ -1,0 +1,109 @@
+package skilldist
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Uninstall removes the skill for agent at scope. A missing installation is
+// a no-op reported via Report.NotInstalled, never an error.
+func Uninstall(agent Agent, scope Scope, opts Options) (Report, error) {
+	target, err := resolveTarget(agent, scope, opts)
+	if err != nil {
+		return Report{}, err
+	}
+
+	report := Report{Agent: agent.Name, Scope: scope, Path: target}
+
+	switch agent.Kind {
+	case KindFile:
+		removed, err := removeSkillFile(target)
+		if err != nil {
+			return Report{}, err
+		}
+		report.NotInstalled = !removed
+	case KindBlock:
+		removed, err := removeBlock(target)
+		if err != nil {
+			return Report{}, err
+		}
+		report.NotInstalled = !removed
+	default:
+		return Report{}, fmt.Errorf("agent %s: unsupported write kind %q", agent.Name, agent.Kind)
+	}
+
+	report.LegacyRemoved = cleanupLegacy(agent, scope, opts)
+	return report, nil
+}
+
+// UninstallAll removes the user-scope skill for every supported agent in
+// registry order, stopping on the first failure.
+func UninstallAll(opts Options) ([]Report, error) {
+	reports := make([]Report, 0, len(agents))
+	for _, agent := range agents {
+		report, err := Uninstall(agent, ScopeUser, opts)
+		if err != nil {
+			return reports, fmt.Errorf("uninstall %s: %w", agent.Name, err)
+		}
+		reports = append(reports, report)
+	}
+	return reports, nil
+}
+
+// removeSkillFile removes the dedicated skill directory (skills/walden/)
+// that holds SKILL.md.
+func removeSkillFile(target string) (removed bool, err error) {
+	dir := filepath.Dir(target)
+	if _, err := os.Stat(dir); errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("inspect %s: %w", dir, err)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return false, fmt.Errorf("remove %s: %w", dir, err)
+	}
+	return true, nil
+}
+
+// removeBlock extracts the Walden marker block from target, preserving all
+// unrelated content. A file left empty by the extraction is deleted.
+func removeBlock(target string) (removed bool, err error) {
+	existing, err := os.ReadFile(target)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", target, err)
+	}
+
+	begin, end, err := blockBounds(existing, target)
+	if err != nil {
+		return false, err
+	}
+	if begin == -1 {
+		return false, nil
+	}
+
+	// Also drop the blank separator line inserted ahead of the block.
+	start := begin
+	if start >= 2 && existing[start-1] == '\n' && existing[start-2] == '\n' {
+		start--
+	}
+
+	out := append([]byte(nil), existing[:start]...)
+	out = append(out, existing[end:]...)
+
+	if len(bytes.TrimSpace(out)) == 0 {
+		if err := os.Remove(target); err != nil {
+			return false, fmt.Errorf("remove %s: %w", target, err)
+		}
+		return true, nil
+	}
+	if _, err := writeFileAtomic(target, out); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/skilldist/uninstall_test.go
+++ b/internal/skilldist/uninstall_test.go
@@ -1,0 +1,185 @@
+package skilldist
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUninstallRemovesFileKindInstallations(t *testing.T) {
+	for _, name := range []string{"claude", "copilot", "opencode"} {
+		t.Run(name, func(t *testing.T) {
+			opts, _ := testOptions(t)
+			agent := mustLookup(t, name)
+			installReport, err := Install(agent, ScopeUser, opts)
+			if err != nil {
+				t.Fatalf("Install: %v", err)
+			}
+
+			report, err := Uninstall(agent, ScopeUser, opts)
+			if err != nil {
+				t.Fatalf("Uninstall: %v", err)
+			}
+			if report.NotInstalled {
+				t.Fatal("expected an installed skill to be removed")
+			}
+			if _, err := os.Stat(filepath.Dir(installReport.Path)); !os.IsNotExist(err) {
+				t.Fatal("the skills/walden directory must be removed")
+			}
+		})
+	}
+}
+
+func TestUninstallBlockPreservesUnrelatedContent(t *testing.T) {
+	opts, home := testOptions(t)
+	target := filepath.Join(home, ".codex", "AGENTS.md")
+	prior := "# My agents\n\npersonal notes\n"
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(prior), 0o644); err != nil {
+		t.Fatalf("seed AGENTS.md: %v", err)
+	}
+
+	agent := mustLookup(t, "codex")
+	if _, err := Install(agent, ScopeUser, opts); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	report, err := Uninstall(agent, ScopeUser, opts)
+	if err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	if report.NotInstalled {
+		t.Fatal("expected the block to be removed")
+	}
+
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	if !bytes.Equal(data, []byte(prior)) {
+		t.Fatalf("install+uninstall must restore the original file\nwant: %q\ngot:  %q", prior, data)
+	}
+}
+
+func TestUninstallBlockRemovesEmptiedFile(t *testing.T) {
+	opts, home := testOptions(t)
+	agent := mustLookup(t, "codex")
+	if _, err := Install(agent, ScopeUser, opts); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if _, err := Uninstall(agent, ScopeUser, opts); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatal("an AGENTS.md holding only the walden block must be removed entirely")
+	}
+}
+
+func TestUninstallBlockCorruptMarkersAbort(t *testing.T) {
+	opts, home := testOptions(t)
+	target := filepath.Join(home, ".codex", "AGENTS.md")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	corrupt := "notes\n" + blockBegin + "\nno end marker\n"
+	if err := os.WriteFile(target, []byte(corrupt), 0o644); err != nil {
+		t.Fatalf("seed AGENTS.md: %v", err)
+	}
+
+	_, err := Uninstall(mustLookup(t, "codex"), ScopeUser, opts)
+	if !errors.Is(err, ErrCorruptBlock) {
+		t.Fatalf("expected ErrCorruptBlock, got %v", err)
+	}
+	data, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Fatalf("read AGENTS.md: %v", readErr)
+	}
+	if !bytes.Equal(data, []byte(corrupt)) {
+		t.Fatal("a corrupt block must abort the operation without modifying the file")
+	}
+}
+
+func TestUninstallProjectScope(t *testing.T) {
+	opts, _ := testOptions(t)
+	agent := mustLookup(t, "claude")
+	if _, err := Install(agent, ScopeProject, opts); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	report, err := Uninstall(agent, ScopeProject, opts)
+	if err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	if report.NotInstalled {
+		t.Fatal("expected the project installation to be removed")
+	}
+	if _, err := os.Stat(filepath.Join(opts.WorkDir, ".claude", "skills", "walden")); !os.IsNotExist(err) {
+		t.Fatal("project skill directory must be removed")
+	}
+}
+
+func TestUninstallMissingInstallationIsNoOp(t *testing.T) {
+	for _, name := range AgentNames() {
+		t.Run(name, func(t *testing.T) {
+			opts, _ := testOptions(t)
+			report, err := Uninstall(mustLookup(t, name), ScopeUser, opts)
+			if err != nil {
+				t.Fatalf("Uninstall of absent skill must not error: %v", err)
+			}
+			if !report.NotInstalled {
+				t.Fatal("expected NotInstalled to be reported")
+			}
+		})
+	}
+}
+
+func TestUninstallRemovesLegacyCommand(t *testing.T) {
+	opts, home := testOptions(t)
+	legacy := filepath.Join(home, ".claude", "commands", "walden.md")
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(legacy, []byte("old command"), 0o644); err != nil {
+		t.Fatalf("seed legacy command: %v", err)
+	}
+
+	report, err := Uninstall(mustLookup(t, "claude"), ScopeUser, opts)
+	if err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	if !report.LegacyRemoved {
+		t.Fatal("expected legacy removal to be reported")
+	}
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Fatal("legacy command file must be removed")
+	}
+}
+
+func TestUninstallAllCoversEveryAgent(t *testing.T) {
+	opts, home := testOptions(t)
+	if _, err := InstallAll(opts); err != nil {
+		t.Fatalf("InstallAll: %v", err)
+	}
+
+	reports, err := UninstallAll(opts)
+	if err != nil {
+		t.Fatalf("UninstallAll: %v", err)
+	}
+	if len(reports) != len(AgentNames()) {
+		t.Fatalf("expected %d reports, got %d", len(AgentNames()), len(reports))
+	}
+	for _, suffix := range []string{
+		".claude/skills/walden",
+		".codex/AGENTS.md",
+		".copilot/skills/walden",
+		".config/opencode/skills/walden",
+	} {
+		if _, err := os.Stat(filepath.Join(home, suffix)); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be removed", suffix)
+		}
+	}
+}

--- a/setup.sh
+++ b/setup.sh
@@ -6,17 +6,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INSTALL_DIR="$HOME/.local/bin"
 BINARY_NAME="walden"
-SKILL_SOURCE="$SCRIPT_DIR/skill/walden/SKILL.md"
-CLAUDE_TARGET="$HOME/.claude/skills/walden/SKILL.md"
-CLAUDE_COMMAND_LEGACY="$HOME/.claude/commands/walden.md"
-CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
-CODEX_TARGET="$CODEX_HOME/AGENTS.md"
-CODEX_BEGIN="# --- BEGIN WALDEN SKILL ---"
-CODEX_END="# --- END WALDEN SKILL ---"
-COPILOT_HOME="${COPILOT_HOME:-$HOME/.copilot}"
-COPILOT_TARGET="$COPILOT_HOME/skills/walden/SKILL.md"
-OPENCODE_HOME="${OPENCODE_HOME:-${XDG_CONFIG_HOME:-$HOME/.config}/opencode}"
-OPENCODE_TARGET="$OPENCODE_HOME/skills/walden/SKILL.md"
+WALDEN="${INSTALL_DIR}/${BINARY_NAME}"
 
 # --- Colors (degrade gracefully) ---
 
@@ -74,8 +64,8 @@ check_prerequisites() {
     exit 1
   fi
 
-  if [ ! -f "$SKILL_SOURCE" ]; then
-    err "SKILL.md not found at $SKILL_SOURCE"
+  if [ ! -f "$SCRIPT_DIR/go.mod" ]; then
+    err "go.mod not found at $SCRIPT_DIR"
     err "Run this script from the walden repository root."
     exit 1
   fi
@@ -97,8 +87,8 @@ build_binary() {
 
 install_binary() {
   mkdir -p "$INSTALL_DIR"
-  cp "${SCRIPT_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/${BINARY_NAME}"
-  chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
+  cp "${SCRIPT_DIR}/${BINARY_NAME}" "$WALDEN"
+  chmod +x "$WALDEN"
   rm -f "${SCRIPT_DIR}/${BINARY_NAME}"
 
   case ":$PATH:" in
@@ -107,14 +97,14 @@ install_binary() {
        warn "  export PATH=\"${INSTALL_DIR}:\$PATH\"" ;;
   esac
 
-  ok "Binary installed to ${INSTALL_DIR}/${BINARY_NAME}"
+  ok "Binary installed to $WALDEN"
 }
 
 # --- Binary verify ---
 
 verify_binary() {
-  if "${INSTALL_DIR}/${BINARY_NAME}" version >/dev/null 2>&1; then
-    result="$("${INSTALL_DIR}/${BINARY_NAME}" version 2>&1 | head -1)"
+  if "$WALDEN" version >/dev/null 2>&1; then
+    result="$("$WALDEN" version 2>&1 | head -1)"
     ok "Verified: ${result}"
   else
     warn "Binary installed but 'walden version' did not succeed"
@@ -122,82 +112,12 @@ verify_binary() {
   fi
 }
 
-# --- Skill install: Claude ---
-
-install_skill_claude() {
-  mkdir -p "$(dirname "$CLAUDE_TARGET")"
-  cp "$SKILL_SOURCE" "$CLAUDE_TARGET"
-  ok "Skill installed for Claude Code at ${CLAUDE_TARGET}"
-  if [ -f "$CLAUDE_COMMAND_LEGACY" ]; then
-    rm -f "$CLAUDE_COMMAND_LEGACY"
-    info "Removed legacy /walden command at ${CLAUDE_COMMAND_LEGACY}"
-  fi
-}
-
-# --- Skill install: Codex ---
-
-install_skill_codex() {
-  if grep -q "$CODEX_BEGIN" "$CODEX_TARGET" 2>/dev/null; then
-    ok "Skill already installed for Codex (skipping)"
-    return 0
-  fi
-
-  mkdir -p "$(dirname "$CODEX_TARGET")"
-  {
-    printf '\n%s\n' "$CODEX_BEGIN"
-    cat "$SKILL_SOURCE"
-    printf '\n%s\n' "$CODEX_END"
-  } >> "$CODEX_TARGET"
-  ok "Skill installed for Codex at ${CODEX_TARGET}"
-}
-
-# --- Skill install: Copilot ---
-
-install_skill_copilot() {
-  mkdir -p "$(dirname "$COPILOT_TARGET")"
-  cp "$SKILL_SOURCE" "$COPILOT_TARGET"
-  ok "Skill installed for Copilot at ${COPILOT_TARGET}"
-}
-
-# --- Skill install: OpenCode ---
-
-install_skill_opencode() {
-  mkdir -p "$(dirname "$OPENCODE_TARGET")"
-  cp "$SKILL_SOURCE" "$OPENCODE_TARGET"
-  ok "Skill installed for OpenCode at ${OPENCODE_TARGET}"
-}
-
-# --- Skill verify ---
-
-verify_skill() {
-  verified=0
-  if [ -f "$CLAUDE_TARGET" ]; then
-    ok "Claude skill present at ${CLAUDE_TARGET}"
-    verified=1
-  fi
-  if grep -q "$CODEX_BEGIN" "$CODEX_TARGET" 2>/dev/null; then
-    ok "Codex skill present at ${CODEX_TARGET}"
-    verified=1
-  fi
-  if [ -f "$COPILOT_TARGET" ]; then
-    ok "Copilot skill present at ${COPILOT_TARGET}"
-    verified=1
-  fi
-  if [ -f "$OPENCODE_TARGET" ]; then
-    ok "OpenCode skill present at ${OPENCODE_TARGET}"
-    verified=1
-  fi
-  if [ "$verified" -eq 0 ]; then
-    info "No skill files installed (skipped)"
-  fi
-}
-
-# --- Skill prompt ---
+# --- Skill install (delegated to the binary) ---
 
 prompt_skill_install() {
   if ! [ -t 0 ]; then
     info "Non-interactive mode: skipping skill install"
-    info "Run './setup.sh install' interactively to install the skill"
+    info "Run '${WALDEN} skill install <agent>' to install the skill"
     return 0
   fi
 
@@ -213,82 +133,37 @@ prompt_skill_install() {
   read -r choice < /dev/tty
 
   case "$choice" in
-    1) install_skill_claude ;;
-    2) install_skill_codex ;;
-    3) install_skill_copilot ;;
-    4) install_skill_opencode ;;
-    5) install_skill_claude; install_skill_codex; install_skill_copilot; install_skill_opencode ;;
+    1) "$WALDEN" skill install claude ;;
+    2) "$WALDEN" skill install codex ;;
+    3) "$WALDEN" skill install copilot ;;
+    4) "$WALDEN" skill install opencode ;;
+    5) "$WALDEN" skill install --all ;;
     6) info "Skill install skipped" ;;
     *) warn "Invalid choice: ${choice}. Skipping skill install." ;;
   esac
 }
 
+verify_skill() {
+  "$WALDEN" skill status
+}
+
 # --- Uninstall ---
 
+uninstall_skill() {
+  if [ -x "$WALDEN" ]; then
+    "$WALDEN" skill uninstall --all
+  else
+    warn "walden binary not found at ${WALDEN}; skill files may remain"
+    warn "Reinstall and run '${BINARY_NAME} skill uninstall --all' to remove them"
+  fi
+}
+
 uninstall_binary() {
-  if [ -f "${INSTALL_DIR}/${BINARY_NAME}" ]; then
-    rm -f "${INSTALL_DIR}/${BINARY_NAME}"
-    ok "Removed ${INSTALL_DIR}/${BINARY_NAME}"
+  if [ -f "$WALDEN" ]; then
+    rm -f "$WALDEN"
+    ok "Removed $WALDEN"
   else
-    info "Binary not found at ${INSTALL_DIR}/${BINARY_NAME} (skipping)"
-  fi
-}
-
-uninstall_skill_claude() {
-  if [ -f "$CLAUDE_TARGET" ]; then
-    rm -rf "$(dirname "$CLAUDE_TARGET")"
-    ok "Removed ${CLAUDE_TARGET}"
-  else
-    info "Claude skill not found (skipping)"
-  fi
-  if [ -f "$CLAUDE_COMMAND_LEGACY" ]; then
-    rm -f "$CLAUDE_COMMAND_LEGACY"
-    ok "Removed legacy /walden command at ${CLAUDE_COMMAND_LEGACY}"
-  fi
-}
-
-uninstall_skill_codex() {
-  if [ ! -f "$CODEX_TARGET" ]; then
-    info "Codex AGENTS.md not found (skipping)"
-    return 0
-  fi
-
-  if ! grep -q "$CODEX_BEGIN" "$CODEX_TARGET" 2>/dev/null; then
-    info "No Walden block in Codex AGENTS.md (skipping)"
-    return 0
-  fi
-
-  tmp="$(mktemp)"
-  awk -v begin="$CODEX_BEGIN" -v end="$CODEX_END" '
-    $0 == begin { skip=1; next }
-    $0 == end   { skip=0; next }
-    !skip       { print }
-  ' "$CODEX_TARGET" > "$tmp"
-
-  if [ -s "$tmp" ]; then
-    mv "$tmp" "$CODEX_TARGET"
-  else
-    rm -f "$tmp" "$CODEX_TARGET"
-  fi
-
-  ok "Removed Walden block from ${CODEX_TARGET}"
-}
-
-uninstall_skill_copilot() {
-  if [ -f "$COPILOT_TARGET" ]; then
-    rm -rf "$(dirname "$COPILOT_TARGET")"
-    ok "Removed ${COPILOT_TARGET}"
-  else
-    info "Copilot skill not found (skipping)"
-  fi
-}
-
-uninstall_skill_opencode() {
-  if [ -f "$OPENCODE_TARGET" ]; then
-    rm -rf "$(dirname "$OPENCODE_TARGET")"
-    ok "Removed ${OPENCODE_TARGET}"
-  else
-    info "OpenCode skill not found (skipping)"
+    info "Binary not found at $WALDEN (skipping)"
   fi
 }
 
@@ -321,11 +196,8 @@ main() {
       ;;
     uninstall)
       printf "\n${BOLD}=== Walden Uninstall ===${NC}\n\n"
+      uninstall_skill
       uninstall_binary
-      uninstall_skill_claude
-      uninstall_skill_codex
-      uninstall_skill_copilot
-      uninstall_skill_opencode
       printf "\n${BOLD}=== Done ===${NC}\n"
       ;;
     --help|-h)

--- a/skill/embed.go
+++ b/skill/embed.go
@@ -1,0 +1,16 @@
+// Package skill exposes the canonical Walden AI skill bundled into the
+// binary, so every distribution channel that delivers the CLI also delivers
+// the skill at the matching version.
+package skill
+
+import (
+	_ "embed"
+)
+
+//go:embed walden/SKILL.md
+var content []byte
+
+// Content returns the embedded canonical SKILL.md bytes.
+func Content() []byte {
+	return append([]byte(nil), content...)
+}

--- a/skill/embed_test.go
+++ b/skill/embed_test.go
@@ -1,0 +1,28 @@
+package skill
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestContentMatchesCanonicalFile(t *testing.T) {
+	onDisk, err := os.ReadFile("walden/SKILL.md")
+	if err != nil {
+		t.Fatalf("read canonical skill: %v", err)
+	}
+	if len(onDisk) == 0 {
+		t.Fatal("canonical skill file is empty")
+	}
+	if !bytes.Equal(Content(), onDisk) {
+		t.Fatal("embedded content differs from skill/walden/SKILL.md")
+	}
+}
+
+func TestContentReturnsACopy(t *testing.T) {
+	first := Content()
+	first[0] = '!'
+	if bytes.Equal(first[:1], Content()[:1]) {
+		t.Fatal("mutating the returned slice must not affect the embedded content")
+	}
+}

--- a/skill/walden/install-claude.md
+++ b/skill/walden/install-claude.md
@@ -2,39 +2,46 @@
 
 ## Prerequisites
 
-1. Install the `walden` CLI and ensure it is available in `PATH`:
+Install the `walden` CLI and ensure it is available in `PATH`:
 
-   ```bash
-   go install github.com/andrearaponi/walden/cmd/walden@latest
-   ```
+```bash
+go install github.com/andrearaponi/walden/cmd/walden@latest
+```
 
-   Verify with:
+Verify with:
 
-   ```bash
-   walden version
-   ```
+```bash
+walden version
+```
 
-2. Claude Code or a Claude-compatible agent environment with Agent Skills support.
+The skill is embedded in the binary, so the CLI is the only prerequisite.
 
 ## Install the Skill
-
-Claude Code loads Agent Skills from a `skills/<name>/SKILL.md` layout and activates them automatically based on their `description`. Copy `SKILL.md` into the Walden skill directory.
 
 **User-level** (available across all projects):
 
 ```bash
-mkdir -p ~/.claude/skills/walden
-cp skill/walden/SKILL.md ~/.claude/skills/walden/SKILL.md
+walden skill install claude
 ```
 
-**Project-level** (scoped to a single repository):
+This writes the embedded skill to `~/.claude/skills/walden/SKILL.md` and removes the legacy `/walden` command file if one is present.
+
+**Project-level** (scoped to a single repository, shared with your team):
 
 ```bash
-mkdir -p .claude/skills/walden
-cp skill/walden/SKILL.md .claude/skills/walden/SKILL.md
+walden skill install claude --project
+git add .claude/skills/walden/SKILL.md
 ```
 
-`SKILL.md` is used as-is: its `name` and `description` frontmatter is what Claude Code reads to decide when to apply the skill.
+Committing the file gives every teammate the skill on clone — no installation step on their side.
+
+## Verify And Update
+
+```bash
+walden skill status
+```
+
+Reports whether the installation is `in-sync` or `drifted` relative to the binary's embedded copy, and which binary version installed it. After upgrading the binary, rerun `walden skill install claude` to refresh the skill.
 
 ## Usage
 

--- a/skill/walden/install-codex.md
+++ b/skill/walden/install-codex.md
@@ -2,25 +2,53 @@
 
 ## Prerequisites
 
-1. Install the `walden` CLI and ensure it is available in `PATH`:
+Install the `walden` CLI and ensure it is available in `PATH`:
 
-   ```bash
-   go install github.com/andrearaponi/walden/cmd/walden@latest
-   ```
+```bash
+go install github.com/andrearaponi/walden/cmd/walden@latest
+```
 
-   Verify with:
+Verify with:
 
-   ```bash
-   walden version
-   ```
+```bash
+walden version
+```
 
-2. An OpenAI Codex-compatible agent environment.
+The skill is embedded in the binary, so the CLI is the only prerequisite.
 
 ## Install the Skill
 
-Copy the `skill/walden/` directory from this repository into your agent's instruction set or tool configuration.
+**User-level** (applies to every Codex session):
 
-The key file is `SKILL.md` — it contains the full workflow instructions the agent follows.
+```bash
+walden skill install codex
+```
+
+Codex reads instructions from `AGENTS.md`. The command maintains a marker-delimited block inside `${CODEX_HOME:-~/.codex}/AGENTS.md`:
+
+```
+# --- BEGIN WALDEN SKILL ---
+...skill content...
+# --- END WALDEN SKILL ---
+```
+
+Everything outside the markers is preserved. Reinstalling replaces the block in place — run it after upgrading the binary to refresh the skill.
+
+**Project-level** (an `AGENTS.md` in the repository root, shared with your team):
+
+```bash
+walden skill install codex --project
+git add AGENTS.md
+```
+
+## Verify And Remove
+
+```bash
+walden skill status
+walden skill uninstall codex
+```
+
+Uninstalling removes only the Walden block; the rest of your `AGENTS.md` is untouched.
 
 ## Usage
 

--- a/skill/walden/install-copilot.md
+++ b/skill/walden/install-copilot.md
@@ -2,28 +2,39 @@
 
 ## Prerequisites
 
-1. Install the `walden` CLI and ensure it is available in `PATH`:
+Install the `walden` CLI and ensure it is available in `PATH`:
 
-   ```bash
-   go install github.com/andrearaponi/walden/cmd/walden@latest
-   ```
+```bash
+go install github.com/andrearaponi/walden/cmd/walden@latest
+```
 
-   Verify with:
+Verify with:
 
-   ```bash
-   walden version
-   ```
+```bash
+walden version
+```
 
-2. A GitHub Copilot-compatible agent environment.
+The skill is embedded in the binary, so the CLI is the only prerequisite.
 
 ## Install the Skill
 
-Copy `SKILL.md` into `~/.copilot/skills/walden/`:
+```bash
+walden skill install copilot
+```
+
+This writes the embedded skill to `${COPILOT_HOME:-~/.copilot}/skills/walden/SKILL.md`. Copilot support is user-scoped; `--project` is not available for this agent. If your Copilot setup loads instructions from a repository path, export the skill there yourself:
 
 ```bash
-mkdir -p ~/.copilot/skills/walden
-cp skill/walden/SKILL.md ~/.copilot/skills/walden/SKILL.md
+walden skill show > path/your/copilot/setup/reads.md
 ```
+
+## Verify And Update
+
+```bash
+walden skill status
+```
+
+After upgrading the binary, rerun `walden skill install copilot` to refresh the skill.
 
 ## Usage
 

--- a/skill/walden/install-opencode.md
+++ b/skill/walden/install-opencode.md
@@ -2,30 +2,29 @@
 
 ## Prerequisites
 
-1. Install the `walden` CLI and ensure it is available in `PATH`:
+Install the `walden` CLI and ensure it is available in `PATH`:
 
-   ```bash
-   go install github.com/andrearaponi/walden/cmd/walden@latest
-   ```
+```bash
+go install github.com/andrearaponi/walden/cmd/walden@latest
+```
 
-   Verify with:
+Verify with:
 
-   ```bash
-   walden version
-   ```
+```bash
+walden version
+```
 
-2. An [OpenCode](https://opencode.ai) installation with native Agent Skills support.
+The skill is embedded in the binary, so the CLI is the only prerequisite. An [OpenCode](https://opencode.ai) installation with native Agent Skills support is required.
 
 ## Install the Skill
 
-Copy `SKILL.md` into your global OpenCode skills directory:
-
 ```bash
-mkdir -p ~/.config/opencode/skills/walden
-cp skill/walden/SKILL.md ~/.config/opencode/skills/walden/SKILL.md
+walden skill install opencode
 ```
 
-OpenCode discovers skills from several locations. Pick the one that matches your scope:
+This writes the embedded skill to the global OpenCode skills directory. Resolution order: `$OPENCODE_HOME/skills/walden/SKILL.md` when `OPENCODE_HOME` is set, otherwise `${XDG_CONFIG_HOME:-~/.config}/opencode/skills/walden/SKILL.md`.
+
+OpenCode discovers skills from several locations:
 
 | Scope | Path |
 | --- | --- |
@@ -33,11 +32,22 @@ OpenCode discovers skills from several locations. Pick the one that matches your
 | Global (shared with Claude) | `~/.claude/skills/walden/SKILL.md` |
 | Project | `.opencode/skills/walden/SKILL.md` |
 
-OpenCode also reads `~/.claude/skills/`, so if you already installed Walden for Claude Code it is picked up automatically — copying it into both `~/.config/opencode/skills/` and `~/.claude/skills/` would surface the skill twice.
+OpenCode also reads `~/.claude/skills/`, so if you already ran `walden skill install claude` the skill is picked up automatically — installing for both agents would surface it twice. For the OpenCode project scope, export the skill yourself:
 
-`SKILL.md` is used as-is: its `name`, `description`, and `metadata` frontmatter is already valid for OpenCode, and unknown fields are ignored. No edits are required.
+```bash
+mkdir -p .opencode/skills/walden
+walden skill show > .opencode/skills/walden/SKILL.md
+```
 
-If `XDG_CONFIG_HOME` is set, OpenCode resolves the global directory under `$XDG_CONFIG_HOME/opencode/skills/` instead of `~/.config/opencode/skills/`. The `setup.sh` installer honors this automatically.
+`SKILL.md` is used as-is: its `name`, `description`, and `metadata` frontmatter is already valid for OpenCode, and unknown fields are ignored.
+
+## Verify And Update
+
+```bash
+walden skill status
+```
+
+After upgrading the binary, rerun `walden skill install opencode` to refresh the skill.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

The skill is Walden's primary interface, but distribution has been binary-centric: `go install` delivered a skill-less binary, and installing the skill required cloning the repo so `setup.sh` could copy a markdown file. This PR makes the binary the single distribution artifact.

- **`skill/embed.go`** — the canonical `skill/walden/SKILL.md` is embedded via `go:embed` (single source, never forked; mirrors `templates/embed.go`)
- **`walden skill install <agent>|--all [--project]`** — places the skill for `claude`, `codex`, `copilot`, `opencode`. User scope by default; explicit `--project` for claude (`.claude/skills/`) and codex (`AGENTS.md` in CWD) with a commit hint for team sharing. Atomic temp+rename writes; the Codex marker block stays byte-compatible with historical `setup.sh` installs and is replaced in place on reinstall
- **`walden skill uninstall`** — symmetric, idempotent; block extraction preserves unrelated `AGENTS.md` content
- **`walden skill status`** — classifies every agent×scope slot as `in-sync`/`drifted` against the embedded copy (version stamp normalized before comparison), reports the installing binary version, and warns when user and project scopes diverge
- **`walden skill show`** — verbatim SKILL.md on stdout: the escape hatch for agents the registry does not model
- **`setup.sh`** — keeps its interactive prompt, delegates every skill operation to the binary it installs (skill removal runs before binary removal)
- **JSON envelope** — additive `skills`/`content` fields only; `schema_version: v0beta1` unchanged

Installed skills carry a trailing `<!-- walden-skill-version: ... -->` marker so version mismatches between skill and CLI are visible instead of silent.

## Spec

Developed with the full Walden workflow (requirements → design → tasks → execute): 37 EARS acceptance criteria, 100% task and proof reference coverage, every task completed via `walden task complete` with passing proofs.

## Test plan

- `go build ./...` && `go test ./...` green (new suites: `./skill`, `./internal/skilldist`, extended `./internal/app`, `./internal/output`)
- Proof-level checks: no `net` imports in `skilldist`, `go.mod` still dependency-free, `sh -n setup.sh`, legacy shell install functions removed
- Smoke test with the real binary in an isolated $HOME: `install --all` → 4 agents installed, `status` → all `in-sync` with stamped version, project slots `not-installed`