### PR TITLE
feat(site): add 'How to use' to the primary nav

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -27,6 +27,7 @@
     <nav class="nav" aria-label="Primary">
       <a href="#workflow">Workflow</a>
       <a href="#ears">EARS</a>
+      <a href="#howto">How to use</a>
       <a href="#stack">Integrate</a>
       <a href="#install">Install</a>
       <a class="nav-gh" href="https://github.com/andrearaponi/walden">GitHub&nbsp;↗</a>


### PR DESCRIPTION
## Summary

§04 — *How you use it* is the most persuasive section for a first-time visitor (the actual prompt gesture), but it was the only major section unreachable from the top nav. This adds **How to use** between **EARS** and **Integrate**, mirroring page order:

`WORKFLOW · EARS · HOW TO USE · INTEGRATE · INSTALL · GITHUB ↗`

On mobile (≤620px) it collapses with the other nav links, per the existing rule.

## Verification

- Real-browser click test: `#howto` hash set, smooth scroll lands the section at top with the §04 label fully visible below the sticky header (80px vs 73px header height)
- Desktop (1280px) header screenshot confirms the item renders in order with consistent spacing
- Merging touches `site/**` → self-deploys via the split Pages workflow