### PR TITLE
feat: self-update command with fail-closed verification and skill re-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ walden skill status
 
 `walden skill status` reports where the skill is installed and whether it matches the binary's embedded copy.
 
+### Update
+
+```bash
+walden update                    # update to the latest release and re-sync installed skills
+walden update --check            # report what would change, write nothing
+walden update --version v0.6.0   # pin a release, downgrade, or roll back
+```
+
+`walden update` downloads the release binary for your platform, verifies its SHA-256 checksum against the release's `checksums.txt` (fail-closed — there is no bypass), swaps the executable atomically, and smoke-tests the result, restoring the previous binary if the new one fails to run. It then reinstalls every skill installation it finds, so your agents pick up the embedded skill matching the new binary. Source builds (`walden version` reporting `dev`) refuse to update — rebuild from your clone instead. Networking stays confined to this one explicit command: no other command ever checks for updates or touches the network.
+
 ### Uninstall
 
 ```bash
@@ -190,6 +200,7 @@ walden lesson log --feature user-auth --phase execute \
 | `reconcile <feature> [--json]` | Repair stale approval chains after upstream edits |
 | `lesson log [--json]` | Append a lesson to `.walden/lessons.md` |
 | `version [--json]` | Print build version and schema version |
+| `update [--check] [--version <tag>] [--json]` | Update the binary from GitHub releases and re-sync installed skills |
 
 ## Spec Model
 

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -31,6 +31,7 @@ type commandUsage struct {
 
 var commandUsages = []commandUsage{
 	{"version [--json]", "Print the CLI and schema version"},
+	{"update [--check] [--version <tag>] [--json]", "Update the walden binary from GitHub releases and re-sync installed skills"},
 	{"repo init [--json]", "Initialize Walden in the current repository"},
 	{"feature init <name> [--json]", "Scaffold a new feature spec"},
 	{"status <feature> [--json]", "Show a feature's phase, blockers, and next action"},
@@ -64,6 +65,8 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 0
 	case "version":
 		return runVersion(args[1:], stdout, stderr)
+	case "update":
+		return runUpdate(args[1:], stdout, stderr)
 	case "repo":
 		return runRepo(args[1:], stdout, stderr)
 	case "feature":
@@ -98,7 +101,7 @@ func runVersion(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	result := output.Result{
-		Summary:  fmt.Sprintf("walden %s (schema %s)", Version, "v0beta1"),
+		Summary:  fmt.Sprintf("walden %s (schema %s)", effectiveVersion(), "v0beta1"),
 		ExitCode: 0,
 	}
 

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -1,0 +1,148 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/andrearaponi/walden/internal/output"
+	"github.com/andrearaponi/walden/internal/selfupdate"
+)
+
+// updateOptions builds the production options for an update run. It is a
+// seam so tests can point the flow at local doubles instead of GitHub.
+var updateOptions = func(currentVersion string) (selfupdate.Options, error) {
+	return selfupdate.DefaultOptions(currentVersion)
+}
+
+func runUpdate(args []string, stdout io.Writer, stderr io.Writer) int {
+	jsonMode := false
+	checkMode := false
+	pinned := ""
+
+	for index := 0; index < len(args); index++ {
+		switch args[index] {
+		case "--json":
+			jsonMode = true
+		case "--check":
+			checkMode = true
+		case "--version":
+			if index+1 >= len(args) {
+				_, _ = fmt.Fprintf(stderr, "update --version requires a tag (e.g. --version v0.7.0)\n")
+				return 1
+			}
+			pinned = args[index+1]
+			index++
+		default:
+			_, _ = fmt.Fprintf(stderr, "unknown command: update %s\n\n", strings.Join(args, " "))
+			printUsage(stderr)
+			return 1
+		}
+	}
+
+	// The dev-build guard runs before options are assembled, so a source
+	// build never reaches the network.
+	current := effectiveVersion()
+	if current == "dev" {
+		result := output.Result{
+			Summary:    "cannot update a source build: this binary carries no release version",
+			NextAction: "Rebuild from your clone (./setup.sh) or install a release: curl -fsSL https://raw.githubusercontent.com/andrearaponi/walden/main/install.sh | sh",
+			ExitCode:   1,
+		}
+		return emitUpdateResult(result, jsonMode, stdout, stderr)
+	}
+
+	opts, err := updateOptions(current)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+	opts.TargetTag = pinned
+
+	if checkMode {
+		return runUpdateCheck(opts, jsonMode, stdout, stderr)
+	}
+	return runUpdateApply(opts, jsonMode, stdout, stderr)
+}
+
+func runUpdateCheck(opts selfupdate.Options, jsonMode bool, stdout, stderr io.Writer) int {
+	status, err := selfupdate.Check(opts)
+	if err != nil {
+		return emitUpdateResult(output.Result{Summary: err.Error(), ExitCode: 1}, jsonMode, stdout, stderr)
+	}
+
+	// Check mode is a report, not a gate: exit 0 either way.
+	result := output.Result{
+		Summary: fmt.Sprintf("walden %s is up to date", status.CurrentVersion),
+		Update: &output.UpdateStatus{
+			CurrentVersion:  status.CurrentVersion,
+			TargetVersion:   status.TargetVersion,
+			UpdateAvailable: status.UpdateAvailable,
+		},
+		ExitCode: 0,
+	}
+	if status.UpdateAvailable {
+		result.Summary = fmt.Sprintf("update available: %s -> %s", status.CurrentVersion, status.TargetVersion)
+		result.NextAction = fmt.Sprintf("Run `walden update` to install %s", status.TargetVersion)
+	}
+	return emitUpdateResult(result, jsonMode, stdout, stderr)
+}
+
+func runUpdateApply(opts selfupdate.Options, jsonMode bool, stdout, stderr io.Writer) int {
+	report, err := selfupdate.Apply(context.Background(), opts)
+	if err != nil {
+		return emitUpdateResult(output.Result{Summary: err.Error(), ExitCode: 1}, jsonMode, stdout, stderr)
+	}
+
+	if report.AlreadyUpToDate {
+		result := output.Result{
+			Summary: fmt.Sprintf("walden %s is already up to date", report.InstalledVersion),
+			Update: &output.UpdateStatus{
+				CurrentVersion: report.PreviousVersion,
+				TargetVersion:  report.InstalledVersion,
+			},
+			ExitCode: 0,
+		}
+		return emitUpdateResult(result, jsonMode, stdout, stderr)
+	}
+
+	changed := []string{report.ExecutablePath}
+	for _, skill := range report.SyncedSkills {
+		changed = append(changed, skill.Path)
+	}
+
+	result := output.Result{
+		Summary: fmt.Sprintf("walden updated: %s -> %s", report.PreviousVersion, report.InstalledVersion),
+		Update: &output.UpdateStatus{
+			CurrentVersion:  report.PreviousVersion,
+			TargetVersion:   report.InstalledVersion,
+			UpdateAvailable: true,
+			Applied:         true,
+		},
+		ChangedFiles: changed,
+		Warnings:     report.Warnings,
+		NextAction:   fmt.Sprintf("Release notes: %s", report.ReleaseNotesURL),
+		ExitCode:     0,
+	}
+	return emitUpdateResult(result, jsonMode, stdout, stderr)
+}
+
+// emitUpdateResult renders a result following the repo convention: JSON goes
+// to stdout with ok reflecting the exit code, text errors go to stderr.
+func emitUpdateResult(result output.Result, jsonMode bool, stdout, stderr io.Writer) int {
+	if jsonMode {
+		if err := output.PrintJSON(stdout, "update", result); err != nil {
+			_, _ = fmt.Fprintf(stderr, "render json output: %v\n", err)
+			return 1
+		}
+		return result.ExitCode
+	}
+
+	if result.ExitCode != 0 {
+		output.PrintText(stderr, result)
+		return result.ExitCode
+	}
+	output.PrintText(stdout, result)
+	return 0
+}

--- a/internal/app/update_test.go
+++ b/internal/app/update_test.go
@@ -1,0 +1,197 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/output"
+	"github.com/andrearaponi/walden/internal/selfupdate"
+	"github.com/andrearaponi/walden/internal/selfupdate/updatetest"
+)
+
+// stubUpdateEnvironment pins the effective version and wires updateOptions
+// to an offline release fixture serving latestTag with binaryContent.
+func stubUpdateEnvironment(t *testing.T, latestTag, currentVersion string, binaryContent []byte) updatetest.Fixture {
+	t.Helper()
+
+	fixture := updatetest.New(t, latestTag, currentVersion, binaryContent)
+
+	restoreVersion := Version
+	restoreOptions := updateOptions
+	t.Cleanup(func() {
+		Version = restoreVersion
+		updateOptions = restoreOptions
+	})
+
+	Version = currentVersion
+	updateOptions = func(string) (selfupdate.Options, error) {
+		return fixture.Options, nil
+	}
+	return fixture
+}
+
+func TestRunUpdateDevGuardRefusesBeforeAnyNetworkUse(t *testing.T) {
+	restoreVersion := Version
+	restoreSeam := buildInfoVersion
+	restoreOptions := updateOptions
+	t.Cleanup(func() {
+		Version = restoreVersion
+		buildInfoVersion = restoreSeam
+		updateOptions = restoreOptions
+	})
+
+	Version = "dev"
+	buildInfoVersion = func() string { return "(devel)" }
+	updateOptions = func(string) (selfupdate.Options, error) {
+		t.Fatal("dev guard must fire before options (and any network) are touched")
+		return selfupdate.Options{}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"update"}, &stdout, &stderr)
+
+	if exitCode == 0 {
+		t.Fatal("update accepted a dev build")
+	}
+	if !strings.Contains(stderr.String(), "source build") {
+		t.Fatalf("stderr %q does not direct to the source-build workflow", stderr.String())
+	}
+}
+
+func TestRunUpdateRejectsUnknownFlags(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"update", "--no-verify"}, &stdout, &stderr)
+
+	if exitCode == 0 {
+		t.Fatal("update accepted an unknown flag")
+	}
+	if !strings.Contains(stderr.String(), "--no-verify") {
+		t.Fatalf("stderr %q does not name the rejected flag", stderr.String())
+	}
+}
+
+func TestRunUpdateVersionFlagRequiresTag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"update", "--version"}, &stdout, &stderr)
+
+	if exitCode == 0 {
+		t.Fatal("update accepted --version without a tag")
+	}
+	if !strings.Contains(stderr.String(), "--version") {
+		t.Fatalf("stderr %q does not explain the --version usage", stderr.String())
+	}
+}
+
+func TestRunUpdateCheckExitsZeroAndWritesNothing(t *testing.T) {
+	cases := []struct {
+		name      string
+		latestTag string
+		wantWords string
+	}{
+		{name: "update available", latestTag: "v0.7.0", wantWords: "v0.7.0"},
+		{name: "already current", latestTag: "v0.5.0", wantWords: "up to date"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := stubUpdateEnvironment(t, tc.latestTag, "v0.5.0", []byte("unused"))
+
+			var stdout, stderr bytes.Buffer
+			exitCode := Run([]string{"update", "--check"}, &stdout, &stderr)
+
+			if exitCode != 0 {
+				t.Fatalf("check mode exited %d, want 0 (stderr: %s)", exitCode, stderr.String())
+			}
+			if !strings.Contains(stdout.String(), tc.wantWords) {
+				t.Fatalf("check output %q does not mention %q", stdout.String(), tc.wantWords)
+			}
+
+			content, err := os.ReadFile(fixture.Executable)
+			if err != nil {
+				t.Fatalf("read executable: %v", err)
+			}
+			if string(content) != "OLD-BINARY" {
+				t.Fatal("check mode modified the executable")
+			}
+			entries, _ := os.ReadDir(filepath.Dir(fixture.Executable))
+			for _, entry := range entries {
+				if strings.HasPrefix(entry.Name(), ".walden-") {
+					t.Fatalf("check mode left artifact %s", entry.Name())
+				}
+			}
+		})
+	}
+}
+
+func TestRunUpdateCheckEmitsJSONEnvelope(t *testing.T) {
+	stubUpdateEnvironment(t, "v0.7.0", "v0.5.0", []byte("unused"))
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"update", "--check", "--json"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("check mode exited %d, want 0", exitCode)
+	}
+
+	var envelope output.Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if envelope.Command != "update" || !envelope.OK {
+		t.Fatalf("envelope = command %q ok %t, want update/true", envelope.Command, envelope.OK)
+	}
+
+	update := envelope.Result.Update
+	if update == nil {
+		t.Fatal("envelope carries no update block")
+	}
+	if update.CurrentVersion != "v0.5.0" || update.TargetVersion != "v0.7.0" || !update.UpdateAvailable || update.Applied {
+		t.Fatalf("update block = %+v, want v0.5.0 -> v0.7.0 available, not applied", update)
+	}
+}
+
+func TestRunUpdateAppliesAndReportsJSON(t *testing.T) {
+	newBinary := []byte("#!/bin/sh\necho \"walden v0.7.0 (schema v0beta1)\"\n")
+	fixture := stubUpdateEnvironment(t, "v0.7.0", "v0.5.0", newBinary)
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"update", "--json"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("update exited %d, want 0 (stderr: %s)", exitCode, stderr.String())
+	}
+
+	var envelope output.Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+
+	update := envelope.Result.Update
+	if update == nil || !update.Applied || update.TargetVersion != "v0.7.0" {
+		t.Fatalf("update block = %+v, want applied v0.7.0", update)
+	}
+	if len(envelope.Result.ChangedFiles) == 0 || envelope.Result.ChangedFiles[0] == "" {
+		t.Fatalf("changed files = %v, want the executable path", envelope.Result.ChangedFiles)
+	}
+	if !strings.Contains(envelope.Result.NextAction, "/releases/tag/v0.7.0") {
+		t.Fatalf("next action %q does not carry the release notes URL", envelope.Result.NextAction)
+	}
+
+	installed, _ := os.ReadFile(fixture.Executable)
+	if string(installed) != string(newBinary) {
+		t.Fatal("executable does not contain the new release binary")
+	}
+}
+
+func TestRunUpdateUsageListsCommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	Run([]string{"--help"}, &stdout, &stderr)
+
+	if !strings.Contains(stdout.String(), "update [--check] [--version <tag>] [--json]") {
+		t.Fatalf("usage does not list the update command: %s", stdout.String())
+	}
+}

--- a/internal/app/version.go
+++ b/internal/app/version.go
@@ -1,0 +1,48 @@
+package app
+
+import (
+	"runtime/debug"
+	"strconv"
+	"strings"
+)
+
+// buildInfoVersion reads the main module version from the Go build info. It
+// is a seam so tests can simulate go-install and source builds.
+var buildInfoVersion = func() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	return info.Main.Version
+}
+
+// effectiveVersion resolves the version this binary runs as. Release builds
+// carry it via -ldflags; go-install builds carry it as the module version in
+// the build info; anything else is a source build and reports "dev".
+func effectiveVersion() string {
+	if Version != "dev" {
+		return Version
+	}
+	if v := buildInfoVersion(); isReleaseVersion(v) {
+		return v
+	}
+	return "dev"
+}
+
+// isReleaseVersion reports whether v is an exact release tag of the form
+// vMAJOR.MINOR.PATCH. Pseudo-versions and "(devel)" do not qualify.
+func isReleaseVersion(v string) bool {
+	if !strings.HasPrefix(v, "v") {
+		return false
+	}
+	parts := strings.Split(v[1:], ".")
+	if len(parts) != 3 {
+		return false
+	}
+	for _, part := range parts {
+		if _, err := strconv.Atoi(part); err != nil || part == "" {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/app/version_effective_test.go
+++ b/internal/app/version_effective_test.go
@@ -1,0 +1,88 @@
+package app
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestEffectiveVersionResolution(t *testing.T) {
+	cases := []struct {
+		name         string
+		ldflags      string
+		buildVersion string
+		want         string
+	}{
+		{
+			name:         "ldflags version wins over build info",
+			ldflags:      "v0.9.9",
+			buildVersion: "v0.1.0",
+			want:         "v0.9.9",
+		},
+		{
+			name:         "go-install module version adopted when ldflags unset",
+			ldflags:      "dev",
+			buildVersion: "v0.6.0",
+			want:         "v0.6.0",
+		},
+		{
+			name:         "source build reports dev",
+			ldflags:      "dev",
+			buildVersion: "(devel)",
+			want:         "dev",
+		},
+		{
+			name:         "missing build info reports dev",
+			ldflags:      "dev",
+			buildVersion: "",
+			want:         "dev",
+		},
+		{
+			name:         "pseudo-version is not a release tag",
+			ldflags:      "dev",
+			buildVersion: "v0.6.1-0.20260709123456-abcdef123456",
+			want:         "dev",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			restoreVersion := Version
+			restoreSeam := buildInfoVersion
+			t.Cleanup(func() {
+				Version = restoreVersion
+				buildInfoVersion = restoreSeam
+			})
+
+			Version = tc.ldflags
+			buildInfoVersion = func() string { return tc.buildVersion }
+
+			if got := effectiveVersion(); got != tc.want {
+				t.Fatalf("effectiveVersion() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveVersionBacksVersionCommand(t *testing.T) {
+	restoreVersion := Version
+	restoreSeam := buildInfoVersion
+	t.Cleanup(func() {
+		Version = restoreVersion
+		buildInfoVersion = restoreSeam
+	})
+
+	Version = "dev"
+	buildInfoVersion = func() string { return "v0.6.0" }
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := Run([]string{"version"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "v0.6.0") {
+		t.Fatalf("expected version output to adopt build info version, got %q", stdout.String())
+	}
+}

--- a/internal/output/result.go
+++ b/internal/output/result.go
@@ -32,8 +32,17 @@ type Result struct {
 	Coverage              *CoverageReport   `json:"coverage,omitempty"`
 	EARSDistribution      *EARSDistribution `json:"ears_distribution,omitempty"`
 	Skills                []SkillStatus     `json:"skills,omitempty"`
+	Update                *UpdateStatus     `json:"update,omitempty"`
 	Content               string            `json:"content,omitempty"`
 	ExitCode              int               `json:"exit_code"`
+}
+
+// UpdateStatus is the JSON output view of an update check or run.
+type UpdateStatus struct {
+	CurrentVersion  string `json:"current_version"`
+	TargetVersion   string `json:"target_version"`
+	UpdateAvailable bool   `json:"update_available"`
+	Applied         bool   `json:"applied"`
 }
 
 // SkillStatus is the shared output view for one skill installation slot.
@@ -207,6 +216,11 @@ func PrintText(w io.Writer, result Result) {
 			}
 			_, _ = fmt.Fprintln(w)
 		}
+	}
+
+	if result.Update != nil {
+		_, _ = fmt.Fprintf(w, "Update: current=%s target=%s available=%t applied=%t\n",
+			result.Update.CurrentVersion, result.Update.TargetVersion, result.Update.UpdateAvailable, result.Update.Applied)
 	}
 
 	if len(result.Blockers) > 0 {

--- a/internal/output/update_block_test.go
+++ b/internal/output/update_block_test.go
@@ -1,0 +1,74 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestUpdateBlockMarshalsWhenSet(t *testing.T) {
+	var buffer bytes.Buffer
+	result := Result{
+		Summary: "update check",
+		Update: &UpdateStatus{
+			CurrentVersion:  "v0.5.0",
+			TargetVersion:   "v0.7.0",
+			UpdateAvailable: true,
+			Applied:         false,
+		},
+		ExitCode: 0,
+	}
+
+	if err := PrintJSON(&buffer, "update", result); err != nil {
+		t.Fatalf("PrintJSON returned error: %v", err)
+	}
+
+	var envelope struct {
+		Command string `json:"command"`
+		Result  struct {
+			Update map[string]any `json:"update"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(buffer.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if envelope.Command != "update" {
+		t.Fatalf("command = %q, want update", envelope.Command)
+	}
+
+	update := envelope.Result.Update
+	if update["current_version"] != "v0.5.0" || update["target_version"] != "v0.7.0" {
+		t.Fatalf("update block = %v, want current_version/target_version populated", update)
+	}
+	if update["update_available"] != true || update["applied"] != false {
+		t.Fatalf("update block = %v, want update_available=true applied=false", update)
+	}
+}
+
+func TestUpdateBlockOmittedWhenAbsent(t *testing.T) {
+	var buffer bytes.Buffer
+	if err := PrintJSON(&buffer, "status", Result{Summary: "x", ExitCode: 0}); err != nil {
+		t.Fatalf("PrintJSON returned error: %v", err)
+	}
+	if strings.Contains(buffer.String(), "\"update\"") {
+		t.Fatalf("update block leaked into an envelope that did not set it: %s", buffer.String())
+	}
+}
+
+func TestUpdateBlockRendersInText(t *testing.T) {
+	var buffer bytes.Buffer
+	PrintText(&buffer, Result{
+		Summary: "update check",
+		Update: &UpdateStatus{
+			CurrentVersion:  "v0.5.0",
+			TargetVersion:   "v0.7.0",
+			UpdateAvailable: true,
+		},
+	})
+
+	out := buffer.String()
+	if !strings.Contains(out, "v0.5.0") || !strings.Contains(out, "v0.7.0") {
+		t.Fatalf("text output does not render the update versions: %q", out)
+	}
+}

