### PR TITLE
fix(ci): split Pages workflow into build and deploy jobs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,16 +14,19 @@ permissions:
   pages: write
   id-token: write
 
+# Allow one deployment at a time, but never cancel an in-progress one:
+# let a production deploy finish rather than leave Pages half-updated.
 concurrency:
   group: pages
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  # Build and deploy are separate jobs so that re-running only the failed
+  # deploy job (gh run rerun --failed) does NOT re-upload the artifact.
+  # Two artifacts named "github-pages" in one run make deploy-pages fail
+  # permanently — keeping upload in its own job avoids that.
+  build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -36,6 +39,13 @@ jobs:
         with:
           path: site
 
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem

The Pages deploy for #15 went red with:

```
Error: Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.
```

Root cause chain:
1. The original deploy hit a **transient** GitHub Pages backend error (`Deployment failed, try again later`).
2. Recovering with `gh run rerun --failed` re-ran the single `deploy` job — which, because upload and deploy lived in the **same job**, re-ran `upload-pages-artifact` and added a **second** `github-pages` artifact to the run.
3. `actions/deploy-pages` requires exactly one artifact by that name → permanent failure. No rerun can recover it (each adds another artifact).

The site itself was fine — a fresh `workflow_dispatch` run deployed it cleanly. This fixes the recovery path so the class of failure can't recur.

## Fix

Adopt GitHub's canonical two-job structure:

- **`build`** — checkout, configure-pages, upload-pages-artifact (produces exactly one artifact)
- **`deploy`** — `needs: build`, runs only `deploy-pages`

Now `gh run rerun --failed` after a transient deploy error re-runs **only** `deploy`, which consumes the existing single artifact — no re-upload, no duplicate.

Also set `concurrency.cancel-in-progress: false` (GitHub's recommended Pages setting) so an in-progress production deploy is never cancelled mid-flight.

## Verification

- YAML parsed and asserted: two jobs, `deploy` needs `build`, `upload-pages-artifact` only in `build`, `deploy-pages` only in `deploy`, environment intact
- Merging this PR touches `.github/workflows/pages.yml`, so it self-triggers a deploy under the new structure — the green run confirms the fix