### PR TITLE
feat(site): version badge in the header linked to the latest release

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -23,7 +23,10 @@
   <div class="grain" aria-hidden="true"></div>
 
   <header class="site-head">
-    <a class="wordmark" href="#top">Walden<span class="mark">§</span></a>
+    <div class="brand">
+      <a class="wordmark" href="#top">Walden<span class="mark">§</span></a>
+      <a class="version-tag" id="version-tag" href="https://github.com/andrearaponi/walden/releases/latest" aria-label="Latest release">v0.6.0</a>
+    </div>
     <nav class="nav" aria-label="Primary">
       <a href="#workflow">Workflow</a>
       <a class="nav-cta" href="#howto">How to use<span class="nav-cursor" aria-hidden="true"></span></a>
@@ -857,6 +860,16 @@
   </div>
 
   <script>
+    // version tag — static fallback, refreshed from the latest GitHub release
+    (function () {
+      var tag = document.getElementById('version-tag');
+      if (!tag || !window.fetch) return;
+      fetch('https://api.github.com/repos/andrearaponi/walden/releases/latest')
+        .then(function (r) { return r.ok ? r.json() : null; })
+        .then(function (rel) { if (rel && rel.tag_name) tag.textContent = rel.tag_name; })
+        .catch(function () {});
+    })();
+
     // click-to-copy — restrained micro-interaction
     document.querySelectorAll('.copy').forEach(function (btn) {
       btn.addEventListener('click', function () {

--- a/site/styles.css
+++ b/site/styles.css
@@ -81,6 +81,20 @@ a { color: inherit; }
 }
 .wordmark .mark { color: var(--pine); margin-left: .12em; font-weight: 400; }
 
+.brand { display: flex; align-items: baseline; gap: .8rem; min-width: 0; }
+.version-tag {
+  font-family: var(--mono); font-size: .62rem; font-weight: 500;
+  letter-spacing: .1em;
+  color: var(--ink-mute);
+  text-decoration: none;
+  border: 1px solid var(--rule);
+  border-radius: 3px;
+  padding: .25em .55em;
+  white-space: nowrap;
+  transition: color .2s ease, border-color .2s ease;
+}
+.version-tag:hover { color: var(--pine); border-color: var(--pine); }
+
 .nav { display: flex; gap: clamp(1rem, 3vw, 2.4rem); align-items: baseline; }
 .nav a {
   font-family: var(--mono); font-size: .72rem; font-weight: 500;
@@ -109,7 +123,10 @@ a { color: inherit; }
 @media (prefers-reduced-motion: reduce) { .nav-cursor { animation: none; } }
 
 /* Mobile keeps the two links that matter: the CTA and GitHub. */
-@media (max-width: 620px) { .nav a:not(.nav-gh):not(.nav-cta) { display: none; } }
+@media (max-width: 620px) {
+  .nav a:not(.nav-gh):not(.nav-cta) { display: none; }
+  .version-tag { display: none; }
+}
 
 /* ============================  HERO  ================================== */
 .hero {


### PR DESCRIPTION
## What

A small version badge in the site header, next to the wordmark:

- Static fallback (`v0.6.0`) hardcoded in the markup — visible immediately, works without JS.
- A tiny script refreshes it at runtime from the GitHub API (`releases/latest`): `pages.yml` only redeploys on `site/**` changes, so a purely static badge would go stale on the next release. On fetch failure the fallback stays — never an empty badge.
- Links to the latest release page.
- Styled in the page language: JetBrains Mono, hairline border, 3px radius, baseline-aligned with the wordmark. Hidden below 620px alongside the other secondary nav links (it collided with the "How to use" CTA on narrow viewports).

## Validation

Served the site locally and checked in a real browser: desktop header, 660px (narrowest viewport with the full nav), and 375px mobile. Confirmed the page fetches `releases/latest` (200) and the DOM carries the tag.