--- a/internal/selfupdate/apply.go
+++ b/internal/selfupdate/apply.go
@@ -1,0 +1,109 @@
+package selfupdate
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/andrearaponi/walden/internal/skilldist"
+)
+
+// SkillSync is one skill installation re-synced by an update.
+type SkillSync struct {
+	Agent string
+	Scope string
+	Path  string
+}
+
+// Report describes a completed or short-circuited update run.
+type Report struct {
+	PreviousVersion  string
+	InstalledVersion string
+	ExecutablePath   string
+	ReleaseNotesURL  string
+	SyncedSkills     []SkillSync
+	Warnings         []string
+	AlreadyUpToDate  bool
+}
+
+// Apply runs the full update flow: resolve, compare, snapshot skills, probe,
+// download, verify, swap, smoke-test (with rollback), re-sync skills, report.
+// Every abort path cleans its staging file; after the swap the previous
+// binary survives as a backup until the smoke test passes.
+func Apply(ctx context.Context, opts Options) (Report, error) {
+	status, err := Check(opts)
+	if err != nil {
+		return Report{}, err
+	}
+	if !status.UpdateAvailable {
+		return Report{
+			PreviousVersion:  status.CurrentVersion,
+			InstalledVersion: status.CurrentVersion,
+			AlreadyUpToDate:  true,
+		}, nil
+	}
+
+	executable := opts.ExecutablePath
+	if executable == "" {
+		executable, err = os.Executable()
+		if err != nil {
+			return Report{}, fmt.Errorf("locate running binary: %w", err)
+		}
+	}
+	executable, err = resolveExecutable(executable)
+	if err != nil {
+		return Report{}, err
+	}
+
+	// Snapshot before any mutation: the new binary reinstalls these slots.
+	slots := snapshotSkillSlots(skilldist.Options{
+		Version: opts.CurrentVersion,
+		WorkDir: opts.WorkDir,
+		Env:     opts.Env,
+	})
+
+	staged, err := probeStaging(executable)
+	if err != nil {
+		return Report{}, err
+	}
+
+	asset := assetName(status.TargetVersion, opts.OS, opts.Arch)
+	digest, err := downloadAsset(opts.HTTPClient, opts.BaseURL, status.TargetVersion, asset, staged)
+	if err != nil {
+		_ = os.Remove(staged)
+		return Report{}, err
+	}
+
+	if err := verifyChecksum(opts.HTTPClient, opts.BaseURL, status.TargetVersion, asset, staged, digest); err != nil {
+		return Report{}, err
+	}
+
+	backup, err := swapExecutable(staged, executable)
+	if err != nil {
+		_ = os.Remove(staged)
+		return Report{}, err
+	}
+
+	if err := smokeTestAndFinalize(ctx, opts.Runner, executable, backup, status.TargetVersion); err != nil {
+		return Report{}, err
+	}
+
+	synced, warnings := resyncSkills(ctx, opts.Runner, executable, status.TargetVersion, slots)
+
+	report := Report{
+		PreviousVersion:  status.CurrentVersion,
+		InstalledVersion: status.TargetVersion,
+		ExecutablePath:   executable,
+		ReleaseNotesURL:  fmt.Sprintf("%s/releases/tag/%s", opts.BaseURL, status.TargetVersion),
+		SyncedSkills:     make([]SkillSync, 0, len(synced)),
+		Warnings:         warnings,
+	}
+	for _, slot := range synced {
+		report.SyncedSkills = append(report.SyncedSkills, SkillSync{
+			Agent: slot.Agent,
+			Scope: string(slot.Scope),
+			Path:  slot.Path,
+		})
+	}
+	return report, nil
+}

