### PR TITLE
fix: v0.7.1 hardening — JSON error contract, atomic writes, pinned CI, demo fixture

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -19,5 +19,21 @@ jobs:
           go-version: "1.25.0"
           check-latest: true
 
+      - name: Vet
+        run: go vet ./...
+
       - name: Run Go tests
         run: go test ./...
+
+      - name: Run Go tests with the race detector
+        run: go test -race ./...
+
+      - name: Build walden
+        run: go build -o /tmp/walden ./cmd/walden
+
+      - name: Demo smoke (examples/todo-app-demo is the compatibility fixture)
+        working-directory: examples/todo-app-demo
+        run: |
+          set -euo pipefail
+          /tmp/walden validate todo-app --all --json
+          /tmp/walden status todo-app | grep -c 'fresh=true' | grep -qx 3

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,17 +2,19 @@
 
 This is the public roadmap for Walden. It distinguishes committed open source work from exploratory and enterprise-only work.
 
-## Current Release: v0.4.0
+## Current Release: v0.7.x
 
 The open source core today includes:
 
 - Deterministic CLI with all core commands
 - Content-fingerprint freshness chain: tamper detection and provable approval binding on every spec document
-- Versioned JSON output contract (`v0beta1`)
-- Public skill bundle for Claude Code, Codex, Copilot, and OpenCode (model-invoked Agent Skill on Claude Code)
+- Versioned JSON output contract (`v0beta1`), honored on success and error paths alike
+- AI skill embedded in the binary (`walden skill install|status|show`) for Claude Code, Codex, Copilot, and OpenCode, with drift detection against the embedded copy
+- One-liner installer consuming checksum-verified release binaries
+- Self-update from GitHub releases (`walden update`) with fail-closed verification, rollback, and skill re-sync
 - Documentation pack (concepts, workflow, boundaries)
-- Example project with shell-safe verification
-- Repository bootstrap and feature scaffolding templates
+- Example project with shell-safe verification, validated in CI as a compatibility fixture
+- Repository bootstrap and feature scaffolding templates (generated CI pinned to the generating version)
 - Apache-2.0 license
 
 ## Near-Term (Open Source)

--- a/examples/todo-app-demo/.walden/specs/todo-app/design.md
+++ b/examples/todo-app-demo/.walden/specs/todo-app/design.md
@@ -1,8 +1,10 @@
 ---
 status: approved
-approved_at: 2026-03-22T12:10:00Z
-last_modified: 2026-03-22T12:10:00Z
-source_requirements_approved_at: 2026-03-22T12:00:00Z
+approved_at: 2026-07-10T17:57:14Z
+last_modified: 2026-07-10T17:57:14Z
+approved_fingerprint: sha256:fd389da52505fb2fe9898bc4aafd5ecb8efc74abca0a8cd5bceba1ce745a550e
+source_requirements_approved_at: 2026-07-10T17:57:14Z
+source_requirements_fingerprint: sha256:a3da471ec0241fe0027c1b3be7ad775dc8c5f6caa1d51ebb9070d26b51ca0530
 ---
 
 # Feature Design

--- a/examples/todo-app-demo/.walden/specs/todo-app/requirements.md
+++ b/examples/todo-app-demo/.walden/specs/todo-app/requirements.md
@@ -1,7 +1,8 @@
 ---
 status: approved
-approved_at: 2026-03-22T12:00:00Z
-last_modified: 2026-03-22T12:00:00Z
+approved_at: 2026-07-10T17:57:14Z
+last_modified: 2026-07-10T17:57:14Z
+approved_fingerprint: sha256:a3da471ec0241fe0027c1b3be7ad775dc8c5f6caa1d51ebb9070d26b51ca0530
 ---
 
 # Requirements Document

--- a/examples/todo-app-demo/.walden/specs/todo-app/tasks.md
+++ b/examples/todo-app-demo/.walden/specs/todo-app/tasks.md
@@ -1,8 +1,10 @@
 ---
 status: approved
-approved_at: 2026-03-22T12:20:00Z
-last_modified: 2026-03-22T12:20:00Z
-source_design_approved_at: 2026-03-22T12:10:00Z
+approved_at: 2026-07-10T17:57:14Z
+last_modified: 2026-07-10T17:57:14Z
+approved_fingerprint: sha256:45ba4f9dbb4c78a9d427bd987400f27e8cbff99cf11cba76844cb0b9e8f22ffb
+source_design_approved_at: 2026-07-10T17:57:14Z
+source_design_fingerprint: sha256:fd389da52505fb2fe9898bc4aafd5ecb8efc74abca0a8cd5bceba1ce745a550e
 ---
 
 # Implementation Plan

--- a/internal/app/emit.go
+++ b/internal/app/emit.go
@@ -1,0 +1,40 @@
+package app
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/andrearaponi/walden/internal/output"
+)
+
+// emitResult renders every command outcome under one contract: JSON mode
+// prints the versioned envelope on stdout (ok follows the exit code); text
+// mode prints errors as their summary on stderr — plus the next action when
+// present — and successes through PrintText on stdout. Routing all handlers
+// through this helper is what keeps the JSON contract a property of the
+// dispatch layer instead of a per-command convention.
+func emitResult(command string, result output.Result, jsonMode bool, stdout, stderr io.Writer) int {
+	if jsonMode {
+		if err := output.PrintJSON(stdout, command, result); err != nil {
+			_, _ = fmt.Fprintf(stderr, "render json output: %v\n", err)
+			return 1
+		}
+		return result.ExitCode
+	}
+
+	if result.ExitCode != 0 {
+		_, _ = fmt.Fprintf(stderr, "%s\n", result.Summary)
+		if result.NextAction != "" {
+			_, _ = fmt.Fprintf(stderr, "Next action: %s\n", result.NextAction)
+		}
+		return result.ExitCode
+	}
+
+	output.PrintText(stdout, result)
+	return 0
+}
+
+// errorResult wraps an execution error into the shared result shape.
+func errorResult(err error) output.Result {
+	return output.Result{Summary: err.Error(), ExitCode: 1}
+}

