### PR TITLE
fix(site): center the nav CTA cursor on the text

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -97,13 +97,13 @@ a { color: inherit; }
   padding: .5em .9em;
   border-radius: 3px;
   transition: background-color .2s ease;
+  display: inline-flex; align-items: center; gap: .5em;
 }
 .nav a.nav-cta:hover { background-color: var(--pine-bright); }
 .nav a.nav-cta:focus-visible { outline-color: var(--ink); }
 .nav-cursor {
-  display: inline-block; width: .45em; height: .95em;
-  background: var(--paper); margin-left: .5em;
-  vertical-align: text-bottom;
+  width: .45em; height: .9em;
+  background: var(--paper);
   animation: blink 1.6s steps(1) infinite;
 }
 @media (prefers-reduced-motion: reduce) { .nav-cursor { animation: none; } }


### PR DESCRIPTION
## Problem

The blinking cursor in the **HOW TO USE** pill sat visibly lower than the letters (user-reported, screenshot-confirmed). Cause: `vertical-align: text-bottom` anchors to the bottom of the text box — descender depth — but the pill is all-caps mono, so no glyph ever reaches down there and the cursor appeared to hang below the text.

## Fix

The pill becomes `inline-flex` with `align-items: center` and `gap: .5em`; the cursor loses `vertical-align`/`margin-left` and shrinks slightly (`.9em`). Centering is now geometric, independent of font metrics.

## Verification (real browser, 1280px)

- Cursor center vs text center: **0.08px** drift (was visibly offset)
- All four nav links share the same vertical center (39px) — the inline-flex pill keeps the nav baseline via its first flex item
- Screenshot with the blink paused in its visible phase confirms the optical alignment