--- a/internal/selfupdate/apply_test.go
+++ b/internal/selfupdate/apply_test.go
@@ -1,0 +1,175 @@
+package selfupdate
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/shell"
+	"github.com/andrearaponi/walden/internal/skilldist"
+)
+
+// releaseServer serves a complete fake release: latest redirect, one platform
+// asset containing binaryContent, and a checksums.txt with its real digest.
+func releaseServer(t *testing.T, tag string, binaryContent []byte) *httptest.Server {
+	t.Helper()
+	asset := assetName(tag, runtime.GOOS, runtime.GOARCH)
+	digest := sha256.Sum256(binaryContent)
+	checksums := fmt.Sprintf("%s  %s\n", hex.EncodeToString(digest[:]), asset)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/releases/tag/"+tag, http.StatusFound)
+	})
+	mux.HandleFunc("/releases/download/"+tag+"/"+asset, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(binaryContent)
+	})
+	mux.HandleFunc("/releases/download/"+tag+"/checksums.txt", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(checksums))
+	})
+	return httptest.NewServer(mux)
+}
+
+// applyFixture assembles an isolated install: a fake current executable, a
+// home with the claude skill installed, and Options wired to the test server.
+func applyFixture(t *testing.T, server *httptest.Server) (Options, string, string) {
+	t.Helper()
+
+	installDir := t.TempDir()
+	executable := filepath.Join(installDir, "walden")
+	if err := os.WriteFile(executable, []byte("OLD-BINARY"), 0o755); err != nil {
+		t.Fatalf("seed current executable: %v", err)
+	}
+
+	home := t.TempDir()
+	skillPath := filepath.Join(home, ".claude", "skills", "walden", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
+		t.Fatalf("create skill dir: %v", err)
+	}
+	if err := os.WriteFile(skillPath, []byte("skill body\n"), 0o644); err != nil {
+		t.Fatalf("seed skill file: %v", err)
+	}
+
+	opts := Options{
+		CurrentVersion: "v0.5.0",
+		BaseURL:        server.URL,
+		OS:             runtime.GOOS,
+		Arch:           runtime.GOARCH,
+		ExecutablePath: executable,
+		WorkDir:        t.TempDir(),
+		Env:            skilldist.Env{Home: home},
+		HTTPClient:     server.Client(),
+		Runner:         shell.NewExecRunner(),
+	}
+	return opts, executable, installDir
+}
+
+func assertNoUpdateArtifacts(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read install dir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".walden-update-") || strings.HasPrefix(entry.Name(), ".walden-backup-") {
+			t.Fatalf("leftover update artifact %s", entry.Name())
+		}
+	}
+}
+
+func TestApplyEndToEndInstallsAndSyncs(t *testing.T) {
+	newBinary := []byte("#!/bin/sh\necho \"walden v0.7.0 (schema v0beta1)\"\n")
+	server := releaseServer(t, "v0.7.0", newBinary)
+	defer server.Close()
+
+	opts, executable, installDir := applyFixture(t, server)
+
+	report, err := Apply(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Apply returned error: %v", err)
+	}
+
+	installed, readErr := os.ReadFile(executable)
+	if readErr != nil {
+		t.Fatalf("read installed binary: %v", readErr)
+	}
+	if string(installed) != string(newBinary) {
+		t.Fatalf("installed binary does not match the release asset")
+	}
+	if info, _ := os.Stat(executable); info.Mode().Perm() != 0o755 {
+		t.Fatalf("installed binary mode = %v, want 0755", info.Mode().Perm())
+	}
+
+	if report.PreviousVersion != "v0.5.0" || report.InstalledVersion != "v0.7.0" {
+		t.Fatalf("report versions = %q -> %q, want v0.5.0 -> v0.7.0", report.PreviousVersion, report.InstalledVersion)
+	}
+	if !strings.HasSuffix(report.ReleaseNotesURL, "/releases/tag/v0.7.0") {
+		t.Fatalf("release notes URL = %q, want .../releases/tag/v0.7.0", report.ReleaseNotesURL)
+	}
+	if len(report.SyncedSkills) != 1 || report.SyncedSkills[0].Agent != "claude" {
+		t.Fatalf("synced skills = %+v, want the claude slot", report.SyncedSkills)
+	}
+	if len(report.Warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", report.Warnings)
+	}
+	if report.AlreadyUpToDate {
+		t.Fatal("report claims already up to date after an install")
+	}
+
+	assertNoUpdateArtifacts(t, installDir)
+}
+
+func TestApplyRollsBackWhenSmokeTestFails(t *testing.T) {
+	brokenBinary := []byte("#!/bin/sh\nexit 1\n")
+	server := releaseServer(t, "v0.7.0", brokenBinary)
+	defer server.Close()
+
+	opts, executable, installDir := applyFixture(t, server)
+
+	_, err := Apply(context.Background(), opts)
+	if err == nil {
+		t.Fatal("Apply accepted a binary that fails its smoke test")
+	}
+	if !strings.Contains(err.Error(), "restored") {
+		t.Fatalf("error %q does not state the previous binary was restored", err)
+	}
+
+	content, readErr := os.ReadFile(executable)
+	if readErr != nil {
+		t.Fatalf("read executable: %v", readErr)
+	}
+	if string(content) != "OLD-BINARY" {
+		t.Fatalf("executable = %q, want restored OLD-BINARY", content)
+	}
+
+	assertNoUpdateArtifacts(t, installDir)
+}
+
+func TestApplyAlreadyUpToDateMakesNoChanges(t *testing.T) {
+	server := releaseServer(t, "v0.5.0", []byte("irrelevant"))
+	defer server.Close()
+
+	opts, executable, installDir := applyFixture(t, server)
+
+	report, err := Apply(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Apply returned error: %v", err)
+	}
+	if !report.AlreadyUpToDate {
+		t.Fatalf("report = %+v, want AlreadyUpToDate", report)
+	}
+
+	content, _ := os.ReadFile(executable)
+	if string(content) != "OLD-BINARY" {
+		t.Fatalf("executable modified on an up-to-date install: %q", content)
+	}
+	assertNoUpdateArtifacts(t, installDir)
+}

