### PR TITLE
feat(skill): recommended option and explore-before-asking in the Decision Checkpoint Protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Thi
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-09
+
+### Changed
+
+- **Decision Checkpoint Protocol refined in the embedded skill:**
+  - Every `[decision:]` checkpoint now arrives with the skill's recommended option and a one-line rationale; when no option is defensibly better, the fork is presented without a fabricated preference.
+  - New **Explore before asking** rule: when a decision passes the Bifurcation Test, the skill checks whether the codebase, the constitution, or approved upstream documents already answer the question before interrupting; repository-sourced resolutions are recorded inline as `<!-- assumed: <choice> (source: <file or document>) -->` (additive marker suffix — existing `assumed` markers stay valid).
+  - Protocol invariants are untouched: five-checkpoint budget per phase, draft status on unresolved checkpoints, autonomous resolution as the default when in doubt.
+- Prompt-only release: no CLI behavior or JSON contract changes (`schema_version: v0beta1` unchanged). Refresh installed skills with `walden skill install <agent>`; `walden skill status` reports stale installs as drifted.
+
 ## [0.5.0] - 2026-07-02
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,55 +1,33 @@
-## Walden v0.5.0
+## Walden v0.6.0
 
-The binary is now the whole distribution. The AI skill ships inside it, one command installs everything, and skill/CLI version drift is impossible by construction.
+The skill interrupts you less, and earns it more. Two refinements land in the Decision Checkpoint Protocol.
 
