### PR TITLE
feat(site): add 'How you use it' section with a real starting prompt

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -181,9 +181,42 @@
       </dl>
     </section>
 
+    <!-- ─────────────────────  HOW YOU USE IT  ──────────────────────── -->
+    <section class="howto" id="howto">
+      <div class="section-label"><span>§ 04</span> How you use it</div>
+      <p class="lede">
+        One prompt. No commands to memorize — describe the feature to your coding
+        agent, name Walden, and the ceremony starts.
+      </p>
+
+      <figure class="demo-frame howto-frame">
+        <div class="demo-bar">
+          <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+          <span class="demo-bar-title">claude code — new session</span>
+        </div>
+        <div class="howto-stage">
+          <p class="howto-label">you</p>
+          <p class="howto-prompt">We need to build a personal, single-user todo app.
+             Classic CRUD on tasks — each task has categories, a due date, a priority
+             level, and can of course be marked completed. We&rsquo;ll build it in
+             Go&nbsp;1.26, TDD fail-fast, SQLite as the database, OpenAPI for the APIs,
+             adopting RFC&nbsp;7807 problem details. The frontend will be embedded in
+             Go, using React and Tailwind&nbsp;v4. Authentication is out of scope for
+             now. <em>Let&rsquo;s use Walden.</em><span class="cursor" aria-hidden="true"></span></p>
+        </div>
+      </figure>
+
+      <p class="howto-note">
+        What happens next: the skill asks its clarifying questions, then drafts —
+        EARS requirements, design, tasks with proofs — stopping at every gate for
+        your approval. <code>walden validate</code>, <code>walden review approve</code>,
+        <code>walden task complete</code> run underneath. You never type them.
+      </p>
+    </section>
+
     <!-- ─────────────────────  THE STACK (recipes)  ─────────────────── -->
     <section class="stack" id="stack">
-      <div class="section-label"><span>§ 04</span> The kernel under your stack</div>
+      <div class="section-label"><span>§ 05</span> The kernel under your stack</div>
       <p class="lede">
         Walden doesn&rsquo;t replace your agent, your IDE, or your spec tool. It is the
         gate they call — anything that runs a command and reads an exit code gets hard gates.
@@ -231,7 +264,7 @@
 
     <!-- ────────────────────────  INSTALL  ──────────────────────────── -->
     <section class="install" id="install">
-      <div class="section-label"><span>§ 05</span> Install</div>
+      <div class="section-label"><span>§ 06</span> Install</div>
       <p class="lede">
         One command. The latest release binary lands in <code>~/.local/bin/walden</code>,
         checksum-verified — then it installs its own AI skill for Claude&nbsp;Code, Codex,
@@ -252,7 +285,7 @@
 
     <!-- ──────────────────────  ON THE NAME  ────────────────────────── -->
     <section class="name" id="name">
-      <div class="section-label"><span>§ 06</span> On the name</div>
+      <div class="section-label"><span>§ 07</span> On the name</div>
       <blockquote class="thoreau">
         <span class="quote-mark" aria-hidden="true">&ldquo;</span>
         I went to the woods because I wished to live deliberately, to front only
@@ -302,7 +335,7 @@
           if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); }
         });
       }, { threshold: 0.18 });
-      document.querySelectorAll('.section-label, .lede, .claim-line, .claim-sub, .voice, .phase, .ears-sample, .ears-forms, .demo-frame, .recipe, .stack-note, .code-block, .install-alt, .thoreau, .name-note')
+      document.querySelectorAll('.section-label, .lede, .claim-line, .claim-sub, .voice, .phase, .ears-sample, .ears-forms, .demo-frame, .howto-note, .recipe, .stack-note, .code-block, .install-alt, .thoreau, .name-note')
         .forEach(function (el) { el.classList.add('rise'); io.observe(el); });
     }
   </script>

--- a/site/styles.css
+++ b/site/styles.css
@@ -350,6 +350,43 @@ code {
   color: rgba(242,238,228,.46); margin: 0; max-width: 46ch;
 }
 
+/* =========================  HOW YOU USE IT  =========================== */
+/* Reuses .demo-frame / .demo-bar for the terminal chrome; overrides the
+   16:9 stage with a prompt-sized one (double class: order-independent). */
+.demo-frame.howto-frame { aspect-ratio: auto; }
+.howto-stage {
+  padding: clamp(1.7rem, 3.5vw, 2.9rem);
+  color: var(--paper);
+  background:
+    radial-gradient(120% 90% at 50% 0%, rgba(59,96,73,.18), transparent 60%),
+    repeating-linear-gradient(0deg, transparent 0 28px, rgba(255,255,255,.018) 28px 29px);
+}
+.howto-label {
+  font-family: var(--mono); font-size: .68rem; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.18em;
+  color: var(--pine-bright); margin: 0 0 1rem;
+}
+.howto-prompt {
+  font-family: var(--serif); font-weight: 380;
+  font-size: clamp(1.08rem, 1.8vw, 1.45rem); line-height: 1.6;
+  margin: 0; max-width: 58ch; color: var(--paper);
+}
+.howto-prompt em { color: #b7d9bf; }
+.cursor {
+  display: inline-block; width: .5em; height: 1em;
+  background: var(--pine-bright); margin-left: .18em;
+  vertical-align: text-bottom;
+  animation: blink 1.1s steps(1) infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
+@media (prefers-reduced-motion: reduce) { .cursor { animation: none; } }
+.howto-note {
+  max-width: 56ch; color: var(--ink-soft);
+  font-size: 1.05rem; margin: clamp(2rem, 4vw, 3rem) 0 0;
+  padding-left: 1.2rem; border-left: 2px solid var(--pine);
+}
+.howto-note code { background: var(--paper-3); color: var(--pine-deep); }
+
 /* =========================  THE STACK  ================================ */
 .stack-grid {
   display: grid; grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
## Summary

Follow-up to #14 (merged while this commit was in flight): fills the slot left by the held-back demo video with **§04 — How you use it**, showing the actual gesture that starts Walden.

- A real feature-description prompt (single-user todo app: Go 1.26, fail-fast TDD, SQLite, OpenAPI + RFC 7807 problem details, embedded React/Tailwind v4 frontend, auth out of scope) ending in *"Let's use Walden."* — rendered in the dark terminal frame, human voice in serif, blinking cursor (disabled under `prefers-reduced-motion`).
- A pine-ruled note on what happens next: the skill drafts and stops at every gate; `walden validate`, `walden review approve`, `walden task complete` run underneath — you never type them.
- Section labels renumbered §01–§07.
- The frame reuses the demo chrome; the 16:9 override is order-independent (`.demo-frame.howto-frame`), so restoring the video section later cannot break it.

## Test plan

- Rendered in a real browser (local server + element screenshots, reveal forced): label, prompt fully visible, cursor, note all correct
- Computed-style check: `aspect-ratio: auto` wins regardless of rule order; `scrollHeight == clientHeight` (no clipped text)
- Merging triggers the Pages deploy (touches `site/**`)