--- a/internal/selfupdate/checksum.go
+++ b/internal/selfupdate/checksum.go
@@ -1,0 +1,58 @@
+package selfupdate
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// verifyChecksum fetches the release's checksums.txt and verifies the staged
+// asset's digest against it. Verification fails closed: a missing checksums
+// file, a missing entry, or a digest mismatch aborts the update and removes
+// the staged file. There is deliberately no bypass.
+func verifyChecksum(client *http.Client, baseURL, tag, asset, stagedPath, actualDigest string) error {
+	fail := func(err error) error {
+		_ = os.Remove(stagedPath)
+		return err
+	}
+
+	expected, err := fetchExpectedDigest(client, baseURL, tag, asset)
+	if err != nil {
+		return fail(err)
+	}
+	if expected != actualDigest {
+		return fail(fmt.Errorf("checksum mismatch for %s: expected %s, actual %s", asset, expected, actualDigest))
+	}
+	return nil
+}
+
+// fetchExpectedDigest downloads checksums.txt for tag and returns the digest
+// recorded for asset. Lines follow the sha256sum format: "<digest>  <name>".
+func fetchExpectedDigest(client *http.Client, baseURL, tag, asset string) (string, error) {
+	checksumsURL := fmt.Sprintf("%s/releases/download/%s/checksums.txt", baseURL, tag)
+
+	resp, err := client.Get(checksumsURL)
+	if err != nil {
+		return "", fmt.Errorf("fetch checksums.txt for release %s: %w", tag, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("release %s does not provide checksums.txt (%s); releases up to v0.4.0 predate checksums and cannot be installed by walden update", tag, resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("fetch checksums.txt for release %s: %w", tag, err)
+	}
+
+	for _, line := range strings.Split(string(body), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[1] == asset {
+			return fields[0], nil
+		}
+	}
+	return "", fmt.Errorf("no checksums.txt entry for %s in release %s", asset, tag)
+}

--- a/internal/selfupdate/checksum_test.go
+++ b/internal/selfupdate/checksum_test.go
@@ -1,0 +1,103 @@
+package selfupdate
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testAsset = "walden-v0.7.0-linux-amd64"
+
+func checksumServer(t *testing.T, body string, status int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/releases/download/v0.7.0/checksums.txt" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func stagedFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "staging")
+	if err := os.WriteFile(path, []byte("staged"), 0o600); err != nil {
+		t.Fatalf("seed staging file: %v", err)
+	}
+	return path
+}
+
+func TestChecksumVerifiesMatchingEntry(t *testing.T) {
+	digest := strings.Repeat("ab", 32)
+	body := fmt.Sprintf("%s  walden-v0.7.0-darwin-arm64\n%s  %s\n", strings.Repeat("cd", 32), digest, testAsset)
+	server := checksumServer(t, body, http.StatusOK)
+	defer server.Close()
+
+	staged := stagedFile(t)
+	if err := verifyChecksum(server.Client(), server.URL, "v0.7.0", testAsset, staged, digest); err != nil {
+		t.Fatalf("verifyChecksum rejected a matching digest: %v", err)
+	}
+	if _, err := os.Stat(staged); err != nil {
+		t.Fatalf("staging file removed despite successful verification: %v", err)
+	}
+}
+
+func TestChecksumMissingFileFailsClosed(t *testing.T) {
+	server := checksumServer(t, "not found", http.StatusNotFound)
+	defer server.Close()
+
+	staged := stagedFile(t)
+	err := verifyChecksum(server.Client(), server.URL, "v0.7.0", testAsset, staged, strings.Repeat("ab", 32))
+	if err == nil {
+		t.Fatal("verifyChecksum accepted a release without checksums.txt")
+	}
+	if !strings.Contains(err.Error(), "checksums.txt") {
+		t.Fatalf("error %q does not name checksums.txt", err)
+	}
+	if _, statErr := os.Stat(staged); !os.IsNotExist(statErr) {
+		t.Fatal("staging file survived a fail-closed abort")
+	}
+}
+
+func TestChecksumMissingEntryFailsClosed(t *testing.T) {
+	body := fmt.Sprintf("%s  walden-v0.7.0-darwin-arm64\n", strings.Repeat("cd", 32))
+	server := checksumServer(t, body, http.StatusOK)
+	defer server.Close()
+
+	staged := stagedFile(t)
+	err := verifyChecksum(server.Client(), server.URL, "v0.7.0", testAsset, staged, strings.Repeat("ab", 32))
+	if err == nil {
+		t.Fatal("verifyChecksum accepted a checksums.txt without the asset entry")
+	}
+	if !strings.Contains(err.Error(), testAsset) {
+		t.Fatalf("error %q does not name the asset", err)
+	}
+	if _, statErr := os.Stat(staged); !os.IsNotExist(statErr) {
+		t.Fatal("staging file survived a fail-closed abort")
+	}
+}
+
+func TestChecksumMismatchReportsBothDigests(t *testing.T) {
+	expected := strings.Repeat("ab", 32)
+	actual := strings.Repeat("ef", 32)
+	body := fmt.Sprintf("%s  %s\n", expected, testAsset)
+	server := checksumServer(t, body, http.StatusOK)
+	defer server.Close()
+
+	staged := stagedFile(t)
+	err := verifyChecksum(server.Client(), server.URL, "v0.7.0", testAsset, staged, actual)
+	if err == nil {
+		t.Fatal("verifyChecksum accepted a digest mismatch")
+	}
+	if !strings.Contains(err.Error(), expected) || !strings.Contains(err.Error(), actual) {
+		t.Fatalf("error %q does not report both digests", err)
+	}
+	if _, statErr := os.Stat(staged); !os.IsNotExist(statErr) {
+		t.Fatal("staging file survived a fail-closed abort")
+	}
+}

--- a/internal/selfupdate/download.go
+++ b/internal/selfupdate/download.go
@@ -1,0 +1,51 @@
+package selfupdate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+// assetName builds the release asset name for a platform, mirroring the
+// layout produced by the release workflow: walden-{tag}-{os}-{arch}.
+func assetName(tag, goos, goarch string) string {
+	return fmt.Sprintf("walden-%s-%s-%s", tag, goos, goarch)
+}
+
+// downloadAsset streams the release asset for tag into destPath and returns
+// the hex SHA-256 digest of the written bytes. The file is created only
+// after the server responds successfully, so failed downloads leave nothing
+// behind.
+func downloadAsset(client *http.Client, baseURL, tag, asset, destPath string) (string, error) {
+	assetURL := fmt.Sprintf("%s/releases/download/%s/%s", baseURL, tag, asset)
+
+	resp, err := client.Get(assetURL)
+	if err != nil {
+		return "", fmt.Errorf("download %s from release %s: %w", asset, tag, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download %s from release %s: %s (check that the release exists and ships this platform)", asset, tag, resp.Status)
+	}
+
+	file, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("stage %s: %w", asset, err)
+	}
+
+	hash := sha256.New()
+	_, copyErr := io.Copy(file, io.TeeReader(resp.Body, hash))
+	closeErr := file.Close()
+	if copyErr != nil {
+		return "", fmt.Errorf("download %s from release %s: %w", asset, tag, copyErr)
+	}
+	if closeErr != nil {
+		return "", fmt.Errorf("stage %s: %w", asset, closeErr)
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}

--- a/internal/selfupdate/download_test.go
+++ b/internal/selfupdate/download_test.go
@@ -1,0 +1,84 @@
+package selfupdate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDownloadAssetNameMatchesReleaseLayout(t *testing.T) {
+	if got := assetName("v0.7.0", "darwin", "arm64"); got != "walden-v0.7.0-darwin-arm64" {
+		t.Fatalf("assetName = %q, want walden-v0.7.0-darwin-arm64", got)
+	}
+}
+
+func TestDownloadStreamsAssetAndHashes(t *testing.T) {
+	payload := []byte("fake-release-binary-bytes")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/releases/download/v0.7.0/walden-v0.7.0-linux-amd64" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	dest := filepath.Join(t.TempDir(), "staging")
+	digest, err := downloadAsset(server.Client(), server.URL, "v0.7.0", "walden-v0.7.0-linux-amd64", dest)
+	if err != nil {
+		t.Fatalf("downloadAsset returned error: %v", err)
+	}
+
+	wantDigest := sha256.Sum256(payload)
+	if digest != hex.EncodeToString(wantDigest[:]) {
+		t.Fatalf("digest = %q, want %q", digest, hex.EncodeToString(wantDigest[:]))
+	}
+
+	written, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read staged file: %v", err)
+	}
+	if string(written) != string(payload) {
+		t.Fatalf("staged content = %q, want %q", written, payload)
+	}
+}
+
+func TestDownloadFailureNamesAssetAndRelease(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	dest := filepath.Join(t.TempDir(), "staging")
+	_, err := downloadAsset(server.Client(), server.URL, "v0.7.0", "walden-v0.7.0-linux-amd64", dest)
+	if err == nil {
+		t.Fatal("downloadAsset accepted a missing asset")
+	}
+	if !strings.Contains(err.Error(), "walden-v0.7.0-linux-amd64") || !strings.Contains(err.Error(), "v0.7.0") {
+		t.Fatalf("error %q does not name the asset and the release", err)
+	}
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Fatalf("staging file created despite failed download")
+	}
+}
+
+func TestDownloadSurfacesTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	client := &http.Client{Timeout: 50 * time.Millisecond}
+	dest := filepath.Join(t.TempDir(), "staging")
+	_, err := downloadAsset(client, server.URL, "v0.7.0", "walden-v0.7.0-linux-amd64", dest)
+	if err == nil {
+		t.Fatal("downloadAsset did not surface the client timeout")
+	}
+	if !strings.Contains(err.Error(), "walden-v0.7.0-linux-amd64") {
+		t.Fatalf("error %q does not name the asset", err)
+	}
+}