-### Install in one line
+### Every checkpoint comes with a recommendation
+
+When drafting hits a genuine fork, the skill no longer presents it neutrally: it states its recommended option with a one-line rationale. You can answer "do that" instead of re-deriving context the skill already has. And when no option is defensibly better, it says so — no fabricated preferences.
+
+### Explore before asking
+
+Before emitting a checkpoint, the skill now checks whether the codebase, the constitution, or approved upstream documents already answer the question. If they do, it resolves autonomously and records the source inline:
+
+```markdown
+<!-- assumed: v0.6.0 minor bump (source: CHANGELOG.md) -->
+```
+
+Your attention is spent only on decisions the repository cannot answer. The existing `<!-- assumed: ... -->` markers stay valid — the source suffix is additive.
+
+### What did not change
+
+The protocol's invariants are byte-level untouched: at most five checkpoints per phase, unresolved checkpoints keep the document in `draft`, and autonomous resolution remains the default when in doubt. Prompt-only release — no CLI behavior or JSON contract changes (`schema_version: v0beta1`).
+
+### Upgrading
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/andrearaponi/walden/main/install.sh | sh
+# or: go install github.com/andrearaponi/walden/cmd/walden@v0.6.0
 ```
 
-No Go toolchain, no clone: the installer detects your platform (darwin/linux × amd64/arm64), resolves the latest release, verifies the binary against the published SHA-256 checksums (fail-closed), installs it to `~/.local/bin/walden`, and offers to set up the AI skill for your coding agent. Flags pass through the pipe with `sh -s --`:
-
-| Flag | Effect |
-| --- | --- |
-| `--skill <agent\|all>` | Install the skill non-interactively (`claude`, `codex`, `copilot`, `opencode`, `all`) |
-| `--version <tag>` | Pin a release instead of the latest |
-| `--no-verify` | Skip checksum verification (releases ≤ v0.4.0 predate `checksums.txt`) |
-| `--uninstall` | Remove the skill (all agents) and the binary |
-
-This is the first release that publishes `checksums.txt` alongside the binaries.
-
-### The skill lives in the binary
-
-`skill/walden/SKILL.md` is embedded at build time. Whatever channel delivers the binary — the one-liner, `go install`, a manual download — delivers the skill at the exact matching version. The new `walden skill` command group manages placement:
-
-```bash
-walden skill install claude            # user scope: ~/.claude/skills/walden/
-walden skill install claude --project  # project scope: commit it, your team gets the skill on clone
-walden skill install --all             # every supported agent
-walden skill status                    # in-sync / drifted, per agent and scope
-walden skill show > anywhere.md        # escape hatch for agents Walden does not model yet
-walden skill uninstall <agent>|--all
-```
-
-- **Drift is visible instead of silent:** installed skills carry a version stamp; `walden skill status` compares content against the embedded copy (stamp-normalized) and reports which binary version installed what — including diverging user/project installations.
-- **Codex stays clean:** the `AGENTS.md` marker block is byte-compatible with previous `setup.sh` installs, reinstalls replace it in place, and uninstall extracts only the block, preserving everything else.
-- **Atomic placement:** every write stages a temp file and renames — no failure path leaves a partial skill or binary behind.
-
-### Behavior notes (not breaking)
-
-- The JSON contract is unchanged: new `skills` and `content` result fields are additive within `schema_version: v0beta1`.
-- Reinstalling the Codex skill now **replaces** the existing block (previously `setup.sh` skipped it) — refreshing the skill on binary upgrade is the point of the embed.
-- `setup.sh` still works for building from a clone, but delegates all skill placement to the binary.
-
-### Upgrading from v0.4.0
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/andrearaponi/walden/main/install.sh | sh
-# or: go install github.com/andrearaponi/walden/cmd/walden@v0.5.0
-```
-
-Then refresh the skill for the agents you use — one command now:
+Then refresh the skill for the agents you use:
 
 ```bash
 walden skill install <agent>   # or --all
@@ -58,6 +36,4 @@ walden skill status            # confirm everything reads in-sync
 
 ### Built the Walden way
 
-Both features were specified and executed through Walden's own gated ceremony: two full Requirements → Design → Tasks cycles (65 EARS acceptance criteria total, 100% task and proof reference coverage), every task completed through `walden task complete` with passing proofs — including live smoke tests of the installer's fail-closed path against the historical v0.4.0 release.
-
-Still zero external dependencies: `go:embed` is standard library.
+Specified and shipped through Walden's own gated ceremony: Requirements → Design → Tasks with 14 EARS acceptance criteria, 100% task and proof reference coverage, every task completed through `walden task complete` with passing proofs — and yes, the spec that refined the checkpoint protocol used the refined protocol on itself.

--- a/skill/walden/SKILL.md
+++ b/skill/walden/SKILL.md
@@ -151,7 +151,9 @@ Apply this protocol during Phase 1, 2, and 3 drafting. Do not apply during Phase
 
 **Bifurcation Test:** a decision merits a `[decision: <question>]` checkpoint if and only if choosing differently would require discarding or substantially rewriting document content produced after the choice. When in doubt, default to autonomous resolution.
 
-**On TRUE — checkpoint detected:** emit `[decision: <question>]` in the document, explain the fork in plain language, and stop generating further content. Wait for the user's response. On receiving a response, state how the answer will be applied to the document before resuming content generation in the same conversation turn. If the user's response surfaces a previously unidentified bifurcation-significant decision, emit a new `[decision: <question>]` marker for the newly identified fork before generating content that depends on it.
+**Explore before asking:** when a decision passes the Bifurcation Test, check whether the codebase, the constitution, or approved upstream documents already answer the question before emitting a checkpoint. If they do, resolve autonomously and record the assumption with its source: `<!-- assumed: <choice> (source: <file or document>) -->`.
+
+**On TRUE — checkpoint detected:** emit `[decision: <question>]` in the document, explain the fork in plain language, and state your recommended option with a one-line rationale — if no option is defensibly better, present the fork without a recommendation. Stop generating further content. Wait for the user's response. On receiving a response, state how the answer will be applied to the document before resuming content generation in the same conversation turn. If the user's response surfaces a previously unidentified bifurcation-significant decision, emit a new `[decision: <question>]` marker for the newly identified fork before generating content that depends on it.
 
 **On FALSE — autonomous resolution:** record the chosen assumption as `<!-- assumed: <choice> -->` inline in the document and continue drafting without interruption.
 


### PR DESCRIPTION
## What

Two refinements to the Decision Checkpoint Protocol in the embedded skill:

- Every `[decision:]` checkpoint now states the skill's recommended option with a one-line rationale; when no option is defensibly better, the fork is presented without a fabricated preference.
- New **Explore before asking** rule: when a decision passes the Bifurcation Test, the skill checks whether the codebase, the constitution, or approved upstream documents already answer the question before interrupting; repository-sourced resolutions are recorded inline as `<!-- assumed: <choice> (source: <file or document>) -->` (additive suffix — existing markers stay valid).

Protocol invariants are untouched: five-checkpoint budget per phase, draft status on unresolved checkpoints, autonomous resolution as the default when in doubt.

Prompt-only change — no CLI behavior or JSON contract impact (`schema_version: v0beta1` unchanged).

## Release readiness

- CHANGELOG entry for 0.6.0
- RELEASE_NOTES.md rewritten (consumed by release.yml at tag time)

Validated behaviorally on a full spec cycle: three checkpoints, each presented with a recommendation and rationale; repository-sourced autonomous resolutions recorded with their source; draft-first flow and all gates intact.