### PR TITLE
feat(site): adoption-first nav — trim to essentials, CTA pill on 'How to use'

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -26,9 +26,7 @@
     <a class="wordmark" href="#top">Walden<span class="mark">§</span></a>
     <nav class="nav" aria-label="Primary">
       <a href="#workflow">Workflow</a>
-      <a href="#ears">EARS</a>
-      <a href="#howto">How to use</a>
-      <a href="#stack">Integrate</a>
+      <a class="nav-cta" href="#howto">How to use<span class="nav-cursor" aria-hidden="true"></span></a>
       <a href="#install">Install</a>
       <a class="nav-gh" href="https://github.com/andrearaponi/walden">GitHub&nbsp;↗</a>
     </nav>

--- a/site/styles.css
+++ b/site/styles.css
@@ -87,7 +87,29 @@ a { color: inherit; }
   text-transform: uppercase; letter-spacing: 0.16em; color: var(--ink-soft);
 }
 .nav a.nav-gh { color: var(--pine); }
-@media (max-width: 620px) { .nav a:not(.nav-gh) { display: none; } }
+
+/* "How to use" is the adoption CTA: a pine pill carrying the prompt
+   cursor — the same one blinking inside the §04 frame. */
+.nav a.nav-cta {
+  background-image: none;           /* opt out of the underline trick */
+  background-color: var(--pine);
+  color: var(--paper);
+  padding: .5em .9em;
+  border-radius: 3px;
+  transition: background-color .2s ease;
+}
+.nav a.nav-cta:hover { background-color: var(--pine-bright); }
+.nav a.nav-cta:focus-visible { outline-color: var(--ink); }
+.nav-cursor {
+  display: inline-block; width: .45em; height: .95em;
+  background: var(--paper); margin-left: .5em;
+  vertical-align: text-bottom;
+  animation: blink 1.6s steps(1) infinite;
+}
+@media (prefers-reduced-motion: reduce) { .nav-cursor { animation: none; } }
+
+/* Mobile keeps the two links that matter: the CTA and GitHub. */
+@media (max-width: 620px) { .nav a:not(.nav-gh):not(.nav-cta) { display: none; } }
 
 /* ============================  HERO  ================================== */
 .hero {


### PR DESCRIPTION
## Summary

Goal: maximize the "wow, let me install this" path. Two changes:

**1. Nav trimmed to the adoption funnel** — `WORKFLOW · HOW TO USE · INSTALL · GITHUB ↗`

EARS and Integrate leave the nav (their sections stay in the page untouched): as nav labels, "EARS" is jargon that pulls no first-visit clicks and "Integrate" is second-visit content for people evaluating stack fit. Fewer items, less dilution of the three that convert.

**2. "How to use" becomes the attention item** — a pine pill carrying a slowly blinking prompt cursor (1.6s), the same cursor waiting inside the §04 frame. Semantic motion, not decoration; disabled under `prefers-reduced-motion`; `focus-visible` outline switched to ink for contrast on the pine background.

**Mobile finally gets a path to the prompt**: instead of hiding every nav link ≤620px, the pill and GitHub stay visible — one tap from landing to the prompt example.

## Verification (real browser)

- Desktop 1280px: nav renders `WORKFLOW · [HOW TO USE ▮] · INSTALL · GITHUB ↗`, pill `#2c4734` with paper text
- Mobile 390px: header shows wordmark + pill + GitHub, no overflow
- Cursor blink proven by opacity sampling (0 → 1 → 0 across 800ms intervals); computed `animation: blink 1.6s`
- Anchor behavior unchanged (same `#howto` target verified in #17)

Merging touches `site/**` → self-deploys.