--- a/internal/selfupdate/resolve.go
+++ b/internal/selfupdate/resolve.go
@@ -1,0 +1,92 @@
+// Package selfupdate resolves, downloads, verifies, and installs Walden
+// release binaries, then re-syncs installed skills through the new binary.
+// It is the only package in the module that talks to the network, and only
+// on explicit invocation of the update command.
+package selfupdate
+
+import (
+	"fmt"
+	"net/http"
+	"path"
+	"strconv"
+	"strings"
+)
+
+// releaseTag is a parsed vMAJOR.MINOR.PATCH release tag.
+type releaseTag struct {
+	major, minor, patch int
+}
+
+// parseReleaseTag parses a strict vMAJOR.MINOR.PATCH tag. Pseudo-versions,
+// pre-release suffixes, and bare version numbers are rejected.
+func parseReleaseTag(tag string) (releaseTag, error) {
+	formatErr := fmt.Errorf("invalid release tag %q: expected vMAJOR.MINOR.PATCH (e.g. v0.7.0)", tag)
+
+	if !strings.HasPrefix(tag, "v") {
+		return releaseTag{}, formatErr
+	}
+	parts := strings.Split(tag[1:], ".")
+	if len(parts) != 3 {
+		return releaseTag{}, formatErr
+	}
+
+	numbers := make([]int, 3)
+	for i, part := range parts {
+		value, err := strconv.Atoi(part)
+		if err != nil || value < 0 {
+			return releaseTag{}, formatErr
+		}
+		numbers[i] = value
+	}
+	return releaseTag{numbers[0], numbers[1], numbers[2]}, nil
+}
+
+// less reports whether t precedes other in numeric release order.
+func (t releaseTag) less(other releaseTag) bool {
+	if t.major != other.major {
+		return t.major < other.major
+	}
+	if t.minor != other.minor {
+		return t.minor < other.minor
+	}
+	return t.patch < other.patch
+}
+
+// resolveTarget returns the release tag to install: the pinned tag when set
+// (validated, no network), otherwise the tag the releases/latest redirect
+// points at. The GitHub REST API is never consulted: following the redirect
+// avoids its unauthenticated rate limit.
+func resolveTarget(client *http.Client, baseURL, pinned string) (string, error) {
+	if pinned != "" {
+		if _, err := parseReleaseTag(pinned); err != nil {
+			return "", err
+		}
+		return pinned, nil
+	}
+
+	// Copy the client so stopping at the first redirect does not leak into
+	// the caller's client, which downloads assets through real redirects.
+	probe := *client
+	probe.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	latestURL := baseURL + "/releases/latest"
+	resp, err := probe.Get(latestURL)
+	if err != nil {
+		return "", fmt.Errorf("resolve latest release from %s: %w (pin a release explicitly with --version <tag>)", latestURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	location := resp.Header.Get("Location")
+	tag := path.Base(location)
+	if location == "" || parseTagFails(tag) {
+		return "", fmt.Errorf("could not resolve the latest release tag from %s (got %q); pin a release explicitly with --version <tag>", latestURL, location)
+	}
+	return tag, nil
+}
+
+func parseTagFails(tag string) bool {
+	_, err := parseReleaseTag(tag)
+	return err != nil
+}

--- a/internal/selfupdate/resolve_target_test.go
+++ b/internal/selfupdate/resolve_target_test.go
@@ -1,0 +1,100 @@
+package selfupdate
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestResolveLatestFollowsRedirect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/releases/latest" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		http.Redirect(w, r, "/releases/tag/v0.7.0", http.StatusFound)
+	}))
+	defer server.Close()
+
+	tag, err := resolveTarget(server.Client(), server.URL, "")
+	if err != nil {
+		t.Fatalf("resolveTarget returned error: %v", err)
+	}
+	if tag != "v0.7.0" {
+		t.Fatalf("resolveTarget = %q, want v0.7.0", tag)
+	}
+}
+
+func TestResolveLatestMissingLocation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	_, err := resolveTarget(server.Client(), server.URL, "")
+	if err == nil {
+		t.Fatal("resolveTarget accepted a response without a redirect")
+	}
+	if !strings.Contains(err.Error(), "--version") {
+		t.Fatalf("error %q does not suggest --version pinning", err)
+	}
+}
+
+func TestResolveLatestNonTagLocation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/releases", http.StatusFound)
+	}))
+	defer server.Close()
+
+	_, err := resolveTarget(server.Client(), server.URL, "")
+	if err == nil {
+		t.Fatal("resolveTarget accepted a non-tag redirect target")
+	}
+	if !strings.Contains(err.Error(), "--version") {
+		t.Fatalf("error %q does not suggest --version pinning", err)
+	}
+}
+
+func TestResolveLatestTimesOut(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	client := &http.Client{Timeout: 50 * time.Millisecond}
+	_, err := resolveTarget(client, server.URL, "")
+	if err == nil {
+		t.Fatal("resolveTarget did not surface the client timeout")
+	}
+}
+
+func TestResolvePinnedTagSkipsNetwork(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+	}))
+	defer server.Close()
+
+	tag, err := resolveTarget(server.Client(), server.URL, "v0.6.0")
+	if err != nil {
+		t.Fatalf("resolveTarget returned error: %v", err)
+	}
+	if tag != "v0.6.0" {
+		t.Fatalf("resolveTarget = %q, want v0.6.0", tag)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("pinned resolution performed %d network requests, want 0", hits.Load())
+	}
+}
+
+func TestResolvePinnedTagRejectsMalformed(t *testing.T) {
+	_, err := resolveTarget(&http.Client{}, "http://unused.invalid", "0.6.0")
+	if err == nil {
+		t.Fatal("resolveTarget accepted a malformed pinned tag")
+	}
+	if !strings.Contains(err.Error(), "vMAJOR.MINOR.PATCH") {
+		t.Fatalf("error %q does not name the expected format", err)
+	}
+}