--- a/internal/app/emit_test.go
+++ b/internal/app/emit_test.go
@@ -1,0 +1,97 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/output"
+)
+
+func TestEmitResultJSONErrorEnvelope(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	result := errorResult(errors.New("requirements.md is stale"))
+
+	exitCode := emitResult("review-open", result, true, &stdout, &stderr)
+
+	if exitCode != 1 {
+		t.Fatalf("exit code = %d, want 1", exitCode)
+	}
+	var envelope output.Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("stdout is not a JSON envelope: %v (got %q)", err, stdout.String())
+	}
+	if envelope.Command != "review-open" {
+		t.Fatalf("command = %q, want review-open", envelope.Command)
+	}
+	if envelope.OK {
+		t.Fatal("ok = true for a failing result")
+	}
+	if envelope.Result.Summary != "requirements.md is stale" {
+		t.Fatalf("summary = %q, want the error text", envelope.Result.Summary)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr not empty in JSON mode: %q", stderr.String())
+	}
+}
+
+func TestEmitResultTextErrorGoesToStderr(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	result := errorResult(errors.New("boom happened"))
+	result.NextAction = "Run walden reconcile"
+
+	exitCode := emitResult("status", result, false, &stdout, &stderr)
+
+	if exitCode != 1 {
+		t.Fatalf("exit code = %d, want 1", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout not empty for a text-mode error: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "boom happened") {
+		t.Fatalf("stderr %q does not carry the error text", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Run walden reconcile") {
+		t.Fatalf("stderr %q does not carry the next action", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "{") {
+		t.Fatalf("text mode leaked JSON: %q", stderr.String())
+	}
+}
+
+func TestEmitResultTextSuccessUsesPrintText(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	result := output.Result{Summary: "all good", ExitCode: 0}
+
+	exitCode := emitResult("status", result, false, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "all good") {
+		t.Fatalf("stdout %q does not carry the summary", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr not empty on success: %q", stderr.String())
+	}
+}
+
+func TestEmitResultJSONSuccessEnvelope(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	result := output.Result{Summary: "all good", ExitCode: 0}
+
+	exitCode := emitResult("status", result, true, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0", exitCode)
+	}
+	var envelope output.Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("stdout is not a JSON envelope: %v", err)
+	}
+	if !envelope.OK {
+		t.Fatal("ok = false for a succeeding result")
+	}
+}

--- a/internal/app/json_contract_test.go
+++ b/internal/app/json_contract_test.go
@@ -1,0 +1,247 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/output"
+)
+
+// chdirContract moves the test into an isolated directory, mirroring the
+// e2e-test convention, so filesystem-dependent commands see a clean root.
+func chdirContract(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("resolve working directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(previous) })
+
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("enter temp root: %v", err)
+	}
+	return root
+}
+
+// TestJSONErrorContract asserts the envelope contract for one error-inducing
+// invocation of every --json command: parseable envelope on stdout, ok=false,
+// the command's canonical name, a non-empty summary, a non-zero exit code,
+// and nothing on stderr. Two commands are absent by design: `version` has no
+// error path at all, and `skill status` fails only when the working directory
+// cannot be resolved, which is not portably inducible (its error path routes
+// through the same unit-tested renderer as every other command).
+func TestJSONErrorContract(t *testing.T) {
+	cases := []struct {
+		name          string
+		args          []string
+		wantCommand   string
+		wantInSummary string
+		setup         func(t *testing.T, root string)
+	}{
+		{
+			name:        "repo init on unusable root",
+			args:        []string{"repo", "init", "--json"},
+			wantCommand: "repo-init",
+			setup: func(t *testing.T, root string) {
+				// A file where .walden must go makes bootstrap fail.
+				if err := os.WriteFile(filepath.Join(root, ".walden"), []byte("x"), 0o644); err != nil {
+					t.Fatalf("seed blocking file: %v", err)
+				}
+			},
+		},
+		{
+			name:        "feature init without a name",
+			args:        []string{"feature", "init", "--json"},
+			wantCommand: "feature-init",
+		},
+		{
+			name:        "status with invalid feature name",
+			args:        []string{"status", "!!!", "--json"},
+			wantCommand: "status",
+		},
+		{
+			name:        "validate without a feature",
+			args:        []string{"validate", "--json"},
+			wantCommand: "validate",
+		},
+		{
+			name:        "reconcile with invalid feature name",
+			args:        []string{"reconcile", "!!!", "--json"},
+			wantCommand: "reconcile",
+		},
+		{
+			name:        "lesson log without required flags",
+			args:        []string{"lesson", "log", "--json"},
+			wantCommand: "lesson-log",
+		},
+		{
+			name:        "task status with invalid feature name",
+			args:        []string{"task", "status", "!!!", "--json"},
+			wantCommand: "task-status",
+		},
+		{
+			name:        "task start with invalid feature name",
+			args:        []string{"task", "start", "!!!", "--json"},
+			wantCommand: "task-start",
+		},
+		{
+			name:        "task complete with invalid feature name",
+			args:        []string{"task", "complete", "!!!", "1.1", "--json"},
+			wantCommand: "task-complete",
+		},
+		{
+			name:        "task complete-all with invalid feature name",
+			args:        []string{"task", "complete-all", "!!!", "--json"},
+			wantCommand: "task-complete-all",
+		},
+		{
+			name:        "review open without --phase",
+			args:        []string{"review", "open", "demo", "--json"},
+			wantCommand: "review-open",
+		},
+		{
+			name:          "review approve blocked by workflow state",
+			args:          []string{"review", "approve", "demo", "--phase", "requirements", "--json"},
+			wantCommand:   "review-approve",
+			wantInSummary: "requirements",
+			setup: func(t *testing.T, root string) {
+				var stdout, stderr bytes.Buffer
+				if code := Run([]string{"repo", "init"}, &stdout, &stderr); code != 0 {
+					t.Fatalf("repo init failed: %s", stderr.String())
+				}
+				if code := Run([]string{"feature", "init", "demo"}, &stdout, &stderr); code != 0 {
+					t.Fatalf("feature init failed: %s", stderr.String())
+				}
+			},
+		},
+		{
+			name:        "update refused on a dev build",
+			args:        []string{"update", "--json"},
+			wantCommand: "update",
+			setup: func(t *testing.T, _ string) {
+				restoreVersion := Version
+				restoreSeam := buildInfoVersion
+				t.Cleanup(func() {
+					Version = restoreVersion
+					buildInfoVersion = restoreSeam
+				})
+				Version = "dev"
+				buildInfoVersion = func() string { return "(devel)" }
+			},
+		},
+		{
+			name:        "skill install with unknown agent",
+			args:        []string{"skill", "install", "nonexistent-agent", "--json"},
+			wantCommand: "skill-install",
+		},
+		{
+			name:        "skill uninstall with invalid flag combination",
+			args:        []string{"skill", "uninstall", "--all", "--project", "--json"},
+			wantCommand: "skill-uninstall",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := chdirContract(t)
+			if tc.setup != nil {
+				tc.setup(t, root)
+			}
+
+			var stdout, stderr bytes.Buffer
+			exitCode := Run(tc.args, &stdout, &stderr)
+
+			if exitCode == 0 {
+				t.Fatalf("expected non-zero exit code, got 0 (stdout: %s)", stdout.String())
+			}
+
+			var envelope output.Envelope
+			if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+				t.Fatalf("stdout is not a JSON envelope: %v (stdout %q, stderr %q)", err, stdout.String(), stderr.String())
+			}
+			if envelope.SchemaVersion != "v0beta1" {
+				t.Fatalf("schema_version = %q, want v0beta1", envelope.SchemaVersion)
+			}
+			if envelope.Command != tc.wantCommand {
+				t.Fatalf("command = %q, want %q", envelope.Command, tc.wantCommand)
+			}
+			if envelope.OK {
+				t.Fatal("ok = true for a failing invocation")
+			}
+			if strings.TrimSpace(envelope.Result.Summary) == "" {
+				t.Fatal("summary is empty")
+			}
+			if tc.wantInSummary != "" && !strings.Contains(envelope.Result.Summary, tc.wantInSummary) {
+				t.Fatalf("summary %q does not carry the blocking cause %q", envelope.Result.Summary, tc.wantInSummary)
+			}
+			if envelope.Result.ExitCode == 0 {
+				t.Fatal("result.exit_code = 0 for a failing invocation")
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("stderr not empty in JSON mode: %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestJSONErrorContractTextMode(t *testing.T) {
+	cases := []struct {
+		name      string
+		args      []string
+		wantOnErr string
+	}{
+		{"invalid feature name", []string{"status", "!!!"}, "feature name cannot be empty"},
+		{"missing review phase", []string{"review", "open", "demo"}, "--phase"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			chdirContract(t)
+
+			var stdout, stderr bytes.Buffer
+			exitCode := Run(tc.args, &stdout, &stderr)
+
+			if exitCode == 0 {
+				t.Fatal("expected non-zero exit code")
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout not empty for a text-mode error: %q", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tc.wantOnErr) {
+				t.Fatalf("stderr %q does not carry %q", stderr.String(), tc.wantOnErr)
+			}
+			if strings.Contains(stderr.String(), "\"schema_version\"") {
+				t.Fatalf("text mode leaked a JSON envelope: %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestJSONErrorContractUnknownCommandKeepsUsage(t *testing.T) {
+	cases := [][]string{
+		{"frobnicate", "--json"},
+		{"repo", "frobnicate", "--json"},
+	}
+
+	for _, args := range cases {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			chdirContract(t)
+
+			var stdout, stderr bytes.Buffer
+			exitCode := Run(args, &stdout, &stderr)
+
+			if exitCode == 0 {
+				t.Fatal("expected non-zero exit code")
+			}
+			if !strings.Contains(stderr.String(), "unknown command") || !strings.Contains(stderr.String(), "Usage:") {
+				t.Fatalf("stderr %q does not carry usage guidance", stderr.String())
+			}
+		})
+	}
+}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -131,14 +132,12 @@ func runRepo(args []string, stdout io.Writer, stderr io.Writer) int {
 	if len(positional) == 1 && positional[0] == "init" {
 		root, err := os.Getwd()
 		if err != nil {
-			_, _ = fmt.Fprintf(stderr, "resolve working directory: %v\n", err)
-			return 1
+			return emitResult("repo-init", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
 		}
 
-		report, err := repo.Init(root)
+		report, err := repo.Init(root, effectiveVersion())
 		if err != nil {
-			_, _ = fmt.Fprintf(stderr, "%v\n", err)
-			return 1
+			return emitResult("repo-init", errorResult(err), jsonMode, stdout, stderr)
 		}
 
 		result := output.Result{
@@ -180,17 +179,19 @@ func runFeature(args []string, stdout io.Writer, stderr io.Writer) int {
 		positional = append(positional, arg)
 	}
 
+	if len(positional) == 1 && positional[0] == "init" {
+		return emitResult("feature-init", errorResult(errors.New("feature init requires a feature name")), jsonMode, stdout, stderr)
+	}
+
 	if len(positional) >= 2 && positional[0] == "init" {
 		root, err := os.Getwd()
 		if err != nil {
-			_, _ = fmt.Fprintf(stderr, "resolve working directory: %v\n", err)
-			return 1
+			return emitResult("feature-init", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
 		}
 
 		report, err := repo.InitFeature(root, strings.Join(positional[1:], " "))
 		if err != nil {
-			_, _ = fmt.Fprintf(stderr, "%v\n", err)
-			return 1
+			return emitResult("feature-init", errorResult(err), jsonMode, stdout, stderr)
 		}
 
 		summary := fmt.Sprintf("feature scaffold initialized for %s", report.FeatureName)
@@ -244,15 +245,12 @@ func runValidate(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	if len(positional) != 1 {
-		_, _ = fmt.Fprintf(stderr, "unknown command: validate %s\n\n", strings.Join(args, " "))
-		printUsage(stderr)
-		return 1
+		return emitResult("validate", errorResult(errors.New("validate requires exactly one feature name")), jsonMode, stdout, stderr)
 	}
 
 	root, err := os.Getwd()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "resolve working directory: %v\n", err)
-		return 1
+		return emitResult("validate", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
 	}
 
 	scope := validation.ScopeCurrentPhase
@@ -262,8 +260,7 @@ func runValidate(args []string, stdout io.Writer, stderr io.Writer) int {
 
 	result, err := validation.ValidateFeatureWithScope(root, positional[0], scope)
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "validate feature: %v\n", err)
-		return 1
+		return emitResult("validate", errorResult(fmt.Errorf("validate feature: %w", err)), jsonMode, stdout, stderr)
 	}
 
 	exitCode := 0
@@ -349,21 +346,17 @@ func runStatus(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	if len(positional) != 1 {
-		_, _ = fmt.Fprintf(stderr, "unknown command: status %s\n\n", strings.Join(args, " "))
-		printUsage(stderr)
-		return 1
+		return emitResult("status", errorResult(errors.New("status requires exactly one feature name")), jsonMode, stdout, stderr)
 	}
 
 	featureName, err := spec.NormalizeFeatureName(positional[0])
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("status", errorResult(err), jsonMode, stdout, stderr)
 	}
 
 	root, err := os.Getwd()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "resolve working directory: %v\n", err)
-		return 1
+		return emitResult("status", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
 	}
 
 	state, err := workflow.LoadFeatureState(root, featureName)
@@ -406,21 +399,17 @@ func runReconcile(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	if len(positional) != 1 {
-		_, _ = fmt.Fprintf(stderr, "unknown command: reconcile %s\n\n", strings.Join(args, " "))
-		printUsage(stderr)
-		return 1
+		return emitResult("reconcile", errorResult(errors.New("reconcile requires exactly one feature name")), jsonMode, stdout, stderr)
 	}
 
 	featureName, err := spec.NormalizeFeatureName(positional[0])
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("reconcile", errorResult(err), jsonMode, stdout, stderr)
 	}
 
 	root, err := os.Getwd()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "resolve working directory: %v\n", err)
-		return 1
+		return emitResult("reconcile", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
 	}
 
 	reconcileResult, err := workflow.ReconcileFeature(root, featureName)
@@ -505,21 +494,17 @@ func runTaskStatus(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	if len(positional) != 1 {
-		_, _ = fmt.Fprintf(stderr, "unknown command: task status %s\n\n", strings.Join(args, " "))
-		printUsage(stderr)
-		return 1
+		return emitResult("task-status", errorResult(errors.New("task status requires exactly one feature name")), jsonMode, stdout, stderr)
 	}
 
 	featureName, err := spec.NormalizeFeatureName(positional[0])
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("task-status", errorResult(err), jsonMode, stdout, stderr)
 	}
 
 	root, err := os.Getwd()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "resolve working directory: %v\n", err)
-		return 1
+		return emitResult("task-status", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
 	}
 
 	readiness, err := workflow.LoadExecutionReadiness(root, featureName)
@@ -560,9 +545,7 @@ func runLessonLog(args []string, stdout io.Writer, stderr io.Writer) int {
 			continue
 		}
 		if !strings.HasPrefix(arg, "--") || index+1 >= len(args) {
-			_, _ = fmt.Fprintf(stderr, "unknown command: lesson log %s\n\n", strings.Join(args, " "))
-			printUsage(stderr)
-			return 1
+			return emitResult("lesson-log", errorResult(fmt.Errorf("lesson log cannot parse argument %q", arg)), jsonMode, stdout, stderr)
 		}
 
 		values[strings.TrimPrefix(arg, "--")] = args[index+1]
@@ -571,15 +554,13 @@ func runLessonLog(args []string, stdout io.Writer, stderr io.Writer) int {
 
 	for _, required := range []string{"feature", "phase", "trigger", "lesson", "guardrail"} {
 		if strings.TrimSpace(values[required]) == "" {
-			_, _ = fmt.Fprintf(stderr, "lesson log requires --feature, --phase, --trigger, --lesson, and --guardrail\n")
-			return 1
+			return emitResult("lesson-log", errorResult(errors.New("lesson log requires --feature, --phase, --trigger, --lesson, and --guardrail")), jsonMode, stdout, stderr)
 		}
 	}
 
 	root, err := os.Getwd()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "resolve working directory: %v\n", err)
-		return 1
+		return emitResult("lesson-log", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
 	}
 
 	entry, lessonsPath, err := spec.AppendLesson(root, spec.LessonEntry{
@@ -628,15 +609,12 @@ func runTaskStart(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	if len(positional) < 1 || len(positional) > 2 {
-		_, _ = fmt.Fprintf(stderr, "unknown command: task start %s\n\n", strings.Join(args, " "))
-		printUsage(stderr)
-		return 1
+		return emitResult("task-start", errorResult(errors.New("task start requires a feature name and an optional task id")), jsonMode, stdout, stderr)
 	}
 
 	featureName, err := spec.NormalizeFeatureName(positional[0])
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("task-start", errorResult(err), jsonMode, stdout, stderr)
 	}
 
 	taskID := ""
@@ -646,8 +624,7 @@ func runTaskStart(args []string, stdout io.Writer, stderr io.Writer) int {
 
 	root, err := os.Getwd()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "resolve working directory: %v\n", err)
-		return 1
+		return emitResult("task-start", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
 	}
 
 	context, err := workflow.StartTask(root, featureName, taskID)
@@ -689,21 +666,17 @@ func runTaskComplete(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	if len(positional) != 2 {
-		_, _ = fmt.Fprintf(stderr, "unknown command: task complete %s\n\n", strings.Join(args, " "))
-		printUsage(stderr)
-		return 1
+		return emitResult("task-complete", errorResult(errors.New("task complete requires a feature name and a task id")), jsonMode, stdout, stderr)
 	}
 
 	featureName, err := spec.NormalizeFeatureName(positional[0])
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("task-complete", errorResult(err), jsonMode, stdout, stderr)
 	}
 
 	root, err := os.Getwd()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "resolve working directory: %v\n", err)
-		return 1
+		return emitResult("task-complete", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
 	}
 
 	resultData, err := workflow.CompleteTask(context.Background(), root, featureName, positional[1], commandRunner)
@@ -745,21 +718,17 @@ func runTaskCompleteAll(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	if len(positional) != 1 {
-		_, _ = fmt.Fprintf(stderr, "unknown command: task complete-all %s\n\n", strings.Join(args, " "))
-		printUsage(stderr)
-		return 1
+		return emitResult("task-complete-all", errorResult(errors.New("task complete-all requires exactly one feature name")), jsonMode, stdout, stderr)
 	}
 
 	featureName, err := spec.NormalizeFeatureName(positional[0])
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("task-complete-all", errorResult(err), jsonMode, stdout, stderr)
 	}
 
 	root, err := os.Getwd()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "resolve working directory: %v\n", err)
-		return 1
+		return emitResult("task-complete-all", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
 	}
 
 	resultData, err := workflow.CompleteAllTasks(context.Background(), root, featureName, commandRunner)
@@ -802,9 +771,7 @@ func runReviewOpen(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	if len(positional) < 3 {
-		_, _ = fmt.Fprintf(stderr, "unknown command: review open %s\n\n", strings.Join(positional, " "))
-		printUsage(stderr)
-		return 1
+		return emitResult("review-open", errorResult(errors.New("review open requires a feature and --phase requirements|design|tasks")), jsonMode, stdout, stderr)
 	}
 
 	featureName := positional[0]
@@ -817,26 +784,22 @@ func runReviewOpen(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	if phaseName == "" {
-		_, _ = fmt.Fprintf(stderr, "review open requires --phase requirements|design|tasks\n")
-		return 1
+		return emitResult("review-open", errorResult(errors.New("review open requires --phase requirements|design|tasks")), jsonMode, stdout, stderr)
 	}
 
 	phase, err := workflow.ParsePhase(phaseName)
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("review-open", errorResult(err), jsonMode, stdout, stderr)
 	}
 
 	root, err := os.Getwd()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "resolve working directory: %v\n", err)
-		return 1
+		return emitResult("review-open", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
 	}
 
 	context, err := workflow.OpenReview(root, featureName, phase)
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("review-open", errorResult(err), jsonMode, stdout, stderr)
 	}
 
 	result := output.Result{
@@ -871,9 +834,7 @@ func runReviewApprove(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	if len(positional) < 3 {
-		_, _ = fmt.Fprintf(stderr, "unknown command: review approve %s\n\n", strings.Join(positional, " "))
-		printUsage(stderr)
-		return 1
+		return emitResult("review-approve", errorResult(errors.New("review approve requires a feature and --phase requirements|design|tasks")), jsonMode, stdout, stderr)
 	}
 
 	featureName := positional[0]
@@ -886,26 +847,22 @@ func runReviewApprove(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 
 	if phaseName == "" {
-		_, _ = fmt.Fprintf(stderr, "review approve requires --phase requirements|design|tasks\n")
-		return 1
+		return emitResult("review-approve", errorResult(errors.New("review approve requires --phase requirements|design|tasks")), jsonMode, stdout, stderr)
 	}
 
 	phase, err := workflow.ParsePhase(phaseName)
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("review-approve", errorResult(err), jsonMode, stdout, stderr)
 	}
 
 	root, err := os.Getwd()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "resolve working directory: %v\n", err)
-		return 1
+		return emitResult("review-approve", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
 	}
 
 	approveResult, err := workflow.ApproveReview(root, featureName, phase)
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("review-approve", errorResult(err), jsonMode, stdout, stderr)
 	}
 
 	result := output.Result{

--- a/internal/app/skill.go
+++ b/internal/app/skill.go
@@ -40,8 +40,7 @@ func runSkillStatus(args []string, stdout io.Writer, stderr io.Writer) int {
 
 	opts, err := skillOptions()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("skill-status", errorResult(err), jsonMode, stdout, stderr)
 	}
 
 	statuses, warnings := skilldist.Status(opts)
@@ -144,14 +143,12 @@ func runSkillInstall(args []string, stdout io.Writer, stderr io.Writer) int {
 	flags := parseSkillFlags(args)
 	agent, err := resolveSkillTarget("install", flags)
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("skill-install", errorResult(err), flags.jsonMode, stdout, stderr)
 	}
 
 	opts, err := skillOptions()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("skill-install", errorResult(err), flags.jsonMode, stdout, stderr)
 	}
 
 	var reports []skilldist.Report
@@ -167,8 +164,7 @@ func runSkillInstall(args []string, stdout io.Writer, stderr io.Writer) int {
 		reports = []skilldist.Report{report}
 	}
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("skill-install", errorResult(err), flags.jsonMode, stdout, stderr)
 	}
 
 	result := installResult(flags, reports)
@@ -208,14 +204,12 @@ func runSkillUninstall(args []string, stdout io.Writer, stderr io.Writer) int {
 	flags := parseSkillFlags(args)
 	agent, err := resolveSkillTarget("uninstall", flags)
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("skill-uninstall", errorResult(err), flags.jsonMode, stdout, stderr)
 	}
 
 	opts, err := skillOptions()
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("skill-uninstall", errorResult(err), flags.jsonMode, stdout, stderr)
 	}
 
 	var reports []skilldist.Report
@@ -231,8 +225,7 @@ func runSkillUninstall(args []string, stdout io.Writer, stderr io.Writer) int {
 		reports = []skilldist.Report{report}
 	}
 	if err != nil {
-		_, _ = fmt.Fprintf(stderr, "%v\n", err)
-		return 1
+		return emitResult("skill-uninstall", errorResult(err), flags.jsonMode, stdout, stderr)
 	}
 
 	result := uninstallResult(flags, reports)

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -50,7 +50,7 @@ func runUpdate(args []string, stdout io.Writer, stderr io.Writer) int {
 			NextAction: "Rebuild from your clone (./setup.sh) or install a release: curl -fsSL https://raw.githubusercontent.com/andrearaponi/walden/main/install.sh | sh",
 			ExitCode:   1,
 		}
-		return emitUpdateResult(result, jsonMode, stdout, stderr)
+		return emitResult("update", result, jsonMode, stdout, stderr)
 	}
 
 	opts, err := updateOptions(current)
@@ -69,7 +69,7 @@ func runUpdate(args []string, stdout io.Writer, stderr io.Writer) int {
 func runUpdateCheck(opts selfupdate.Options, jsonMode bool, stdout, stderr io.Writer) int {
 	status, err := selfupdate.Check(opts)
 	if err != nil {
-		return emitUpdateResult(output.Result{Summary: err.Error(), ExitCode: 1}, jsonMode, stdout, stderr)
+		return emitResult("update", errorResult(err), jsonMode, stdout, stderr)
 	}
 
 	// Check mode is a report, not a gate: exit 0 either way.
@@ -86,13 +86,13 @@ func runUpdateCheck(opts selfupdate.Options, jsonMode bool, stdout, stderr io.Wr
 		result.Summary = fmt.Sprintf("update available: %s -> %s", status.CurrentVersion, status.TargetVersion)
 		result.NextAction = fmt.Sprintf("Run `walden update` to install %s", status.TargetVersion)
 	}
-	return emitUpdateResult(result, jsonMode, stdout, stderr)
+	return emitResult("update", result, jsonMode, stdout, stderr)
 }
 
 func runUpdateApply(opts selfupdate.Options, jsonMode bool, stdout, stderr io.Writer) int {
 	report, err := selfupdate.Apply(context.Background(), opts)
 	if err != nil {
-		return emitUpdateResult(output.Result{Summary: err.Error(), ExitCode: 1}, jsonMode, stdout, stderr)
+		return emitResult("update", errorResult(err), jsonMode, stdout, stderr)
 	}
 
 	if report.AlreadyUpToDate {
@@ -104,7 +104,7 @@ func runUpdateApply(opts selfupdate.Options, jsonMode bool, stdout, stderr io.Wr
 			},
 			ExitCode: 0,
 		}
-		return emitUpdateResult(result, jsonMode, stdout, stderr)
+		return emitResult("update", result, jsonMode, stdout, stderr)
 	}
 
 	changed := []string{report.ExecutablePath}
@@ -125,24 +125,5 @@ func runUpdateApply(opts selfupdate.Options, jsonMode bool, stdout, stderr io.Wr
 		NextAction:   fmt.Sprintf("Release notes: %s", report.ReleaseNotesURL),
 		ExitCode:     0,
 	}
-	return emitUpdateResult(result, jsonMode, stdout, stderr)
-}
-
-// emitUpdateResult renders a result following the repo convention: JSON goes
-// to stdout with ok reflecting the exit code, text errors go to stderr.
-func emitUpdateResult(result output.Result, jsonMode bool, stdout, stderr io.Writer) int {
-	if jsonMode {
-		if err := output.PrintJSON(stdout, "update", result); err != nil {
-			_, _ = fmt.Fprintf(stderr, "render json output: %v\n", err)
-			return 1
-		}
-		return result.ExitCode
-	}
-
-	if result.ExitCode != 0 {
-		output.PrintText(stderr, result)
-		return result.ExitCode
-	}
-	output.PrintText(stdout, result)
-	return 0
+	return emitResult("update", result, jsonMode, stdout, stderr)
 }

--- a/internal/repo/feature_test.go
+++ b/internal/repo/feature_test.go
@@ -10,7 +10,7 @@ func TestInitFeatureNormalizesNameAndCreatesSpecDocuments(t *testing.T) {
 	root := t.TempDir()
 	mustMkdir(t, filepath.Join(root, ".git"))
 
-	if _, err := Init(root); err != nil {
+	if _, err := Init(root, "v0.7.1"); err != nil {
 		t.Fatalf("expected repo init to succeed, got %v", err)
 	}
 
@@ -50,7 +50,7 @@ func TestInitFeatureSkipsExistingScaffoldWithoutOverwriting(t *testing.T) {
 	root := t.TempDir()
 	mustMkdir(t, filepath.Join(root, ".git"))
 
-	if _, err := Init(root); err != nil {
+	if _, err := Init(root, "v0.7.1"); err != nil {
 		t.Fatalf("expected repo init to succeed, got %v", err)
 	}
 	if _, err := InitFeature(root, "todo-app-demo"); err != nil {

--- a/internal/repo/init.go
+++ b/internal/repo/init.go
@@ -36,8 +36,14 @@ var repoBootstrapFiles = []bootstrapFile{
 
 var gitInitRunner = runGitInit
 
-// Init bootstraps a repository with the baseline Walden file layout.
-func Init(root string) (InitReport, error) {
+// versionToken marks where bootstrap templates receive the generating
+// binary's version, so generated CI installs the exact CLI that wrote it.
+const versionToken = "{{WALDEN_VERSION}}"
+
+// Init bootstraps a repository with the baseline Walden file layout. The
+// version is stamped into templates carrying the version token: release
+// versions become exact pins, source builds fall back to "latest".
+func Init(root string, version string) (InitReport, error) {
 	report := InitReport{}
 
 	gitState, err := ensureGitRepository(root)
@@ -58,6 +64,7 @@ func Init(root string) (InitReport, error) {
 		if err != nil {
 			return InitReport{}, fmt.Errorf("read bootstrap template %q: %w", file.Source, err)
 		}
+		content = []byte(strings.ReplaceAll(string(content), versionToken, installPin(version)))
 
 		state, err := writeManagedFile(root, file, content)
 		if err != nil {
@@ -75,6 +82,15 @@ func Init(root string) (InitReport, error) {
 	}
 
 	return report, nil
+}
+
+// installPin maps the generating binary's version to the go install target:
+// an exact release pin, or "latest" for source builds with no release info.
+func installPin(version string) string {
+	if version == "" || version == "dev" {
+		return "latest"
+	}
+	return version
 }
 
 type gitRepositoryState struct {

--- a/internal/repo/init_pin_test.go
+++ b/internal/repo/init_pin_test.go
@@ -1,0 +1,79 @@
+package repo
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const workflowTarget = ".github/workflows/validate-walden.yml"
+
+func readWorkflow(t *testing.T, root string) string {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join(root, workflowTarget))
+	if err != nil {
+		t.Fatalf("read generated workflow: %v", err)
+	}
+	return string(content)
+}
+
+func TestInitPinsWorkflowToReleaseVersion(t *testing.T) {
+	root := t.TempDir()
+
+	if _, err := Init(root, "v0.7.1"); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+
+	workflow := readWorkflow(t, root)
+	if !strings.Contains(workflow, "cmd/walden@v0.7.1") {
+		t.Fatalf("workflow does not pin the generating version:\n%s", workflow)
+	}
+	if strings.Contains(workflow, "{{WALDEN_VERSION}}") {
+		t.Fatal("workflow still carries the unsubstituted version token")
+	}
+	if strings.Contains(workflow, "@latest") {
+		t.Fatal("workflow installs @latest despite a release version")
+	}
+}
+
+func TestInitDevVersionFallsBackToLatest(t *testing.T) {
+	root := t.TempDir()
+
+	if _, err := Init(root, "dev"); err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+
+	workflow := readWorkflow(t, root)
+	if !strings.Contains(workflow, "cmd/walden@latest") {
+		t.Fatalf("dev build did not fall back to @latest:\n%s", workflow)
+	}
+	if strings.Contains(workflow, "{{WALDEN_VERSION}}") {
+		t.Fatal("workflow still carries the unsubstituted version token")
+	}
+}
+
+func TestInitRefreshesPinOnRerunWithNewerBinary(t *testing.T) {
+	root := t.TempDir()
+
+	if _, err := Init(root, "v0.7.0"); err != nil {
+		t.Fatalf("first Init: %v", err)
+	}
+	report, err := Init(root, "v0.7.1")
+	if err != nil {
+		t.Fatalf("second Init: %v", err)
+	}
+
+	updated := false
+	for _, path := range report.UpdatedFiles {
+		if path == workflowTarget {
+			updated = true
+		}
+	}
+	if !updated {
+		t.Fatalf("re-init did not report the workflow as updated: %+v", report)
+	}
+	if workflow := readWorkflow(t, root); !strings.Contains(workflow, "cmd/walden@v0.7.1") {
+		t.Fatalf("workflow pin not refreshed:\n%s", workflow)
+	}
+}

--- a/internal/repo/init_test.go
+++ b/internal/repo/init_test.go
@@ -11,7 +11,7 @@ func TestInitCreatesBaselineWaldenFiles(t *testing.T) {
 	root := t.TempDir()
 	mustMkdir(t, filepath.Join(root, ".git"))
 
-	report, err := Init(root)
+	report, err := Init(root, "v0.7.1")
 	if err != nil {
 		t.Fatalf("expected init to succeed, got %v", err)
 	}
@@ -57,7 +57,7 @@ func TestInitAutoInitializesGitBeforeWritingFiles(t *testing.T) {
 		gitInitRunner = previousRunner
 	})
 
-	report, err := Init(root)
+	report, err := Init(root, "v0.7.1")
 	if err != nil {
 		t.Fatalf("expected init to auto-bootstrap git, got %v", err)
 	}
@@ -87,7 +87,7 @@ func TestInitFailsWithoutPartialWritesWhenGitBootstrapFails(t *testing.T) {
 		gitInitRunner = previousRunner
 	})
 
-	_, err := Init(root)
+	_, err := Init(root, "v0.7.1")
 	if err == nil {
 		t.Fatal("expected init to fail when git bootstrap fails")
 	}
@@ -106,11 +106,11 @@ func TestInitIsIdempotentOnSecondRun(t *testing.T) {
 	root := t.TempDir()
 	mustMkdir(t, filepath.Join(root, ".git"))
 
-	if _, err := Init(root); err != nil {
+	if _, err := Init(root, "v0.7.1"); err != nil {
 		t.Fatalf("expected first init to succeed, got %v", err)
 	}
 
-	report, err := Init(root)
+	report, err := Init(root, "v0.7.1")
 	if err != nil {
 		t.Fatalf("expected second init to succeed, got %v", err)
 	}

--- a/internal/shell/exec_runner_test.go
+++ b/internal/shell/exec_runner_test.go
@@ -1,0 +1,85 @@
+package shell
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestExecRunnerReportsSuccess(t *testing.T) {
+	runner := NewExecRunner()
+
+	resp, err := runner.Run(context.Background(), "sh", "-c", "printf hello")
+	if err != nil {
+		t.Fatalf("Run returned unexpected error: %v", err)
+	}
+	if resp.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0", resp.ExitCode)
+	}
+	if resp.Stdout != "hello" {
+		t.Fatalf("Stdout = %q, want %q", resp.Stdout, "hello")
+	}
+	if resp.Err != nil {
+		t.Fatalf("Response.Err = %v, want nil", resp.Err)
+	}
+}
+
+func TestExecRunnerCapturesStderr(t *testing.T) {
+	runner := NewExecRunner()
+
+	resp, err := runner.Run(context.Background(), "sh", "-c", "printf oops 1>&2")
+	if err != nil {
+		t.Fatalf("Run returned unexpected error: %v", err)
+	}
+	if resp.Stderr != "oops" {
+		t.Fatalf("Stderr = %q, want %q", resp.Stderr, "oops")
+	}
+}
+
+func TestExecRunnerReportsNonZeroExit(t *testing.T) {
+	runner := NewExecRunner()
+
+	// A command that exits non-zero is not a runner error: the exit code is
+	// captured and returned with a nil error so callers can inspect it.
+	resp, err := runner.Run(context.Background(), "sh", "-c", "exit 3")
+	if err != nil {
+		t.Fatalf("Run returned unexpected error: %v", err)
+	}
+	if resp.ExitCode != 3 {
+		t.Fatalf("ExitCode = %d, want 3", resp.ExitCode)
+	}
+	if resp.Err != nil {
+		t.Fatalf("Response.Err = %v, want nil", resp.Err)
+	}
+}
+
+func TestExecRunnerReportsLaunchFailure(t *testing.T) {
+	runner := NewExecRunner()
+
+	// A command that cannot be launched (not found) is a genuine runner error.
+	resp, err := runner.Run(context.Background(), "walden-nonexistent-binary-xyz")
+	if err == nil {
+		t.Fatal("Run returned nil error for a missing binary, want an error")
+	}
+	if resp.ExitCode != 1 {
+		t.Fatalf("ExitCode = %d, want 1", resp.ExitCode)
+	}
+	if resp.Err == nil {
+		t.Fatal("Response.Err = nil, want the launch error")
+	}
+}
+
+func TestExecRunnerHonorsCancelledContext(t *testing.T) {
+	runner := NewExecRunner()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := runner.Run(ctx, "sh", "-c", "printf hello")
+	if err == nil {
+		t.Fatal("Run with a cancelled context returned nil error, want an error")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("error = %v, want it to mention context cancellation", err)
+	}
+}

--- a/internal/spec/write.go
+++ b/internal/spec/write.go
@@ -37,10 +37,37 @@ func SaveDocument(document Document) error {
 		builder.WriteString("\n")
 	}
 
-	if err := os.WriteFile(document.Path, []byte(builder.String()), 0o644); err != nil {
-		return fmt.Errorf("write document: %w", err)
-	}
+	return writeAtomically(document.Path, []byte(builder.String()))
+}
 
+// writeAtomically stages the content in a temp file inside the target's
+// directory and renames it into place, so no failure path — interruption,
+// full disk, permission error — can leave the document truncated or lost.
+func writeAtomically(path string, content []byte) error {
+	staged, err := os.CreateTemp(filepath.Dir(path), ".walden-doc-*")
+	if err != nil {
+		return fmt.Errorf("stage document %s: %w", path, err)
+	}
+	stagedPath := staged.Name()
+	cleanup := func() { _ = os.Remove(stagedPath) }
+
+	if _, err := staged.Write(content); err != nil {
+		_ = staged.Close()
+		cleanup()
+		return fmt.Errorf("stage document %s: %w", path, err)
+	}
+	if err := staged.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("stage document %s: %w", path, err)
+	}
+	if err := os.Chmod(stagedPath, 0o644); err != nil {
+		cleanup()
+		return fmt.Errorf("stage document %s: %w", path, err)
+	}
+	if err := os.Rename(stagedPath, path); err != nil {
+		cleanup()
+		return fmt.Errorf("write document %s: %w", path, err)
+	}
 	return nil
 }
 

--- a/internal/spec/write_test.go
+++ b/internal/spec/write_test.go
@@ -1,0 +1,128 @@
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func requirementsDocument(dir, body string) Document {
+	return Document{
+		Path: filepath.Join(dir, "requirements.md"),
+		Fields: map[string]string{
+			"status":               "draft",
+			"approved_at":          "",
+			"last_modified":        "2026-07-10T00:00:00Z",
+			"approved_fingerprint": "",
+		},
+		Body: body,
+	}
+}
+
+func TestSaveDocumentWritesContentWithoutStagingLeftovers(t *testing.T) {
+	dir := t.TempDir()
+	document := requirementsDocument(dir, "# Requirements Document\n")
+
+	if err := SaveDocument(document); err != nil {
+		t.Fatalf("SaveDocument returned error: %v", err)
+	}
+
+	content, err := os.ReadFile(document.Path)
+	if err != nil {
+		t.Fatalf("read saved document: %v", err)
+	}
+	if !strings.Contains(string(content), "# Requirements Document") {
+		t.Fatalf("saved content = %q, want the document body", content)
+	}
+	if !strings.HasPrefix(string(content), "---\n") {
+		t.Fatalf("saved content does not start with frontmatter: %q", content)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read document dir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".walden-doc-") {
+			t.Fatalf("staging leftover %s after a successful save", entry.Name())
+		}
+	}
+	if len(entries) != 1 {
+		t.Fatalf("directory holds %d entries, want only the document", len(entries))
+	}
+}
+
+func TestSaveDocumentFailureLeavesExistingDocumentUntouched(t *testing.T) {
+	dir := t.TempDir()
+	document := requirementsDocument(dir, "ORIGINAL BODY\n")
+
+	if err := SaveDocument(document); err != nil {
+		t.Fatalf("seed original document: %v", err)
+	}
+	original, err := os.ReadFile(document.Path)
+	if err != nil {
+		t.Fatalf("read original: %v", err)
+	}
+
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("make directory read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	document.Body = "REPLACEMENT BODY\n"
+	saveErr := SaveDocument(document)
+	if saveErr == nil {
+		t.Fatal("SaveDocument succeeded in a read-only directory")
+	}
+	if !strings.Contains(saveErr.Error(), document.Path) && !strings.Contains(saveErr.Error(), "requirements.md") {
+		t.Fatalf("error %q does not name the affected document", saveErr)
+	}
+
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("restore directory mode: %v", err)
+	}
+	after, err := os.ReadFile(document.Path)
+	if err != nil {
+		t.Fatalf("read document after failed save: %v", err)
+	}
+	if string(after) != string(original) {
+		t.Fatalf("document changed by a failed save:\nbefore: %q\nafter:  %q", original, after)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".walden-doc-") {
+			t.Fatalf("staging leftover %s after a failed save", entry.Name())
+		}
+	}
+}
+
+func TestSaveDocumentReplacesExistingContentAtomically(t *testing.T) {
+	dir := t.TempDir()
+	document := requirementsDocument(dir, "FIRST\n")
+
+	if err := SaveDocument(document); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	document.Body = "SECOND\n"
+	if err := SaveDocument(document); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+
+	content, err := os.ReadFile(document.Path)
+	if err != nil {
+		t.Fatalf("read document: %v", err)
+	}
+	if !strings.Contains(string(content), "SECOND") || strings.Contains(string(content), "FIRST") {
+		t.Fatalf("content = %q, want the replacement body only", content)
+	}
+
+	info, err := os.Stat(document.Path)
+	if err != nil {
+		t.Fatalf("stat document: %v", err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("document mode = %v, want 0644", info.Mode().Perm())
+	}
+}

--- a/templates/embed_test.go
+++ b/templates/embed_test.go
@@ -1,0 +1,71 @@
+package templates
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+func TestRepoFSExposesBootstrapTemplates(t *testing.T) {
+	repoFS := RepoFS()
+
+	// Paths are relative to the "repo" subtree, so the "repo/" prefix is gone.
+	want := []string{
+		"walden/constitution.md",
+		"walden/lessons.md",
+		"github/pull_request_template.md",
+		"github/workflows/validate-walden.yml",
+	}
+
+	for _, name := range want {
+		data, err := fs.ReadFile(repoFS, name)
+		if err != nil {
+			t.Errorf("ReadFile(%q) failed: %v", name, err)
+			continue
+		}
+		if len(data) == 0 {
+			t.Errorf("ReadFile(%q) returned empty content", name)
+		}
+	}
+}
+
+func TestSpecFSExposesDocumentTemplates(t *testing.T) {
+	specFS := SpecFS()
+
+	want := []string{
+		"requirements.md.tmpl",
+		"design.md.tmpl",
+		"tasks.md.tmpl",
+	}
+
+	for _, name := range want {
+		data, err := fs.ReadFile(specFS, name)
+		if err != nil {
+			t.Errorf("ReadFile(%q) failed: %v", name, err)
+			continue
+		}
+		if len(data) == 0 {
+			t.Errorf("ReadFile(%q) returned empty content", name)
+		}
+	}
+}
+
+func TestRepoWorkflowTemplateCarriesVersionToken(t *testing.T) {
+	data, err := fs.ReadFile(RepoFS(), "github/workflows/validate-walden.yml")
+	if err != nil {
+		t.Fatalf("read workflow template: %v", err)
+	}
+	if !strings.Contains(string(data), "{{WALDEN_VERSION}}") {
+		t.Error("workflow template lost the {{WALDEN_VERSION}} pin token (repo init would generate an unpinned install)")
+	}
+}
+
+func TestSubFilesystemsAreScoped(t *testing.T) {
+	// The repo subtree must not leak spec templates and vice versa.
+	if _, err := fs.Stat(RepoFS(), "requirements.md.tmpl"); err == nil {
+		t.Error("RepoFS unexpectedly exposes spec template requirements.md.tmpl")
+	}
+	if _, err := fs.Stat(SpecFS(), "walden/constitution.md"); err == nil {
+		t.Error("SpecFS unexpectedly exposes repo template walden/constitution.md")
+	}
+}

--- a/templates/repo/github/workflows/validate-walden.yml
+++ b/templates/repo/github/workflows/validate-walden.yml
@@ -25,7 +25,7 @@ jobs:
           go-version: "1.25"
 
       - name: Install walden
-        run: go install github.com/andrearaponi/walden/cmd/walden@latest
+        run: go install github.com/andrearaponi/walden/cmd/walden@{{WALDEN_VERSION}}
 
       - name: Validate Walden specs
         run: |


### PR DESCRIPTION
## Summary

Hardening patch addressing the reliability findings from the external technical review of v0.6.0. Six focused fixes, no change to fingerprint semantics, the document schema, or the workflow model — no existing approved chain goes stale.

## What changed

- **JSON envelope on every error path (WDN-006).** Every execution error inside a recognized command now routes through one shared renderer: `--json` failures emit the versioned envelope on stdout (`ok:false`, canonical command name, blocking cause in the summary) instead of bare text on stderr. `review open/approve` and the whole `skill` group were the offenders; `task *` already complied. Unknown commands/subcommands keep plain usage text. A table-driven contract matrix locks one error mode per `--json` command (`version` excluded: it has no error path).
- **Atomic spec writes (WDN-009).** `SaveDocument` stages in a temp file inside the document's directory and renames into place — the same pattern the skill installer and self-update already use. No failure path can truncate an approved document.
- **Pinned generated CI (WDN-004).** `repo init` stamps its own version into `validate-walden.yml` (`{{WALDEN_VERSION}}` token): release builds pin exactly, source builds fall back to `@latest`, re-init refreshes the pin. A new Walden release can no longer break user CI without a repository change.
- **Demo migrated and gated (WDN-005).** The shipped todo-app-demo predated fingerprints and reported stale under every release since v0.4.0 — the first thing an evaluator touched contradicted the README. It now carries a fresh approval chain and doubles as the compatibility fixture: CI builds the binary and smoke-tests the demo, so future strict migrations break here first, not in a user's repository.
- **CI gates (WDN-018, partial).** `go vet` and `go test -race` join the pipeline.
- **Seam coverage (WDN-011).** `internal/shell` had zero direct coverage; the real `ExecRunner` and the embedded template filesystems now have dedicated suites.
- **Roadmap currency (WDN-019).** The public roadmap pointed at v0.4.0; it now reflects the v0.7.x line.

## Compatibility

- Envelope changes are additive within `schema_version: v0beta1`; success-path output is byte-identical.
- Text-mode errors keep the bare message on stderr (plus a next-action hint where one exists).
- Arg-validation errors on recognized commands (e.g. `validate` with no feature) now return a precise message instead of the generic usage dump — under `--json` they return an envelope.

## Deliberately deferred

Anti-vacuous proof detection, evidence ledger, and proof timeouts belong to the v0.8 evidence design; document-type-aware fingerprint normalization and parser unification need document schema versioning to migrate safely.

## Testing

Developed through the Walden gated workflow (7 EARS requirements, 100% task and proof reference coverage, every task closed through `walden task complete`). Full suite green with vet and race locally; the new CI gates and the demo smoke run on this PR itself.