### PR TITLE
feat: publish the site on GitHub Pages, aligned with the one-liner install

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Deploy site
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'site/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,310 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Walden — Intention before code. Proof before completion.</title>
+  <meta name="description" content="Walden is an open-source, spec-driven delivery kernel. It turns ideas into reviewed specifications and executes approved work through a deterministic, gated workflow." />
+
+  <meta property="og:title" content="Walden — a spec-driven delivery kernel" />
+  <meta property="og:description" content="Intention before code. Proof before completion. A deterministic Go CLI that enforces the workflow; an optional AI skill that drafts the specs." />
+  <meta property="og:type" content="website" />
+
+  <link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2064%2064'%3E%3Crect%20width='64'%20height='64'%20rx='13'%20fill='%232c4734'/%3E%3Ctext%20x='32'%20y='46'%20font-family='Georgia,serif'%20font-size='42'%20fill='%23f2eee4'%20text-anchor='middle'%3EW%3C/text%3E%3C/svg%3E" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..600;1,9..144,300..520&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <!-- paper grain overlay -->
+  <div class="grain" aria-hidden="true"></div>
+
+  <header class="site-head">
+    <a class="wordmark" href="#top">Walden<span class="mark">§</span></a>
+    <nav class="nav" aria-label="Primary">
+      <a href="#workflow">Workflow</a>
+      <a href="#ears">EARS</a>
+      <a href="#stack">Integrate</a>
+      <a href="#install">Install</a>
+      <a class="nav-gh" href="https://github.com/andrearaponi/walden">GitHub&nbsp;↗</a>
+    </nav>
+  </header>
+
+  <main id="top">
+
+    <!-- ───────────────────────────  HERO  ─────────────────────────── -->
+    <section class="hero">
+      <!-- pond contours: atmosphere -->
+      <svg class="contours" viewBox="0 0 600 600" aria-hidden="true" preserveAspectRatio="xMidYMid slice">
+        <g fill="none" stroke="currentColor">
+          <ellipse cx="300" cy="300" rx="70"  ry="52"  transform="rotate(-18 300 300)"/>
+          <ellipse cx="300" cy="300" rx="118" ry="92"  transform="rotate(-18 300 300)"/>
+          <ellipse cx="300" cy="300" rx="170" ry="132" transform="rotate(-18 300 300)"/>
+          <ellipse cx="300" cy="300" rx="226" ry="176" transform="rotate(-18 300 300)"/>
+          <ellipse cx="300" cy="300" rx="288" ry="222" transform="rotate(-18 300 300)"/>
+          <ellipse cx="300" cy="300" rx="356" ry="272" transform="rotate(-18 300 300)"/>
+        </g>
+      </svg>
+
+      <p class="eyebrow reveal">Spec-driven delivery kernel · Open source</p>
+      <h1 class="hero-title">
+        <span class="reveal" style="--d:.05s">Intention before code.</span>
+        <span class="reveal accent" style="--d:.18s">Proof before completion.</span>
+      </h1>
+      <p class="hero-sub reveal" style="--d:.32s">
+        Walden turns ideas into reviewed feature specifications and executes approved
+        work through a deterministic, gated workflow. A Go CLI enforces the rules.
+        An optional AI skill drafts the specs.
+      </p>
+
+      <div class="install-line reveal" style="--d:.44s">
+        <code id="cmd-hero">curl -fsSL https://raw.githubusercontent.com/andrearaponi/walden/main/install.sh | sh</code>
+        <button class="copy" data-copy="#cmd-hero" aria-label="Copy install command">Copy</button>
+      </div>
+
+      <p class="meta-line reveal" style="--d:.54s">
+        Apache&#8209;2.0 &nbsp;·&nbsp; Zero dependencies &nbsp;·&nbsp; Pure Go standard library
+      </p>
+    </section>
+
+    <!-- ─────────────────────────  THE CLAIM  ───────────────────────── -->
+    <section class="claim" aria-label="Positioning">
+      <p class="claim-line">
+        <span class="claim-soft">Plan modes draft. Checklists suggest. Analysis advises.</span>
+        <span class="claim-hard">Walden enforces.</span>
+      </p>
+      <p class="claim-sub">
+        Blocking gates with exit codes — validation, proofs, freshness —
+        independent of any model&rsquo;s judgment.
+      </p>
+    </section>
+
+    <!-- ───────────────────────  TWO VOICES  ────────────────────────── -->
+    <section class="voices" id="voices">
+      <div class="section-label"><span>§ 01</span> Two halves, one boundary</div>
+      <p class="lede">
+        Walden draws a hard line between what a machine should decide and what a human
+        should author. The non-deterministic work is drafted. The rules are enforced.
+      </p>
+
+      <div class="voices-grid">
+        <div class="voice voice--human">
+          <p class="voice-head">The skill drafts</p>
+          <ul>
+            <li>Asks the clarifying questions</li>
+            <li>Writes requirements in EARS form</li>
+            <li>Designs architecture, weighs the alternatives</li>
+            <li>Breaks work into tasks, each with a proof</li>
+            <li>Reads past lessons before similar work</li>
+          </ul>
+          <p class="voice-foot">non-deterministic · proposes, never approves</p>
+        </div>
+
+        <div class="voice voice--machine">
+          <p class="voice-head">The CLI enforces</p>
+          <ul>
+            <li>phase order: requirements → design → tasks</li>
+            <li>document freshness &amp; approval chains</li>
+            <li>AC traceability — 100% coverage required</li>
+            <li>a verification proof on every leaf task</li>
+            <li>stale-document detection &amp; reconciliation</li>
+          </ul>
+          <p class="voice-foot">deterministic · the same answer every time</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ───────────────────────  WORKFLOW  ──────────────────────────── -->
+    <section class="workflow" id="workflow">
+      <div class="section-label"><span>§ 02</span> How it works</div>
+      <p class="lede">
+        Every feature moves through four phases. Each one has an approval gate that must
+        pass before the next begins. Phases cannot be skipped.
+      </p>
+
+      <ol class="phases">
+        <li class="phase">
+          <span class="phase-num">01</span>
+          <h3>Requirements</h3>
+          <p>What the feature must do — EARS acceptance criteria with stable IDs like <code>R1.AC1</code>.</p>
+          <span class="gate">validate · review · approve</span>
+        </li>
+        <li class="phase">
+          <span class="phase-num">02</span>
+          <h3>Design</h3>
+          <p>How it gets built — architecture, alternatives considered, tradeoffs, a coverage matrix.</p>
+          <span class="gate">validate · review · approve</span>
+        </li>
+        <li class="phase">
+          <span class="phase-num">03</span>
+          <h3>Tasks</h3>
+          <p>What code to write, in order. Every leaf task traces to an AC and carries a proof.</p>
+          <span class="gate">validate · review · approve</span>
+        </li>
+        <li class="phase">
+          <span class="phase-num">04</span>
+          <h3>Execute</h3>
+          <p>Build it. The CLI runs each verification proof — a task closes only when its proof passes.</p>
+          <span class="gate">verify · complete</span>
+        </li>
+      </ol>
+
+      <p class="workflow-note">
+        Change an already-approved document and everything downstream resets to draft.
+        Execution stays blocked until the chain is reconciled. No code outruns its spec.
+      </p>
+    </section>
+
+    <!-- ─────────────────────────  EARS  ────────────────────────────── -->
+    <section class="ears" id="ears">
+      <div class="section-label"><span>§ 03</span> Requirements that can't be vague</div>
+      <p class="lede">
+        Every acceptance criterion takes exactly one of six EARS forms. The CLI validates
+        the grammar — a single <code>SHALL</code>, the right keywords in the right place.
+      </p>
+
+      <blockquote class="ears-sample">
+        <span class="kw">WHEN</span> a task&rsquo;s verification proof passes,
+        the system <span class="kw">SHALL</span> mark the task complete.
+      </blockquote>
+
+      <dl class="ears-forms">
+        <div><dt>Ubiquitous</dt><dd>the system SHALL …</dd></div>
+        <div><dt>Event-driven</dt><dd>WHEN … the system SHALL …</dd></div>
+        <div><dt>State-driven</dt><dd>WHILE … the system SHALL …</dd></div>
+        <div><dt>Optional</dt><dd>WHERE … the system SHALL …</dd></div>
+        <div><dt>Unwanted</dt><dd>IF … THEN the system SHALL …</dd></div>
+        <div><dt>Complex</dt><dd>WHILE … WHEN … the system SHALL …</dd></div>
+      </dl>
+    </section>
+
+    <!-- ─────────────────────  THE STACK (recipes)  ─────────────────── -->
+    <section class="stack" id="stack">
+      <div class="section-label"><span>§ 04</span> The kernel under your stack</div>
+      <p class="lede">
+        Walden doesn&rsquo;t replace your agent, your IDE, or your spec tool. It is the
+        gate they call — anything that runs a command and reads an exit code gets hard gates.
+      </p>
+
+      <div class="stack-grid">
+        <article class="recipe">
+          <h3 class="recipe-name">Your coding agent</h3>
+          <p>Claude Code, Codex, Copilot, OpenCode — the skill ships inside the
+             binary. It drafts the specs; the kernel enforces the gates.</p>
+          <code class="recipe-cmd">walden skill install &lt;agent&gt;</code>
+          <span class="recipe-out">skill drafts · kernel enforces</span>
+        </article>
+
+        <article class="recipe">
+          <h3 class="recipe-name">Your CI</h3>
+          <p>Gate every pull request that touches a spec. Validation runs headless
+             and the exit code decides — no model in the loop.</p>
+          <code class="recipe-cmd">walden validate &lt;feature&gt; --all --json</code>
+          <span class="recipe-out">exit ≠ 0 → merge blocked</span>
+        </article>
+
+        <article class="recipe">
+          <h3 class="recipe-name">Inside Kiro</h3>
+          <p>Kiro&rsquo;s hooks honor exit codes. Run the gate as a pre&#8209;tool&#8209;use
+             hook: when validation fails, the action is blocked.</p>
+          <code class="recipe-cmd">walden validate &lt;feature&gt; --all</code>
+          <span class="recipe-out">exit ≠ 0 → action blocked</span>
+        </article>
+
+        <article class="recipe">
+          <h3 class="recipe-name">Inside Spec Kit</h3>
+          <p>Spec Kit workflows run shell steps. Put the gate between phases:
+             the pipeline advances only when the kernel agrees.</p>
+          <code class="recipe-cmd">walden validate &lt;feature&gt; --all</code>
+          <span class="recipe-out">exit ≠ 0 → workflow halts</span>
+        </article>
+      </div>
+
+      <p class="workflow-note stack-note">
+        The same gate returns the same answer in every host. Enforcement stops being
+        a feature of your editor and becomes a property of the spec.
+      </p>
+    </section>
+
+    <!-- ────────────────────────  INSTALL  ──────────────────────────── -->
+    <section class="install" id="install">
+      <div class="section-label"><span>§ 05</span> Install</div>
+      <p class="lede">
+        One command. The latest release binary lands in <code>~/.local/bin/walden</code>,
+        checksum-verified — then it installs its own AI skill for Claude&nbsp;Code, Codex,
+        Copilot, or OpenCode. No Go toolchain, no clone.
+      </p>
+
+      <div class="code-block">
+        <button class="copy" data-copy="#cmd-setup" aria-label="Copy install command">Copy</button>
+        <pre id="cmd-setup"><span class="c">curl -fsSL https://raw.githubusercontent.com/andrearaponi/walden/main/install.sh | sh</span></pre>
+      </div>
+
+      <p class="install-alt">
+        Prefer the toolchain? <code>go install github.com/andrearaponi/walden/cmd/walden@latest</code>
+        &nbsp;·&nbsp; then <code>walden skill install &lt;agent&gt;</code>. Building from a clone?
+        <code>./setup.sh</code> still works.
+      </p>
+    </section>
+
+    <!-- ──────────────────────  ON THE NAME  ────────────────────────── -->
+    <section class="name" id="name">
+      <div class="section-label"><span>§ 06</span> On the name</div>
+      <blockquote class="thoreau">
+        <span class="quote-mark" aria-hidden="true">&ldquo;</span>
+        I went to the woods because I wished to live deliberately, to front only
+        the essential facts of life.
+      </blockquote>
+      <p class="thoreau-cite">— Henry David Thoreau, <cite>Walden, or Life in the Woods</cite></p>
+      <p class="name-note">
+        Do fewer things, but do them with full attention. Software rarely does. Walden
+        is an attempt to apply that discipline — to require intention before code, and
+        proof before completion.
+      </p>
+    </section>
+
+  </main>
+
+  <footer class="site-foot">
+    <div class="foot-left">
+      <span class="foot-mark">Walden</span>
+      <span class="foot-meta">Apache-2.0 · built deliberately</span>
+    </div>
+    <nav class="foot-nav" aria-label="Footer">
+      <a href="https://github.com/andrearaponi/walden">GitHub</a>
+      <a href="https://github.com/andrearaponi/walden/tree/main/docs">Docs</a>
+      <a href="https://github.com/andrearaponi/walden/releases">Releases</a>
+    </nav>
+  </footer>
+
+  <script>
+    // click-to-copy — restrained micro-interaction
+    document.querySelectorAll('.copy').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var el = document.querySelector(btn.dataset.copy);
+        if (!el) return;
+        navigator.clipboard.writeText(el.innerText.trim()).then(function () {
+          var prev = btn.textContent;
+          btn.textContent = 'Copied';
+          btn.classList.add('is-copied');
+          setTimeout(function () { btn.textContent = prev; btn.classList.remove('is-copied'); }, 1400);
+        });
+      });
+    });
+
+    // deliberate scroll reveals (respects reduced motion)
+    if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      var io = new IntersectionObserver(function (entries) {
+        entries.forEach(function (e) {
+          if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); }
+        });
+      }, { threshold: 0.18 });
+      document.querySelectorAll('.section-label, .lede, .claim-line, .claim-sub, .voice, .phase, .ears-sample, .ears-forms, .demo-frame, .recipe, .stack-note, .code-block, .install-alt, .thoreau, .name-note')
+        .forEach(function (el) { el.classList.add('rise'); io.observe(el); });
+    }
+  </script>
+</body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,450 @@
+/* ============================================================
+   Walden — paper, ink & pine.
+   Two voices: Fraunces (intention) · JetBrains Mono (enforcement).
+   ============================================================ */
+
+:root {
+  --paper:      #f2eee4;   /* warm bone */
+  --paper-2:    #ece6d8;   /* recessed panels */
+  --paper-3:    #e4ddcc;   /* deeper recess */
+  --ink:        #181610;   /* warm near-black */
+  --ink-soft:   rgba(24, 22, 16, 0.66);
+  --ink-mute:   rgba(24, 22, 16, 0.45);
+  --rule:       rgba(24, 22, 16, 0.14);
+  --rule-soft:  rgba(24, 22, 16, 0.08);
+  --pine:       #2c4734;   /* life in the woods */
+  --pine-deep:  #1f3527;
+  --pine-bright:#3b6049;
+
+  --serif: "Fraunces", Georgia, "Times New Roman", serif;
+  --mono:  "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
+
+  --measure: 62ch;
+  --pad: clamp(1.4rem, 5vw, 7rem);
+  --section-gap: clamp(5rem, 11vw, 9.5rem);
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+@media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--serif);
+  font-optical-sizing: auto;
+  font-size: clamp(1.02rem, 0.55vw + 0.92rem, 1.16rem);
+  line-height: 1.62;
+  font-weight: 380;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+}
+
+/* paper grain ----------------------------------------------------------- */
+.grain {
+  position: fixed; inset: 0; z-index: 1; pointer-events: none;
+  opacity: 0.4; mix-blend-mode: multiply;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.34'/%3E%3C/svg%3E");
+}
+
+::selection { background: var(--pine); color: var(--paper); }
+
+a { color: inherit; }
+
+/* links: precise hairline underline ------------------------------------- */
+.nav a, .foot-nav a, .install-alt a, .thoreau-cite a {
+  text-decoration: none;
+  background-image: linear-gradient(currentColor, currentColor);
+  background-size: 0% 1px; background-position: 0 100%; background-repeat: no-repeat;
+  transition: background-size .35s cubic-bezier(.2,.7,.2,1);
+}
+.nav a:hover, .foot-nav a:hover, .install-alt a:hover { background-size: 100% 1px; }
+
+:focus-visible { outline: 2px solid var(--pine); outline-offset: 3px; border-radius: 2px; }
+
+/* ===========================  HEADER  ================================== */
+.site-head {
+  position: sticky; top: 0; z-index: 20;
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 1.15rem var(--pad);
+  background: color-mix(in srgb, var(--paper) 82%, transparent);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--rule-soft);
+}
+.wordmark {
+  font-family: var(--serif);
+  font-size: 1.35rem; font-weight: 520; letter-spacing: -0.01em;
+  text-decoration: none; color: var(--ink);
+}
+.wordmark .mark { color: var(--pine); margin-left: .12em; font-weight: 400; }
+
+.nav { display: flex; gap: clamp(1rem, 3vw, 2.4rem); align-items: baseline; }
+.nav a {
+  font-family: var(--mono); font-size: .72rem; font-weight: 500;
+  text-transform: uppercase; letter-spacing: 0.16em; color: var(--ink-soft);
+}
+.nav a.nav-gh { color: var(--pine); }
+@media (max-width: 620px) { .nav a:not(.nav-gh) { display: none; } }
+
+/* ============================  HERO  ================================== */
+.hero {
+  position: relative;
+  padding: clamp(5rem, 13vw, 11rem) var(--pad) clamp(4rem, 9vw, 7rem);
+  border-bottom: 1px solid var(--rule);
+  overflow: hidden;
+}
+.contours {
+  position: absolute; z-index: 0;
+  top: 50%; right: -14vw; transform: translateY(-50%);
+  width: min(58vw, 720px); height: min(58vw, 720px);
+  color: var(--pine);
+  opacity: 0.13;
+  stroke-width: 1.1;
+}
+@media (max-width: 760px) {
+  .contours { right: -38vw; top: 8%; transform: none; width: 120vw; height: 120vw; opacity: 0.085; }
+}
+.hero > *:not(.contours) { position: relative; z-index: 2; }
+
+.eyebrow {
+  font-family: var(--mono); font-size: .74rem; font-weight: 500;
+  text-transform: uppercase; letter-spacing: 0.24em; color: var(--pine);
+  margin: 0 0 1.8rem;
+}
+.hero-title {
+  font-family: var(--serif);
+  font-weight: 420;
+  font-size: clamp(2.7rem, 7.5vw, 6.4rem);
+  line-height: 0.98; letter-spacing: -0.025em;
+  margin: 0 0 1.6rem; max-width: 16ch;
+}
+.hero-title span { display: block; }
+.hero-title .accent {
+  font-style: italic; font-weight: 380;
+  color: var(--pine-deep);
+}
+.hero-sub {
+  font-size: clamp(1.1rem, 0.7vw + 1rem, 1.38rem);
+  color: var(--ink-soft); max-width: 54ch; margin: 0 0 2.6rem;
+  line-height: 1.55;
+}
+
+/* install one-liner ----------------------------------------------------- */
+.install-line {
+  display: inline-flex; align-items: stretch; gap: 0;
+  max-width: 100%; margin-bottom: 1.5rem;
+  border: 1px solid var(--ink); border-radius: 3px;
+  background: var(--paper);
+  box-shadow: 4px 4px 0 var(--ink);
+  overflow: hidden;
+}
+.install-line code {
+  font-family: var(--mono); font-size: clamp(.74rem, 1.6vw, .9rem);
+  padding: .85rem 1.1rem; color: var(--ink);
+  white-space: nowrap; overflow-x: auto; line-height: 1.4;
+}
+.copy {
+  font-family: var(--mono); font-size: .68rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.12em;
+  border: none; border-left: 1px solid var(--ink);
+  background: var(--ink); color: var(--paper);
+  padding: 0 1.1rem; cursor: pointer; flex-shrink: 0;
+  transition: background .2s ease, color .2s ease;
+}
+.copy:hover { background: var(--pine); }
+.copy.is-copied { background: var(--pine-bright); }
+
+.meta-line {
+  font-family: var(--mono); font-size: .73rem; letter-spacing: 0.08em;
+  color: var(--ink-mute); margin: 0;
+}
+
+/* =========================  THE CLAIM  ================================ */
+section.claim {
+  background: var(--ink);
+  color: var(--paper);
+  padding: clamp(3.5rem, 8vw, 6.5rem) var(--pad);
+  border-bottom: none;
+}
+.claim-line {
+  font-family: var(--serif); font-weight: 400;
+  font-size: clamp(1.7rem, 4vw, 3.2rem);
+  line-height: 1.22; letter-spacing: -0.015em;
+  margin: 0 0 1.5rem; max-width: 30ch;
+}
+.claim-soft { display: block; color: rgba(242, 238, 228, 0.5); }
+.claim-hard { display: block; font-style: italic; color: var(--paper); }
+.claim-hard::after { content: " ▮"; color: var(--pine-bright); font-style: normal; font-size: .6em; }
+.claim-sub {
+  font-family: var(--mono); font-size: .76rem; letter-spacing: 0.06em;
+  color: rgba(242, 238, 228, 0.55); margin: 0; max-width: 72ch; line-height: 1.7;
+}
+
+/* =====================  SECTION SCAFFOLD  ============================= */
+section:not(.hero) { padding: var(--section-gap) var(--pad); border-bottom: 1px solid var(--rule); }
+
+.section-label {
+  font-family: var(--mono); font-size: .76rem; font-weight: 500;
+  text-transform: uppercase; letter-spacing: 0.16em; color: var(--ink);
+  margin-bottom: 1.7rem; display: flex; align-items: baseline; gap: .9rem;
+}
+.section-label span { color: var(--pine); font-weight: 700; }
+
+.lede {
+  font-size: clamp(1.2rem, 0.9vw + 1.05rem, 1.6rem);
+  line-height: 1.45; max-width: 40ch; color: var(--ink);
+  margin: 0 0 clamp(2.4rem, 5vw, 3.6rem); font-weight: 360;
+}
+
+/* inline code ----------------------------------------------------------- */
+code {
+  font-family: var(--mono);
+  font-size: 0.86em;
+  background: var(--paper-3);
+  padding: 0.08em 0.4em; border-radius: 3px;
+}
+.lede code, .workflow-note code { background: var(--paper-3); color: var(--pine-deep); }
+
+/* =======================  TWO VOICES  ================================= */
+.voices-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  border: 1px solid var(--ink);
+}
+@media (max-width: 740px) { .voices-grid { grid-template-columns: 1fr; } }
+
+.voice { padding: clamp(1.8rem, 3.5vw, 3rem); }
+.voice--human  { background: var(--paper); }
+.voice--machine{ background: var(--paper-2); border-left: 1px solid var(--ink); }
+@media (max-width: 740px) { .voice--machine { border-left: none; border-top: 1px solid var(--ink); } }
+
+.voice-head {
+  font-family: var(--mono); font-size: .73rem; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.18em; color: var(--pine);
+  margin: 0 0 1.4rem; padding-bottom: 1rem; border-bottom: 1px solid var(--rule);
+}
+.voice ul { list-style: none; margin: 0; padding: 0; }
+.voice li { padding: .55rem 0; border-bottom: 1px solid var(--rule-soft); }
+.voice li:last-child { border-bottom: none; }
+
+/* human voice = serif prose; machine voice = mono */
+.voice--human li { font-family: var(--serif); font-size: 1.08rem; }
+.voice--machine li { font-family: var(--mono); font-size: .82rem; color: var(--ink-soft); line-height: 1.5; }
+
+.voice-foot {
+  font-family: var(--mono); font-size: .68rem; letter-spacing: 0.1em;
+  color: var(--ink-mute); margin: 1.4rem 0 0; text-transform: uppercase;
+}
+
+/* =========================  WORKFLOW  ================================= */
+.phases {
+  list-style: none; margin: 0 0 clamp(2rem, 4vw, 3rem); padding: 0;
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  border-top: 1px solid var(--ink);
+}
+@media (max-width: 880px) { .phases { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 520px) { .phases { grid-template-columns: 1fr; } }
+
+.phase {
+  padding: 1.8rem 1.5rem 1.6rem;
+  border-bottom: 1px solid var(--ink);
+  border-right: 1px solid var(--rule);
+  position: relative;
+}
+.phase:last-child { border-right: none; }
+@media (max-width: 880px) {
+  .phase:nth-child(2n) { border-right: none; }
+}
+.phase-num {
+  font-family: var(--mono); font-size: .72rem; font-weight: 700;
+  color: var(--pine); letter-spacing: 0.1em;
+}
+.phase h3 {
+  font-family: var(--serif); font-weight: 480;
+  font-size: 1.5rem; letter-spacing: -0.01em;
+  margin: .5rem 0 .6rem;
+}
+.phase p { font-size: .98rem; color: var(--ink-soft); margin: 0 0 1.3rem; line-height: 1.5; }
+.gate {
+  font-family: var(--mono); font-size: .66rem; letter-spacing: 0.08em;
+  text-transform: uppercase; color: var(--ink-mute);
+  display: block; padding-top: .9rem; border-top: 1px dashed var(--rule);
+}
+.workflow-note {
+  max-width: 56ch; color: var(--ink-soft);
+  font-size: 1.05rem; margin: 0;
+  padding-left: 1.2rem; border-left: 2px solid var(--pine);
+}
+
+/* ===========================  EARS  =================================== */
+.ears-sample {
+  margin: 0 0 clamp(2.2rem, 4vw, 3.2rem); padding: clamp(1.6rem, 3vw, 2.6rem);
+  background: var(--ink); color: var(--paper);
+  border-radius: 3px;
+  font-family: var(--mono); font-weight: 400;
+  font-size: clamp(1rem, 1.6vw, 1.4rem); line-height: 1.55;
+  box-shadow: 6px 6px 0 var(--pine);
+}
+.ears-sample .kw { color: #b7d9bf; font-weight: 700; }
+
+.ears-forms {
+  display: grid; grid-template-columns: repeat(2, 1fr);
+  gap: 0; margin: 0; border: 1px solid var(--rule);
+}
+@media (max-width: 600px) { .ears-forms { grid-template-columns: 1fr; } }
+.ears-forms > div {
+  display: flex; flex-direction: column; gap: .25rem;
+  padding: 1.05rem 1.3rem;
+  border-bottom: 1px solid var(--rule); border-right: 1px solid var(--rule);
+}
+.ears-forms > div:nth-child(2n) { border-right: none; }
+@media (max-width: 600px) { .ears-forms > div { border-right: none; } }
+.ears-forms dt {
+  font-family: var(--serif); font-style: italic; font-size: 1.1rem; font-weight: 420;
+}
+.ears-forms dd {
+  margin: 0; font-family: var(--mono); font-size: .76rem;
+  color: var(--ink-soft); letter-spacing: 0.01em;
+}
+
+/* ===========================  DEMO  =================================== */
+.demo-frame {
+  margin: 0; border: 1px solid var(--ink); border-radius: 5px;
+  overflow: hidden; background: #14130e;
+  box-shadow: 8px 8px 0 var(--ink);
+  aspect-ratio: 16 / 9; display: flex; flex-direction: column;
+}
+.demo-bar {
+  display: flex; align-items: center; gap: .5rem;
+  padding: .7rem 1rem; background: #1f1d16;
+  border-bottom: 1px solid rgba(255,255,255,.08);
+}
+.demo-bar .dot { width: .62rem; height: .62rem; border-radius: 50%; background: #3a382e; }
+.demo-bar .dot:first-child { background: var(--pine-bright); }
+.demo-bar-title {
+  font-family: var(--mono); font-size: .7rem; letter-spacing: 0.06em;
+  color: rgba(242,238,228,.5); margin-left: .6rem;
+}
+.demo-stage {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: .9rem;
+  text-align: center; padding: 1.5rem; color: var(--paper);
+  background:
+    radial-gradient(120% 90% at 50% 0%, rgba(59,96,73,.18), transparent 60%),
+    repeating-linear-gradient(0deg, transparent 0 28px, rgba(255,255,255,.018) 28px 29px);
+}
+.demo-stage .play {
+  font-size: 1.4rem; color: var(--paper);
+  width: 3.4rem; height: 3.4rem; display: grid; place-items: center;
+  border: 1px solid rgba(242,238,228,.3); border-radius: 50%;
+  padding-left: .2rem;
+}
+.demo-caption {
+  font-family: var(--serif); font-style: italic; font-size: 1.35rem;
+  margin: 0; color: var(--paper);
+}
+.demo-sub {
+  font-family: var(--mono); font-size: .72rem; letter-spacing: 0.05em;
+  color: rgba(242,238,228,.46); margin: 0; max-width: 46ch;
+}
+
+/* =========================  THE STACK  ================================ */
+.stack-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  border-top: 1px solid var(--ink);
+  margin: 0 0 clamp(2rem, 4vw, 3rem);
+}
+@media (max-width: 680px) { .stack-grid { grid-template-columns: 1fr; } }
+
+.recipe {
+  padding: 1.9rem 1.6rem 1.7rem;
+  border-bottom: 1px solid var(--ink);
+  border-right: 1px solid var(--rule);
+}
+.recipe:nth-child(2n) { border-right: none; }
+@media (max-width: 680px) { .recipe { border-right: none; } }
+
+.recipe-name {
+  font-family: var(--serif); font-weight: 480;
+  font-size: 1.4rem; letter-spacing: -0.01em;
+  margin: 0 0 .6rem;
+}
+.recipe p { font-size: .97rem; color: var(--ink-soft); line-height: 1.55; margin: 0 0 1.2rem; }
+.recipe-cmd {
+  display: block; font-family: var(--mono); font-size: .77rem;
+  background: var(--ink); color: var(--paper);
+  padding: .7rem .95rem; border-radius: 3px; margin: 0 0 1rem;
+  overflow-x: auto; white-space: nowrap;
+}
+.recipe-cmd::before { content: "$ "; color: var(--pine-bright); }
+.recipe-out {
+  font-family: var(--mono); font-size: .66rem; letter-spacing: 0.08em;
+  text-transform: uppercase; color: var(--ink-mute);
+  display: block; padding-top: .85rem; border-top: 1px dashed var(--rule);
+}
+
+/* ==========================  INSTALL  ================================= */
+.code-block {
+  position: relative; border: 1px solid var(--ink); border-radius: 3px;
+  background: var(--ink); color: var(--paper);
+  box-shadow: 5px 5px 0 var(--pine);
+  margin-bottom: 1.7rem; overflow: hidden;
+}
+.code-block .copy { position: absolute; top: 0; right: 0; height: 100%; border-left: 1px solid rgba(255,255,255,.14); }
+.code-block pre {
+  margin: 0; padding: 1.4rem 5.2rem 1.4rem 1.4rem;
+  font-family: var(--mono); font-size: .86rem; line-height: 1.9;
+  overflow-x: auto;
+}
+.code-block .c::before { content: "$ "; color: var(--pine-bright); }
+.install-alt { font-size: 1rem; color: var(--ink-soft); margin: 0; max-width: 60ch; }
+.install-alt code { background: var(--paper-3); color: var(--pine-deep); }
+
+/* ========================  ON THE NAME  ============================== */
+.name { position: relative; }
+.thoreau {
+  margin: 0 0 1.2rem; max-width: 22ch;
+  font-family: var(--serif); font-style: italic; font-weight: 360;
+  font-size: clamp(1.9rem, 4.5vw, 3.4rem); line-height: 1.18;
+  letter-spacing: -0.015em; position: relative;
+}
+.thoreau .quote-mark {
+  font-style: normal; color: var(--pine);
+  font-size: 1.3em; line-height: 0;
+  margin-right: .06em;
+}
+.thoreau-cite {
+  font-family: var(--mono); font-size: .74rem; letter-spacing: 0.08em;
+  color: var(--ink-mute); margin: 0 0 2.4rem;
+}
+.thoreau-cite cite { font-style: normal; }
+.name-note { max-width: 54ch; color: var(--ink-soft); font-size: 1.12rem; margin: 0; }
+
+/* ==========================  FOOTER  ================================= */
+.site-foot {
+  display: flex; align-items: center; justify-content: space-between;
+  flex-wrap: wrap; gap: 1.2rem;
+  padding: 2.6rem var(--pad);
+  background: var(--paper-2);
+}
+.foot-left { display: flex; align-items: baseline; gap: 1rem; flex-wrap: wrap; }
+.foot-mark { font-family: var(--serif); font-size: 1.2rem; font-weight: 520; }
+.foot-meta { font-family: var(--mono); font-size: .7rem; letter-spacing: 0.08em; color: var(--ink-mute); text-transform: uppercase; }
+.foot-nav { display: flex; gap: 1.8rem; }
+.foot-nav a {
+  font-family: var(--mono); font-size: .72rem; text-transform: uppercase;
+  letter-spacing: 0.14em; color: var(--ink-soft); text-decoration: none;
+}
+
+/* ==========================  MOTION  ================================= */
+.reveal { opacity: 0; transform: translateY(14px); animation: rise .9s cubic-bezier(.2,.7,.2,1) forwards; animation-delay: var(--d, 0s); }
+.rise { opacity: 0; transform: translateY(22px); transition: opacity .8s cubic-bezier(.2,.7,.2,1), transform .8s cubic-bezier(.2,.7,.2,1); }
+.rise.in { opacity: 1; transform: none; }
+
+@keyframes rise { to { opacity: 1; transform: none; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal, .rise { animation: none !important; transition: none !important; opacity: 1 !important; transform: none !important; }
+}


### PR DESCRIPTION
## Summary

First deploy of the Walden site, aligned with the v0.5.0 distribution story:

- **Hero + Install (§05)** lead with the one-liner — `curl -fsSL .../install.sh | sh` (checksum-verified release binaries, no Go toolchain, no clone). `go install` and `./setup.sh` stay as alternatives.
- **Coding-agent recipe** now shows `walden skill install <agent>` — the skill ships inside the binary.
- **Demo section (§04) held back** until the recording is ready; its styles and reveal hooks stay in place so it can return as-is.

## Deployment

- `pages.yml`: uploads `site/` via `actions/upload-pages-artifact` + `actions/deploy-pages` on pushes to `main` touching `site/**` (plus `workflow_dispatch`).
- Repo Pages configured with `build_type: workflow` → deploys to **https://andrearaponi.github.io/walden/**

*(The "How you use it" section landed separately in the follow-up PR — this one was merged while that commit was still being drafted.)*