--- a/internal/selfupdate/resolve_test.go
+++ b/internal/selfupdate/resolve_test.go
@@ -1,0 +1,80 @@
+package selfupdate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTagParseAcceptsReleaseFormat(t *testing.T) {
+	cases := []struct {
+		tag  string
+		want releaseTag
+	}{
+		{"v0.5.0", releaseTag{0, 5, 0}},
+		{"v1.2.3", releaseTag{1, 2, 3}},
+		{"v10.20.30", releaseTag{10, 20, 30}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.tag, func(t *testing.T) {
+			got, err := parseReleaseTag(tc.tag)
+			if err != nil {
+				t.Fatalf("parseReleaseTag(%q) returned error: %v", tc.tag, err)
+			}
+			if got != tc.want {
+				t.Fatalf("parseReleaseTag(%q) = %+v, want %+v", tc.tag, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTagParseRejectsMalformedTags(t *testing.T) {
+	cases := []string{
+		"",
+		"0.5.0",
+		"v0.5",
+		"v0.5.0.1",
+		"v0.5.0-rc1",
+		"va.b.c",
+		"latest",
+		"v0.6.1-0.20260709123456-abcdef123456",
+	}
+
+	for _, tag := range cases {
+		t.Run(tag, func(t *testing.T) {
+			if _, err := parseReleaseTag(tag); err == nil {
+				t.Fatalf("parseReleaseTag(%q) accepted a malformed tag", tag)
+			} else if !strings.Contains(err.Error(), "vMAJOR.MINOR.PATCH") {
+				t.Fatalf("parseReleaseTag(%q) error %q does not name the expected format", tag, err)
+			}
+		})
+	}
+}
+
+func TestTagCompareOrdersNumerically(t *testing.T) {
+	skillGate := releaseTag{0, 5, 0}
+
+	cases := []struct {
+		tag       string
+		belowGate bool
+	}{
+		{"v0.4.9", true},
+		{"v0.5.0", false},
+		{"v0.5.1", false},
+		{"v0.10.0", false},
+		{"v1.0.0", false},
+		{"v0.0.9", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.tag, func(t *testing.T) {
+			parsed, err := parseReleaseTag(tc.tag)
+			if err != nil {
+				t.Fatalf("parseReleaseTag(%q) returned error: %v", tc.tag, err)
+			}
+			if got := parsed.less(skillGate); got != tc.belowGate {
+				t.Fatalf("%s below v0.5.0 = %t, want %t", tc.tag, got, tc.belowGate)
+			}
+		})
+	}
+}

--- a/internal/selfupdate/runner_fake_test.go
+++ b/internal/selfupdate/runner_fake_test.go
@@ -1,0 +1,23 @@
+package selfupdate
+
+import (
+	"context"
+
+	"github.com/andrearaponi/walden/internal/shell"
+)
+
+// fakeRunner records every invocation and answers through a configurable
+// respond function, standing in for the real exec-backed runner.
+type fakeRunner struct {
+	calls   [][]string
+	respond func(name string, args []string) (shell.Response, error)
+}
+
+func (f *fakeRunner) Run(_ context.Context, name string, args ...string) (shell.Response, error) {
+	call := append([]string{name}, args...)
+	f.calls = append(f.calls, call)
+	if f.respond == nil {
+		return shell.Response{ExitCode: 0}, nil
+	}
+	return f.respond(name, args)
+}

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -1,0 +1,75 @@
+package selfupdate
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/andrearaponi/walden/internal/shell"
+	"github.com/andrearaponi/walden/internal/skilldist"
+)
+
+// defaultBaseURL is the production release host. It is intentionally not
+// user-configurable: all release traffic stays on HTTPS to GitHub, and the
+// injectable field below exists only as a test seam.
+const defaultBaseURL = "https://github.com/andrearaponi/walden"
+
+// Options configures an update run. Production callers start from
+// DefaultOptions; tests fill the seams (BaseURL, HTTPClient, Runner,
+// ExecutablePath) explicitly.
+type Options struct {
+	CurrentVersion string
+	TargetTag      string // empty targets the latest release
+	BaseURL        string
+	OS             string
+	Arch           string
+	ExecutablePath string // empty resolves the running binary
+	WorkDir        string
+	Env            skilldist.Env
+	HTTPClient     *http.Client
+	Runner         shell.Runner
+}
+
+// DefaultOptions returns production defaults for the running binary.
+func DefaultOptions(currentVersion string) (Options, error) {
+	workDir, err := os.Getwd()
+	if err != nil {
+		return Options{}, fmt.Errorf("resolve working directory: %w", err)
+	}
+
+	return Options{
+		CurrentVersion: currentVersion,
+		BaseURL:        defaultBaseURL,
+		OS:             runtime.GOOS,
+		Arch:           runtime.GOARCH,
+		WorkDir:        workDir,
+		Env:            skilldist.EnvFromOS(),
+		HTTPClient:     &http.Client{Timeout: 30 * time.Second},
+		Runner:         shell.NewExecRunner(),
+	}, nil
+}
+
+// Status reports the outcome of a check: what runs now, what the target
+// release is, and whether they differ.
+type Status struct {
+	CurrentVersion  string
+	TargetVersion   string
+	UpdateAvailable bool
+}
+
+// Check resolves the target release and compares it with the current
+// version. It never touches the filesystem.
+func Check(opts Options) (Status, error) {
+	tag, err := resolveTarget(opts.HTTPClient, opts.BaseURL, opts.TargetTag)
+	if err != nil {
+		return Status{}, err
+	}
+
+	return Status{
+		CurrentVersion:  opts.CurrentVersion,
+		TargetVersion:   tag,
+		UpdateAvailable: tag != opts.CurrentVersion,
+	}, nil
+}

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -1,0 +1,95 @@
+package selfupdate
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func checkServer(t *testing.T, latestTag string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/releases/tag/"+latestTag, http.StatusFound)
+	}))
+}
+
+func TestCheckReportsUpdateAvailable(t *testing.T) {
+	server := checkServer(t, "v0.7.0")
+	defer server.Close()
+
+	status, err := Check(Options{
+		CurrentVersion: "v0.5.0",
+		BaseURL:        server.URL,
+		HTTPClient:     server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+
+	want := Status{CurrentVersion: "v0.5.0", TargetVersion: "v0.7.0", UpdateAvailable: true}
+	if status != want {
+		t.Fatalf("Check = %+v, want %+v", status, want)
+	}
+}
+
+func TestCheckReportsAlreadyCurrent(t *testing.T) {
+	server := checkServer(t, "v0.5.0")
+	defer server.Close()
+
+	status, err := Check(Options{
+		CurrentVersion: "v0.5.0",
+		BaseURL:        server.URL,
+		HTTPClient:     server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+	if status.UpdateAvailable {
+		t.Fatalf("Check reported an update for an identical version: %+v", status)
+	}
+}
+
+func TestCheckHonorsPinnedTarget(t *testing.T) {
+	server := checkServer(t, "v0.7.0")
+	defer server.Close()
+
+	status, err := Check(Options{
+		CurrentVersion: "v0.7.0",
+		TargetTag:      "v0.6.0",
+		BaseURL:        server.URL,
+		HTTPClient:     server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("Check returned error: %v", err)
+	}
+
+	want := Status{CurrentVersion: "v0.7.0", TargetVersion: "v0.6.0", UpdateAvailable: true}
+	if status != want {
+		t.Fatalf("Check = %+v, want %+v (pinned downgrade)", status, want)
+	}
+}
+
+func TestCheckDefaultOptionsAreProductionSafe(t *testing.T) {
+	opts, err := DefaultOptions("v0.5.0")
+	if err != nil {
+		t.Fatalf("DefaultOptions returned error: %v", err)
+	}
+
+	if !strings.HasPrefix(opts.BaseURL, "https://github.com/") {
+		t.Fatalf("default BaseURL = %q, want an https://github.com/ URL", opts.BaseURL)
+	}
+	if opts.HTTPClient == nil || opts.HTTPClient.Timeout != 30*time.Second {
+		t.Fatalf("default HTTP client must carry a 30s timeout, got %+v", opts.HTTPClient)
+	}
+	if opts.OS == "" || opts.Arch == "" {
+		t.Fatalf("default platform not populated: os=%q arch=%q", opts.OS, opts.Arch)
+	}
+	if opts.Runner == nil {
+		t.Fatal("default Runner is nil")
+	}
+	if opts.CurrentVersion != "v0.5.0" {
+		t.Fatalf("CurrentVersion = %q, want v0.5.0", opts.CurrentVersion)
+	}
+}

--- a/internal/selfupdate/smoke.go
+++ b/internal/selfupdate/smoke.go
@@ -1,0 +1,43 @@
+package selfupdate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/andrearaponi/walden/internal/shell"
+)
+
+// smokeTestAndFinalize proves the freshly installed binary works by running
+// its version command: pass means exit 0 with the target tag in the output.
+// A pass deletes the backup; any failure restores the previous binary over
+// the executable path so the install never ends in a broken state.
+func smokeTestAndFinalize(ctx context.Context, runner shell.Runner, executable, backup, targetTag string) error {
+	resp, err := runner.Run(ctx, executable, "version")
+
+	pass := err == nil && resp.ExitCode == 0 && strings.Contains(resp.Stdout, targetTag)
+	if pass {
+		if removeErr := os.Remove(backup); removeErr != nil {
+			return fmt.Errorf("update installed, but removing the backup failed: %w (remove %s manually)", removeErr, backup)
+		}
+		return nil
+	}
+
+	reason := describeSmokeFailure(resp, err, targetTag)
+	if restoreErr := os.Rename(backup, executable); restoreErr != nil {
+		return fmt.Errorf("smoke test failed (%s) and restoring the previous binary failed: %v (backup kept at %s)", reason, restoreErr, backup)
+	}
+	return fmt.Errorf("smoke test failed for the new binary (%s); previous binary restored", reason)
+}
+
+func describeSmokeFailure(resp shell.Response, err error, targetTag string) string {
+	switch {
+	case err != nil:
+		return fmt.Sprintf("could not execute it: %v", err)
+	case resp.ExitCode != 0:
+		return fmt.Sprintf("version exited %d: %s", resp.ExitCode, strings.TrimSpace(resp.Stderr))
+	default:
+		return fmt.Sprintf("version output %q does not report %s", strings.TrimSpace(resp.Stdout), targetTag)
+	}
+}

--- a/internal/selfupdate/smoke_test.go
+++ b/internal/selfupdate/smoke_test.go
@@ -1,0 +1,100 @@
+package selfupdate
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/shell"
+)
+
+func seedSwapAftermath(t *testing.T) (executable, backup string) {
+	t.Helper()
+	dir := t.TempDir()
+	executable = filepath.Join(dir, "walden")
+	backup = filepath.Join(dir, ".walden-backup-test")
+	if err := os.WriteFile(executable, []byte("NEW-BINARY"), 0o755); err != nil {
+		t.Fatalf("seed executable: %v", err)
+	}
+	if err := os.WriteFile(backup, []byte("OLD-BINARY"), 0o755); err != nil {
+		t.Fatalf("seed backup: %v", err)
+	}
+	return executable, backup
+}
+
+func TestSmokePassDeletesBackup(t *testing.T) {
+	executable, backup := seedSwapAftermath(t)
+	runner := &fakeRunner{respond: func(string, []string) (shell.Response, error) {
+		return shell.Response{Stdout: "walden v0.7.0 (schema v0beta1)", ExitCode: 0}, nil
+	}}
+
+	if err := smokeTestAndFinalize(context.Background(), runner, executable, backup, "v0.7.0"); err != nil {
+		t.Fatalf("smokeTestAndFinalize returned error: %v", err)
+	}
+
+	if len(runner.calls) != 1 || runner.calls[0][0] != executable || runner.calls[0][1] != "version" {
+		t.Fatalf("smoke test invoked %v, want [%s version]", runner.calls, executable)
+	}
+	if _, err := os.Stat(backup); !os.IsNotExist(err) {
+		t.Fatal("backup survived a passing smoke test")
+	}
+	content, _ := os.ReadFile(executable)
+	if string(content) != "NEW-BINARY" {
+		t.Fatalf("executable content = %q, want NEW-BINARY", content)
+	}
+}
+
+func TestSmokeFailureRestoresPreviousBinary(t *testing.T) {
+	cases := []struct {
+		name    string
+		respond func(string, []string) (shell.Response, error)
+	}{
+		{
+			name: "wrong version reported",
+			respond: func(string, []string) (shell.Response, error) {
+				return shell.Response{Stdout: "walden v0.5.0 (schema v0beta1)", ExitCode: 0}, nil
+			},
+		},
+		{
+			name: "non-zero exit",
+			respond: func(string, []string) (shell.Response, error) {
+				return shell.Response{Stderr: "segfault", ExitCode: 1}, nil
+			},
+		},
+		{
+			name: "launch failure",
+			respond: func(string, []string) (shell.Response, error) {
+				return shell.Response{}, errors.New("exec format error")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			executable, backup := seedSwapAftermath(t)
+			runner := &fakeRunner{respond: tc.respond}
+
+			err := smokeTestAndFinalize(context.Background(), runner, executable, backup, "v0.7.0")
+			if err == nil {
+				t.Fatal("smokeTestAndFinalize accepted a failing smoke test")
+			}
+			if !strings.Contains(err.Error(), "restored") {
+				t.Fatalf("error %q does not state the previous binary was restored", err)
+			}
+
+			content, readErr := os.ReadFile(executable)
+			if readErr != nil {
+				t.Fatalf("read executable: %v", readErr)
+			}
+			if string(content) != "OLD-BINARY" {
+				t.Fatalf("executable content = %q, want restored OLD-BINARY", content)
+			}
+			if _, statErr := os.Stat(backup); !os.IsNotExist(statErr) {
+				t.Fatal("backup still present after restore")
+			}
+		})
+	}
+}

--- a/internal/selfupdate/swap.go
+++ b/internal/selfupdate/swap.go
@@ -1,0 +1,58 @@
+package selfupdate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// resolveExecutable resolves the running binary's path through symbolic
+// links, so the swap replaces the real target rather than the link.
+func resolveExecutable(path string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve executable path %s: %w", path, err)
+	}
+	return resolved, nil
+}
+
+// probeStaging creates the PID-suffixed staging file next to the executable
+// and returns its path. Staging in the same directory keeps the final rename
+// atomic and doubles as the writability probe: it fails before any download
+// when the install location cannot be written.
+func probeStaging(executable string) (string, error) {
+	dir := filepath.Dir(executable)
+	staged := filepath.Join(dir, fmt.Sprintf(".walden-update-%d", os.Getpid()))
+
+	file, err := os.OpenFile(staged, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("cannot write to %s: %w (reinstall walden to a writable location, or rerun with the required permissions)", dir, err)
+	}
+	if err := file.Close(); err != nil {
+		return "", fmt.Errorf("cannot write to %s: %w", dir, err)
+	}
+	return staged, nil
+}
+
+// swapExecutable installs the staged binary over the executable path with an
+// atomic rename, keeping the previous binary as a PID-suffixed backup for
+// rollback. The caller deletes the backup after a passing smoke test or
+// restores it on failure.
+func swapExecutable(staged, executable string) (string, error) {
+	if err := os.Chmod(staged, 0o755); err != nil {
+		return "", fmt.Errorf("mark staged binary executable: %w", err)
+	}
+
+	backup := filepath.Join(filepath.Dir(executable), fmt.Sprintf(".walden-backup-%d", os.Getpid()))
+	if err := os.Rename(executable, backup); err != nil {
+		return "", fmt.Errorf("back up current binary: %w", err)
+	}
+
+	if err := os.Rename(staged, executable); err != nil {
+		// Put the previous binary back so a failed swap never leaves the
+		// install without a working executable.
+		_ = os.Rename(backup, executable)
+		return "", fmt.Errorf("install new binary: %w", err)
+	}
+	return backup, nil
+}

--- a/internal/selfupdate/swap_test.go
+++ b/internal/selfupdate/swap_test.go
@@ -1,0 +1,136 @@
+package selfupdate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func seedExecutable(t *testing.T, dir, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, "walden")
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("seed executable: %v", err)
+	}
+	return path
+}
+
+func TestSwapReplacesContentAndMode(t *testing.T) {
+	dir := t.TempDir()
+	executable := seedExecutable(t, dir, "OLD-BINARY")
+
+	staged := filepath.Join(dir, ".walden-update-test")
+	if err := os.WriteFile(staged, []byte("NEW-BINARY"), 0o600); err != nil {
+		t.Fatalf("seed staged file: %v", err)
+	}
+
+	backup, err := swapExecutable(staged, executable)
+	if err != nil {
+		t.Fatalf("swapExecutable returned error: %v", err)
+	}
+
+	content, err := os.ReadFile(executable)
+	if err != nil {
+		t.Fatalf("read swapped executable: %v", err)
+	}
+	if string(content) != "NEW-BINARY" {
+		t.Fatalf("executable content = %q, want NEW-BINARY", content)
+	}
+
+	info, err := os.Stat(executable)
+	if err != nil {
+		t.Fatalf("stat swapped executable: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("executable mode = %v, want 0755", info.Mode().Perm())
+	}
+
+	backupContent, err := os.ReadFile(backup)
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(backupContent) != "OLD-BINARY" {
+		t.Fatalf("backup content = %q, want OLD-BINARY", backupContent)
+	}
+}
+
+func TestSwapResolvesSymlinkedExecutable(t *testing.T) {
+	realDir := t.TempDir()
+	linkDir := t.TempDir()
+	real := seedExecutable(t, realDir, "OLD-BINARY")
+
+	link := filepath.Join(linkDir, "walden")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	resolved, err := resolveExecutable(link)
+	if err != nil {
+		t.Fatalf("resolveExecutable returned error: %v", err)
+	}
+	if evalReal, _ := filepath.EvalSymlinks(real); resolved != evalReal {
+		t.Fatalf("resolveExecutable = %q, want %q", resolved, evalReal)
+	}
+
+	staged := filepath.Join(filepath.Dir(resolved), ".walden-update-test")
+	if err := os.WriteFile(staged, []byte("NEW-BINARY"), 0o600); err != nil {
+		t.Fatalf("seed staged file: %v", err)
+	}
+	if _, err := swapExecutable(staged, resolved); err != nil {
+		t.Fatalf("swapExecutable returned error: %v", err)
+	}
+
+	throughLink, err := os.ReadFile(link)
+	if err != nil {
+		t.Fatalf("read through symlink: %v", err)
+	}
+	if string(throughLink) != "NEW-BINARY" {
+		t.Fatalf("content through symlink = %q, want NEW-BINARY", throughLink)
+	}
+}
+
+func TestSwapUnwritableDirectoryAbortsUntouched(t *testing.T) {
+	dir := t.TempDir()
+	executable := seedExecutable(t, dir, "OLD-BINARY")
+
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("make directory read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	_, err := probeStaging(executable)
+	if err == nil {
+		t.Fatal("probeStaging succeeded in a read-only directory")
+	}
+	if !strings.Contains(err.Error(), dir) {
+		t.Fatalf("error %q does not name the directory", err)
+	}
+
+	content, readErr := os.ReadFile(executable)
+	if readErr != nil {
+		t.Fatalf("read executable: %v", readErr)
+	}
+	if string(content) != "OLD-BINARY" {
+		t.Fatalf("executable modified by a failed probe: %q", content)
+	}
+}
+
+func TestSwapProbeStagesNextToExecutable(t *testing.T) {
+	dir := t.TempDir()
+	executable := seedExecutable(t, dir, "OLD-BINARY")
+
+	staged, err := probeStaging(executable)
+	if err != nil {
+		t.Fatalf("probeStaging returned error: %v", err)
+	}
+	if filepath.Dir(staged) != dir {
+		t.Fatalf("staging dir = %q, want %q", filepath.Dir(staged), dir)
+	}
+	if !strings.HasPrefix(filepath.Base(staged), ".walden-update-") {
+		t.Fatalf("staging name = %q, want .walden-update-* prefix", filepath.Base(staged))
+	}
+	if _, err := os.Stat(staged); err != nil {
+		t.Fatalf("staging file not created: %v", err)
+	}
+}

--- a/internal/selfupdate/sync.go
+++ b/internal/selfupdate/sync.go
@@ -1,0 +1,77 @@
+package selfupdate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/andrearaponi/walden/internal/shell"
+	"github.com/andrearaponi/walden/internal/skilldist"
+)
+
+// skillInstallGate is the first release whose binary ships `skill install`.
+// Targets below it cannot re-sync skills and degrade to a warning.
+var skillInstallGate = releaseTag{0, 5, 0}
+
+// skillSlot identifies one installed skill installation to re-sync.
+type skillSlot struct {
+	Agent string
+	Scope skilldist.Scope
+	Path  string
+}
+
+// snapshotSkillSlots records every skill installation detectable from the
+// current environment. It runs before the swap so the update knows what to
+// re-sync even though installation itself is delegated to the new binary.
+func snapshotSkillSlots(opts skilldist.Options) []skillSlot {
+	statuses, _ := skilldist.Status(opts)
+
+	slots := make([]skillSlot, 0, len(statuses))
+	for _, status := range statuses {
+		if !status.Installed {
+			continue
+		}
+		slots = append(slots, skillSlot{Agent: status.Agent, Scope: status.Scope, Path: status.Path})
+	}
+	return slots
+}
+
+// resyncSkills reinstalls each recorded slot by invoking the new binary's
+// `skill install` command, so every installation carries the embedded skill
+// matching the installed release. Failures never fail the update: the binary
+// swap is the contract, skill drift stays repairable and is reported as
+// warnings.
+func resyncSkills(ctx context.Context, runner shell.Runner, executable, targetTag string, slots []skillSlot) ([]skillSlot, []string) {
+	target, err := parseReleaseTag(targetTag)
+	if err == nil && target.less(skillInstallGate) {
+		return nil, []string{fmt.Sprintf("release %s predates `walden skill install`; skill re-sync skipped — run the installer to refresh skills for this release", targetTag)}
+	}
+
+	synced := make([]skillSlot, 0, len(slots))
+	warnings := []string{}
+	for _, slot := range slots {
+		args := []string{"skill", "install", slot.Agent}
+		if slot.Scope == skilldist.ScopeProject {
+			args = append(args, "--project")
+		}
+
+		resp, runErr := runner.Run(ctx, executable, args...)
+		if runErr != nil || resp.ExitCode != 0 {
+			warnings = append(warnings, fmt.Sprintf("skill re-sync failed for %s (%s scope): %s — run `walden skill install %s` to repair", slot.Agent, slot.Scope, describeSyncFailure(resp, runErr), slot.Agent))
+			continue
+		}
+		synced = append(synced, slot)
+	}
+	return synced, warnings
+}
+
+func describeSyncFailure(resp shell.Response, err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	detail := strings.TrimSpace(resp.Stderr)
+	if detail == "" {
+		detail = fmt.Sprintf("exit %d", resp.ExitCode)
+	}
+	return detail
+}

--- a/internal/selfupdate/sync_test.go
+++ b/internal/selfupdate/sync_test.go
@@ -1,0 +1,106 @@
+package selfupdate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/shell"
+	"github.com/andrearaponi/walden/internal/skilldist"
+)
+
+func TestSyncSnapshotRecordsInstalledSlots(t *testing.T) {
+	home := t.TempDir()
+	skillPath := filepath.Join(home, ".claude", "skills", "walden", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
+		t.Fatalf("create skill dir: %v", err)
+	}
+	if err := os.WriteFile(skillPath, []byte("skill body\n"), 0o644); err != nil {
+		t.Fatalf("seed skill file: %v", err)
+	}
+
+	opts := skilldist.Options{
+		Version: "v0.6.0",
+		WorkDir: t.TempDir(),
+		Env:     skilldist.Env{Home: home},
+	}
+
+	slots := snapshotSkillSlots(opts)
+
+	if len(slots) != 1 {
+		t.Fatalf("snapshot recorded %d slots, want 1: %+v", len(slots), slots)
+	}
+	if slots[0].Agent != "claude" || slots[0].Scope != skilldist.ScopeUser || slots[0].Path != skillPath {
+		t.Fatalf("snapshot slot = %+v, want claude/user at %s", slots[0], skillPath)
+	}
+}
+
+func TestSyncReinstallsRecordedSlots(t *testing.T) {
+	runner := &fakeRunner{}
+	slots := []skillSlot{
+		{Agent: "claude", Scope: skilldist.ScopeUser, Path: "/home/u/.claude/skills/walden/SKILL.md"},
+		{Agent: "codex", Scope: skilldist.ScopeProject, Path: "/repo/AGENTS.md"},
+	}
+
+	synced, warnings := resyncSkills(context.Background(), runner, "/usr/local/bin/walden", "v0.7.0", slots)
+
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	if len(synced) != 2 {
+		t.Fatalf("synced %d slots, want 2", len(synced))
+	}
+
+	wantCalls := [][]string{
+		{"/usr/local/bin/walden", "skill", "install", "claude"},
+		{"/usr/local/bin/walden", "skill", "install", "codex", "--project"},
+	}
+	if !reflect.DeepEqual(runner.calls, wantCalls) {
+		t.Fatalf("runner calls = %v, want %v", runner.calls, wantCalls)
+	}
+}
+
+func TestSyncFailureBecomesWarning(t *testing.T) {
+	runner := &fakeRunner{respond: func(_ string, args []string) (shell.Response, error) {
+		if len(args) >= 3 && args[2] == "codex" {
+			return shell.Response{Stderr: "permission denied", ExitCode: 1}, nil
+		}
+		return shell.Response{ExitCode: 0}, nil
+	}}
+	slots := []skillSlot{
+		{Agent: "claude", Scope: skilldist.ScopeUser},
+		{Agent: "codex", Scope: skilldist.ScopeUser},
+	}
+
+	synced, warnings := resyncSkills(context.Background(), runner, "/bin/walden", "v0.7.0", slots)
+
+	if len(synced) != 1 || synced[0].Agent != "claude" {
+		t.Fatalf("synced = %+v, want only claude", synced)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want exactly one", warnings)
+	}
+	if !strings.Contains(warnings[0], "codex") || !strings.Contains(warnings[0], "user") {
+		t.Fatalf("warning %q does not name the agent and scope", warnings[0])
+	}
+}
+
+func TestSyncSkipsPreSkillReleases(t *testing.T) {
+	runner := &fakeRunner{}
+	slots := []skillSlot{{Agent: "claude", Scope: skilldist.ScopeUser}}
+
+	synced, warnings := resyncSkills(context.Background(), runner, "/bin/walden", "v0.4.0", slots)
+
+	if len(runner.calls) != 0 {
+		t.Fatalf("re-sync invoked the binary %d times for a pre-skill release, want 0", len(runner.calls))
+	}
+	if len(synced) != 0 {
+		t.Fatalf("synced = %+v, want none", synced)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "skip") {
+		t.Fatalf("warnings = %v, want one skip warning", warnings)
+	}
+}

--- a/internal/selfupdate/updatetest/updatetest.go
+++ b/internal/selfupdate/updatetest/updatetest.go
@@ -1,0 +1,104 @@
+// Package updatetest provides an in-process fake release host and a seeded
+// install fixture for exercising the update flow without network access. It
+// lives under internal/selfupdate so every net/http import in the module —
+// production or test support — stays confined to the selfupdate subtree.
+package updatetest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/andrearaponi/walden/internal/selfupdate"
+	"github.com/andrearaponi/walden/internal/shell"
+	"github.com/andrearaponi/walden/internal/skilldist"
+)
+
+// TB is the subset of testing.TB the fixture needs, kept local so importing
+// this package never drags the testing package into a build.
+type TB interface {
+	Helper()
+	Fatalf(format string, args ...any)
+	Cleanup(func())
+}
+
+// Fixture wires a complete offline update environment: a fake release host
+// serving one tag for the current platform (with real checksums), a fake
+// installed executable, and a home carrying one installed claude skill.
+type Fixture struct {
+	Options    selfupdate.Options
+	Executable string
+}
+
+// New builds the fixture for tag, serving binaryContent as the release
+// asset. The returned Options carry currentVersion and every seam pointed at
+// local doubles; all resources tear down via t.Cleanup.
+func New(t TB, tag, currentVersion string, binaryContent []byte) Fixture {
+	t.Helper()
+
+	server := newReleaseServer(tag, binaryContent)
+	t.Cleanup(server.Close)
+
+	installDir := tempDir(t)
+	executable := filepath.Join(installDir, "walden")
+	if err := os.WriteFile(executable, []byte("OLD-BINARY"), 0o755); err != nil {
+		t.Fatalf("seed current executable: %v", err)
+	}
+
+	home := tempDir(t)
+	skillPath := filepath.Join(home, ".claude", "skills", "walden", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
+		t.Fatalf("create skill dir: %v", err)
+	}
+	if err := os.WriteFile(skillPath, []byte("skill body\n"), 0o644); err != nil {
+		t.Fatalf("seed skill file: %v", err)
+	}
+
+	return Fixture{
+		Options: selfupdate.Options{
+			CurrentVersion: currentVersion,
+			BaseURL:        server.URL,
+			OS:             runtime.GOOS,
+			Arch:           runtime.GOARCH,
+			ExecutablePath: executable,
+			WorkDir:        tempDir(t),
+			Env:            skilldist.Env{Home: home},
+			HTTPClient:     server.Client(),
+			Runner:         shell.NewExecRunner(),
+		},
+		Executable: executable,
+	}
+}
+
+// newReleaseServer serves the release layout the updater consumes: the
+// latest redirect, one platform asset, and its checksums.txt entry.
+func newReleaseServer(tag string, binaryContent []byte) *httptest.Server {
+	asset := fmt.Sprintf("walden-%s-%s-%s", tag, runtime.GOOS, runtime.GOARCH)
+	digest := sha256.Sum256(binaryContent)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/releases/tag/"+tag, http.StatusFound)
+	})
+	mux.HandleFunc("/releases/download/"+tag+"/"+asset, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(binaryContent)
+	})
+	mux.HandleFunc("/releases/download/"+tag+"/checksums.txt", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, "%s  %s\n", hex.EncodeToString(digest[:]), asset)
+	})
+	return httptest.NewServer(mux)
+}
+
+func tempDir(t TB) string {
+	dir, err := os.MkdirTemp("", "walden-updatetest-")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}


### PR DESCRIPTION
## Summary

`walden update` brings the installed binary to a chosen GitHub release in one command — no installer re-run, no repository clone — and re-syncs every installed skill so agents pick up the embedded copy matching the new binary.

```bash
walden update                    # update to the latest release and re-sync installed skills
walden update --check            # report what would change, write nothing
walden update --version v0.6.0   # pin a release, downgrade, or roll back
```

## Design

- **Redirect-based resolution** — the latest tag comes from the `releases/latest` HTTP redirect, never the REST API: immune to the unauthenticated rate limit, no remote JSON parsing.
- **Fail-closed integrity** — SHA-256 verified against the release's `checksums.txt`; a missing file, missing entry, or mismatch aborts with staging cleaned up. There is deliberately no bypass flag.
- **Atomic swap with rollback** — staged in the executable's directory (doubles as the writability probe), previous binary kept as a backup; a post-install smoke test failing restores it, so no path ends without a working binary.
- **Skill re-sync through the new binary** — installed slots are snapshotted via `skilldist.Status` before the swap, then reinstalled by exec-ing the new binary (`skill install <agent> [--project]`). Failures degrade to warnings; targets below v0.5.0 skip with a warning.
- **Explicit-only networking** — `net/http` is confined to `internal/selfupdate` (test fixtures included, via the `updatetest` subpackage); no other command checks for updates or touches the network. Zero new dependencies.
- **Versioned output** — `--json` emits the `v0beta1` envelope with an additive `update` block (`current_version`, `target_version`, `update_available`, `applied`); `--check` is a report, not a gate (exit 0 either way).
- `effectiveVersion()` falls back to Go build info, so `go install` binaries now report their real version instead of `dev` and become updatable; true source builds refuse to update with guidance.

## Testing

- Table-driven unit suites for resolution, checksum verification, swap/rollback, smoke test, and skill re-sync — all against local doubles, no network in CI.
- End-to-end integration: full `Apply` (happy path and rollback) against an in-process release host serving a stub binary with real checksums.
- Invariant proofs: `net/http` confined to `internal/selfupdate`, `go.mod` still dependency-free, full suite green.
- Real-world smoke: a v0.5.0-stamped build resolved `v0.5.0 -> v0.6.0` against live GitHub via `--check`; dev-build guard verified.

Developed through the Walden gated workflow: requirements (EARS, 33 ACs), design, and task plan all reviewed and approved before execution; every task closed through its verification proof.