### PR TITLE
feat: execution evidence ledger — derived states, walden verify, output assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ walden lesson log --feature user-auth --phase execute \
 | `task start <feature> [task-id] [--json]` | Get execution context for the next or a specific task |
 | `task complete <feature> <task-id> [--json]` | Run verification proof and mark task complete |
 | `task complete-all <feature> [--json]` | Complete all runnable tasks in order, stop on first failure |
+| `verify <feature> [--all] [--check] [--json]` | Re-prove completed tasks against the current code and refresh evidence |
+| `evidence status <feature> [--json]` | Report each task's derived execution-evidence state |
 | `reconcile <feature> [--json]` | Repair stale approval chains after upstream edits |
 | `lesson log [--json]` | Append a lesson to `.walden/lessons.md` |
 | `version [--json]` | Print build version and schema version |
@@ -313,6 +315,16 @@ For pipes, `&&`, or globbing, use the Kubernetes shell pattern:
   - command: ["sh", "-c", "test -d .walden && go test ./..."]
 ```
 
+### Output Assertions
+
+`expect_output` requires the step's combined output to contain the declared content — closing the vacuous-pass hole where a test command matching zero tests exits 0:
+
+```markdown
+- Verification:
+  - command: ["go", "test", "-run", "TestAuth", "./internal/auth/"]
+    expect_output: "--- PASS: TestAuth"
+```
+
 ### Multi-Step Verification
 
 Steps run in order, stopping on first failure:
@@ -330,6 +342,31 @@ Single-line format is deprecated. It does not support quotes, pipes, or shell op
 ```markdown
 - Verification: go test ./...
 ```
+
+## Evidence
+
+Completing a task records durable execution evidence in `.walden/evidence/<feature>.json`: the proof's steps (argv, exit codes, output digests) bound to the approved chain fingerprints and to a **code identity** — a deterministic hash of the working tree with `.walden/` excluded, so committing the evidence never invalidates it. The checkbox in `tasks.md` stays the human-readable projection; the evidence document is the authoritative execution state, committed and reviewed like the specs it proves.
+
+States are **derived at read time**, never stored:
+
+| State | Meaning |
+| --- | --- |
+| `verified` | The recorded proof matches the current spec chain and the current code |
+| `stale-spec` | Requirements, design, or this task's definition changed since the proof ran |
+| `stale-code` | The working tree changed since the proof ran |
+| `failed` | The last re-verification failed |
+| `unrecorded` | Completed before the ledger existed (`walden verify` upgrades it) |
+| `pending` | Not completed yet |
+
+Re-prove the current code on demand:
+
+```bash
+walden verify <feature>          # re-run proofs for non-verified completed tasks
+walden verify <feature> --all    # re-run every completed task's proof
+walden verify <feature> --check  # report only — writes nothing (CI-friendly)
+```
+
+`walden evidence status <feature>` reports the derived states without running anything (always exit 0). `walden task status` warns when completed tasks are no longer verified — a spec change or code change is visible as staleness instead of hiding behind a checked box. Timestamps in evidence records are human context only: every verdict depends exclusively on content identities.
 
 ## EARS
 

--- a/internal/app/evidence.go
+++ b/internal/app/evidence.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/andrearaponi/walden/internal/output"
+	"github.com/andrearaponi/walden/internal/workflow"
+)
+
+func runEvidence(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) > 0 && args[0] == "status" {
+		return runEvidenceStatus(args[1:], stdout, stderr)
+	}
+
+	_, _ = fmt.Fprintf(stderr, "unknown command: evidence %s\n\n", strings.Join(args, " "))
+	printUsage(stderr)
+	return 1
+}
+
+func runEvidenceStatus(args []string, stdout io.Writer, stderr io.Writer) int {
+	jsonMode := false
+	positional := make([]string, 0, len(args))
+	for _, arg := range args {
+		if arg == "--json" {
+			jsonMode = true
+			continue
+		}
+		positional = append(positional, arg)
+	}
+
+	if len(positional) != 1 {
+		return emitResult("evidence-status", errorResult(errors.New("evidence status requires exactly one feature name")), jsonMode, stdout, stderr)
+	}
+
+	root, err := os.Getwd()
+	if err != nil {
+		return emitResult("evidence-status", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
+	}
+
+	featureName, entries, err := workflow.EvidenceReport(context.Background(), root, positional[0])
+	if err != nil {
+		return emitResult("evidence-status", errorResult(err), jsonMode, stdout, stderr)
+	}
+
+	counts := map[string]int{}
+	rendered := make([]output.EvidenceStatus, 0, len(entries))
+	for _, entry := range entries {
+		counts[entry.State]++
+		rendered = append(rendered, output.EvidenceStatus{
+			TaskID:           entry.TaskID,
+			State:            entry.State,
+			RecordedIdentity: entry.RecordedIdentity,
+			CurrentIdentity:  entry.CurrentIdentity,
+		})
+	}
+
+	summaryParts := []string{}
+	for _, state := range []string{"verified", "failed", "stale-spec", "stale-code", "unrecorded", "pending"} {
+		if counts[state] > 0 {
+			summaryParts = append(summaryParts, fmt.Sprintf("%d %s", counts[state], state))
+		}
+	}
+	summary := fmt.Sprintf("evidence status for %s", featureName)
+	if len(summaryParts) > 0 {
+		summary = fmt.Sprintf("evidence status for %s: %s", featureName, strings.Join(summaryParts, ", "))
+	}
+
+	// Evidence status is a report, not a gate: derived states never change
+	// the exit code.
+	result := output.Result{Summary: summary, Evidence: rendered, ExitCode: 0}
+	if counts["stale-spec"]+counts["stale-code"]+counts["failed"]+counts["unrecorded"] > 0 {
+		result.NextAction = fmt.Sprintf("Run walden verify %s to re-prove the current code", featureName)
+	}
+	return emitResult("evidence-status", result, jsonMode, stdout, stderr)
+}

--- a/internal/app/evidence_status_command_test.go
+++ b/internal/app/evidence_status_command_test.go
@@ -1,0 +1,108 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/output"
+)
+
+func TestEvidenceStatusCommandReportsVerified(t *testing.T) {
+	setupEvidenceFeature(t)
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"evidence", "status", "todo-app-demo", "--json"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("evidence status exited %d: %s", exitCode, stderr.String())
+	}
+
+	var envelope output.Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if envelope.Command != "evidence-status" || !envelope.OK {
+		t.Fatalf("envelope = %s ok=%t", envelope.Command, envelope.OK)
+	}
+	if len(envelope.Result.Evidence) != 1 || envelope.Result.Evidence[0].State != "verified" {
+		t.Fatalf("evidence = %+v, want one verified entry", envelope.Result.Evidence)
+	}
+	if !strings.Contains(envelope.Result.Summary, "1 verified") {
+		t.Fatalf("summary %q lacks state counts", envelope.Result.Summary)
+	}
+}
+
+func TestEvidenceStatusCommandStaysZeroOnStaleSpec(t *testing.T) {
+	root := setupEvidenceFeature(t)
+
+	// Requirements change and the chain is re-approved with fresh
+	// fingerprints — the WDN-002 revival — while proofs never rerun.
+	writeStatusFeatureFile(t, root, "todo-app-demo", "requirements.md", `---
+status: approved
+approved_at: 2026-03-22T09:00:00Z
+last_modified: 2026-03-22T09:00:00Z
+---
+
+# Requirements Document
+
+## R2 Brand new behavior
+`)
+	writeStatusFeatureFile(t, root, "todo-app-demo", "design.md", `---
+status: approved
+approved_at: 2026-03-22T09:10:00Z
+last_modified: 2026-03-22T09:10:00Z
+source_requirements_approved_at: 2026-03-22T09:00:00Z
+---
+
+# Feature Design
+`)
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"evidence", "status", "todo-app-demo"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("report-not-gate violated: exit %d (%s)", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "stale-spec") {
+		t.Fatalf("output does not surface stale-spec: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "walden verify") {
+		t.Fatalf("output does not point at the remedy: %s", stdout.String())
+	}
+}
+
+func TestEvidenceStatusCommandTaskStatusWarningPassthrough(t *testing.T) {
+	root := setupEvidenceFeature(t)
+
+	writeStatusFeatureFile(t, root, "todo-app-demo", "requirements.md", `---
+status: approved
+approved_at: 2026-03-22T09:00:00Z
+last_modified: 2026-03-22T09:00:00Z
+---
+
+# Requirements Document
+
+## R2 Brand new behavior
+`)
+	writeStatusFeatureFile(t, root, "todo-app-demo", "design.md", `---
+status: approved
+approved_at: 2026-03-22T09:10:00Z
+last_modified: 2026-03-22T09:10:00Z
+source_requirements_approved_at: 2026-03-22T09:00:00Z
+---
+
+# Feature Design
+`)
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"task", "status", "todo-app-demo"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("task status exited %d: %s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "stale-spec") || !strings.Contains(stdout.String(), "evidence") {
+		t.Fatalf("task status does not surface the evidence warning: %s", stdout.String())
+	}
+}

--- a/internal/app/json_contract_test.go
+++ b/internal/app/json_contract_test.go
@@ -145,6 +145,16 @@ func TestJSONErrorContract(t *testing.T) {
 			args:        []string{"skill", "uninstall", "--all", "--project", "--json"},
 			wantCommand: "skill-uninstall",
 		},
+		{
+			name:        "verify with invalid feature name",
+			args:        []string{"verify", "!!!", "--json"},
+			wantCommand: "verify",
+		},
+		{
+			name:        "evidence status with invalid feature name",
+			args:        []string{"evidence", "status", "!!!", "--json"},
+			wantCommand: "evidence-status",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -42,6 +42,8 @@ var commandUsages = []commandUsage{
 	{"task start <feature> [task-id] [--json]", "Resolve normalized execution context for a task"},
 	{"task complete <feature> <task-id> [--json]", "Run a task's proofs and mark it complete"},
 	{"task complete-all <feature> [--json]", "Complete all runnable tasks in order"},
+	{"verify <feature> [--all] [--check] [--json]", "Re-prove completed tasks against the current code and refresh evidence"},
+	{"evidence status <feature> [--json]", "Report each completed task's derived execution-evidence state"},
 	{"validate <feature> [--all] [--json]", "Check EARS, traceability, and freshness"},
 	{"review open <feature> --phase <phase> [--json]", "Open the review gate (move to in-review)"},
 	{"review approve <feature> --phase <phase> [--json]", "Approve the review gate (move to approved)"},
@@ -82,6 +84,10 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 		return runTask(args[1:], stdout, stderr)
 	case "validate":
 		return runValidate(args[1:], stdout, stderr)
+	case "verify":
+		return runVerify(args[1:], stdout, stderr)
+	case "evidence":
+		return runEvidence(args[1:], stdout, stderr)
 	case "review":
 		return runReview(args[1:], stdout, stderr)
 	case "skill":
@@ -961,6 +967,7 @@ func taskStatusSuccessResult(readiness workflow.ExecutionReadiness) output.Resul
 	if readiness.NextTask != nil {
 		result.Task = toOutputTaskStatus(*readiness.NextTask)
 	}
+	result.Warnings = append(result.Warnings, readiness.EvidenceWarnings...)
 
 	return result
 }
@@ -1069,8 +1076,9 @@ func taskCompleteSuccessResult(result workflow.TaskCompletionResult) output.Resu
 		Summary:      fmt.Sprintf("task completed for %s", result.Feature),
 		CurrentPhase: string(result.CurrentPhase),
 		Task:         toOutputTaskStatus(result.Task),
-		ChangedFiles: []string{".walden/specs/" + result.Feature + "/tasks.md"},
+		ChangedFiles: []string{".walden/specs/" + result.Feature + "/tasks.md", ".walden/evidence/" + result.Feature + ".json"},
 		NextAction:   result.NextAction,
+		Warnings:     result.Warnings,
 		ExitCode:     0,
 	}
 }

--- a/internal/app/verify.go
+++ b/internal/app/verify.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/andrearaponi/walden/internal/output"
+	"github.com/andrearaponi/walden/internal/workflow"
+)
+
+func runVerify(args []string, stdout io.Writer, stderr io.Writer) int {
+	jsonMode := false
+	all := false
+	check := false
+	positional := make([]string, 0, len(args))
+	for _, arg := range args {
+		switch arg {
+		case "--json":
+			jsonMode = true
+		case "--all":
+			all = true
+		case "--check":
+			check = true
+		default:
+			positional = append(positional, arg)
+		}
+	}
+
+	if len(positional) != 1 {
+		return emitResult("verify", errorResult(errors.New("verify requires exactly one feature name")), jsonMode, stdout, stderr)
+	}
+
+	root, err := os.Getwd()
+	if err != nil {
+		return emitResult("verify", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
+	}
+
+	verifyResult, err := workflow.Verify(context.Background(), root, positional[0], all, check, commandRunner)
+	if err != nil {
+		return emitResult("verify", errorResult(err), jsonMode, stdout, stderr)
+	}
+
+	result := verifyOutputResult(verifyResult)
+	return emitResult("verify", result, jsonMode, stdout, stderr)
+}
+
+func verifyOutputResult(verifyResult workflow.VerifyResult) output.Result {
+	entries := make([]output.EvidenceStatus, 0, len(verifyResult.Outcomes))
+	for _, outcome := range verifyResult.Outcomes {
+		passed := outcome.Passed
+		entries = append(entries, output.EvidenceStatus{
+			TaskID:  outcome.TaskID,
+			State:   outcome.State,
+			Passed:  &passed,
+			Failure: outcome.Failure,
+		})
+	}
+
+	suffix := ""
+	if verifyResult.Checked {
+		suffix = " (check mode: nothing persisted)"
+	}
+
+	result := output.Result{Evidence: entries, ExitCode: 0}
+	switch {
+	case len(verifyResult.Failed) > 0:
+		result.Summary = fmt.Sprintf("verification failed for %s: %s%s", verifyResult.Feature, strings.Join(verifyResult.Failed, ", "), suffix)
+		result.NextAction = fmt.Sprintf("Fix the failing proofs and rerun walden verify %s", verifyResult.Feature)
+		result.ExitCode = 1
+	case len(verifyResult.Outcomes) == 0:
+		result.Summary = fmt.Sprintf("nothing to verify for %s: %d completed task(s) already verified%s", verifyResult.Feature, len(verifyResult.Skipped), suffix)
+	default:
+		result.Summary = fmt.Sprintf("verification passed for %s: %d task(s) re-proven, %d skipped as verified%s", verifyResult.Feature, len(verifyResult.Outcomes), len(verifyResult.Skipped), suffix)
+	}
+	return result
+}

--- a/internal/app/verify_command_test.go
+++ b/internal/app/verify_command_test.go
@@ -1,0 +1,163 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/output"
+	"github.com/andrearaponi/walden/internal/testutil"
+)
+
+// setupEvidenceFeature bootstraps a real repository in a temp cwd, approves a
+// one-task feature, and completes it through the CLI so evidence exists.
+func setupEvidenceFeature(t *testing.T) string {
+	t.Helper()
+	root := chdirContract(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"repo", "init"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("repo init failed: %s", stderr.String())
+	}
+	if code := Run([]string{"feature", "init", "Todo App Demo"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("feature init failed: %s", stderr.String())
+	}
+
+	writeStatusFeatureFile(t, root, "todo-app-demo", "requirements.md", `---
+status: approved
+approved_at: 2026-03-22T07:00:00Z
+last_modified: 2026-03-22T07:00:00Z
+---
+
+# Requirements Document
+`)
+	writeStatusFeatureFile(t, root, "todo-app-demo", "design.md", `---
+status: approved
+approved_at: 2026-03-22T07:10:00Z
+last_modified: 2026-03-22T07:10:00Z
+source_requirements_approved_at: 2026-03-22T07:00:00Z
+---
+
+# Feature Design
+`)
+	writeStatusFeatureFile(t, root, "todo-app-demo", "tasks.md", `---
+status: approved
+approved_at: 2026-03-22T07:20:00Z
+last_modified: 2026-03-22T07:20:00Z
+source_design_approved_at: 2026-03-22T07:10:00Z
+---
+
+# Implementation Plan
+
+- [ ] 1. Build parser
+  - [ ] 1.1 Implement parser
+    - Requirements: `+"`R1`"+`
+    - Design: Task Store
+    - Verification:
+      - command: ["go", "test", "./internal/spec"]
+`)
+
+	overrideCommandRunner(t, testutil.NewFakeRunner(testutil.Response{Stdout: "ok", ExitCode: 0}))
+	if code := Run([]string{"task", "complete", "todo-app-demo", "1.1"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("task complete failed: %s", stderr.String())
+	}
+	return root
+}
+
+func overrideCommandRunner(t *testing.T, runner *testutil.FakeRunner) *testutil.FakeRunner {
+	t.Helper()
+	previous := commandRunner
+	commandRunner = runner
+	t.Cleanup(func() { commandRunner = previous })
+	return runner
+}
+
+func TestRunVerifyDefaultSkipsVerifiedTasks(t *testing.T) {
+	setupEvidenceFeature(t)
+	runner := overrideCommandRunner(t, testutil.NewFakeRunner())
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"verify", "todo-app-demo"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("verify exited %d: %s", exitCode, stderr.String())
+	}
+	if len(runner.Calls()) != 0 {
+		t.Fatalf("verified task re-executed: %v", runner.Calls())
+	}
+	if !strings.Contains(stdout.String(), "already verified") {
+		t.Fatalf("summary does not report the skip: %s", stdout.String())
+	}
+}
+
+func TestRunVerifyAllReprovesAndReportsJSON(t *testing.T) {
+	setupEvidenceFeature(t)
+	overrideCommandRunner(t, testutil.NewFakeRunner(testutil.Response{Stdout: "ok", ExitCode: 0}))
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"verify", "todo-app-demo", "--all", "--json"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("verify --all exited %d: %s", exitCode, stderr.String())
+	}
+
+	var envelope output.Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if envelope.Command != "verify" || !envelope.OK {
+		t.Fatalf("envelope = %s ok=%t", envelope.Command, envelope.OK)
+	}
+	if len(envelope.Result.Evidence) != 1 {
+		t.Fatalf("evidence entries = %d, want 1", len(envelope.Result.Evidence))
+	}
+	entry := envelope.Result.Evidence[0]
+	if entry.TaskID != "1.1" || entry.State != "verified" || entry.Passed == nil || !*entry.Passed {
+		t.Fatalf("entry = %+v, want 1.1 verified passed", entry)
+	}
+}
+
+func TestRunVerifyFailureExitsNonZeroNamingTasks(t *testing.T) {
+	setupEvidenceFeature(t)
+	overrideCommandRunner(t, testutil.NewFakeRunner(testutil.Response{Stderr: "boom", ExitCode: 1}))
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"verify", "todo-app-demo", "--all"}, &stdout, &stderr)
+
+	if exitCode == 0 {
+		t.Fatal("failing verify exited zero")
+	}
+	if !strings.Contains(stderr.String(), "verification failed") || !strings.Contains(stderr.String(), "1.1") {
+		t.Fatalf("stderr %q does not name the failed task", stderr.String())
+	}
+}
+
+func TestRunVerifyCheckPersistsNothing(t *testing.T) {
+	root := setupEvidenceFeature(t)
+	overrideCommandRunner(t, testutil.NewFakeRunner(testutil.Response{Stdout: "ok", ExitCode: 0}))
+
+	ledgerPath := root + "/.walden/evidence/todo-app-demo.json"
+	before, err := os.ReadFile(ledgerPath)
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"verify", "todo-app-demo", "--all", "--check"}, &stdout, &stderr)
+	if exitCode != 0 {
+		t.Fatalf("verify --check exited %d: %s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "check mode") {
+		t.Fatalf("summary does not note check mode: %s", stdout.String())
+	}
+
+	after, err := os.ReadFile(ledgerPath)
+	if err != nil {
+		t.Fatalf("read ledger after: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Fatal("check mode modified the ledger")
+	}
+}

--- a/internal/evidence/derive.go
+++ b/internal/evidence/derive.go
@@ -1,0 +1,78 @@
+package evidence
+
+// Derived task states, ordered by precedence: failed > stale-spec >
+// stale-code > verified; unrecorded and pending stand apart.
+const (
+	StateVerified   = "verified"
+	StateFailed     = "failed"
+	StateStaleSpec  = "stale-spec"
+	StateStaleCode  = "stale-code"
+	StateUnrecorded = "unrecorded"
+	StatePending    = "pending"
+)
+
+// ChainFingerprints carries the current approved fingerprints records are
+// compared against. Task-definition fingerprints travel on each LeafTask.
+type ChainFingerprints struct {
+	Requirements string
+	Design       string
+}
+
+// LeafTask is the minimal task view derivation needs.
+type LeafTask struct {
+	ID          string
+	Completed   bool
+	Fingerprint string
+}
+
+// TaskEvidence is one task's derived execution state.
+type TaskEvidence struct {
+	TaskID           string
+	State            string
+	RecordedIdentity string
+	CurrentIdentity  string
+}
+
+// Derive computes every task's state from facts at read time — the record's
+// bindings against the current chain and code identity. Nothing here reads
+// or writes stored status labels, and timestamps never participate.
+func Derive(document Document, current ChainFingerprints, currentIdentity string, identityOK bool, tasks []LeafTask) []TaskEvidence {
+	derived := make([]TaskEvidence, 0, len(tasks))
+	if !identityOK {
+		currentIdentity = ""
+	}
+
+	for _, task := range tasks {
+		record, recorded := document.Tasks[task.ID]
+
+		entry := TaskEvidence{TaskID: task.ID, CurrentIdentity: currentIdentity}
+		switch {
+		case !task.Completed:
+			entry.State = StatePending
+		case !recorded:
+			entry.State = StateUnrecorded
+		default:
+			entry.RecordedIdentity = record.CodeIdentity
+			entry.State = recordState(record, current, task, currentIdentity)
+		}
+		derived = append(derived, entry)
+	}
+	return derived
+}
+
+func recordState(record Record, current ChainFingerprints, task LeafTask, currentIdentity string) string {
+	switch {
+	case record.Result != ResultPassed:
+		return StateFailed
+	case record.RequirementsFingerprint != current.Requirements,
+		record.DesignFingerprint != current.Design,
+		record.TaskFingerprint != task.Fingerprint:
+		return StateStaleSpec
+	case record.CodeIdentity != currentIdentity:
+		// Two absent identities compare equal: no-git repositories never
+		// drown in stale-code noise.
+		return StateStaleCode
+	default:
+		return StateVerified
+	}
+}

--- a/internal/evidence/derive_test.go
+++ b/internal/evidence/derive_test.go
@@ -1,0 +1,137 @@
+package evidence
+
+import "testing"
+
+func TestDeriveStatesAndPrecedence(t *testing.T) {
+	current := ChainFingerprints{Requirements: "sha256:req", Design: "sha256:des"}
+	baseRecord := func() Record {
+		return Record{
+			TaskFingerprint:         "sha256:task",
+			RequirementsFingerprint: "sha256:req",
+			DesignFingerprint:       "sha256:des",
+			TasksFingerprint:        "sha256:tasks",
+			CodeIdentity:            "sha256:code",
+			Result:                  ResultPassed,
+		}
+	}
+	task := LeafTask{ID: "1.1", Completed: true, Fingerprint: "sha256:task"}
+
+	cases := []struct {
+		name            string
+		mutate          func(*Record)
+		task            LeafTask
+		recorded        bool
+		currentIdentity string
+		identityOK      bool
+		want            string
+	}{
+		{
+			name: "verified when every binding matches",
+			task: task, recorded: true, currentIdentity: "sha256:code", identityOK: true,
+			want: StateVerified,
+		},
+		{
+			name: "pending when the task is unchecked",
+			task: LeafTask{ID: "1.1", Completed: false}, recorded: true,
+			currentIdentity: "sha256:code", identityOK: true,
+			want: StatePending,
+		},
+		{
+			name: "unrecorded when completed without an entry",
+			task: task, recorded: false, currentIdentity: "sha256:code", identityOK: true,
+			want: StateUnrecorded,
+		},
+		{
+			name:   "failed result wins",
+			mutate: func(r *Record) { r.Result = ResultFailed },
+			task:   task, recorded: true, currentIdentity: "sha256:code", identityOK: true,
+			want: StateFailed,
+		},
+		{
+			name:   "failed beats stale-spec",
+			mutate: func(r *Record) { r.Result = ResultFailed; r.RequirementsFingerprint = "sha256:old" },
+			task:   task, recorded: true, currentIdentity: "sha256:code", identityOK: true,
+			want: StateFailed,
+		},
+		{
+			name:   "requirements change is stale-spec",
+			mutate: func(r *Record) { r.RequirementsFingerprint = "sha256:old" },
+			task:   task, recorded: true, currentIdentity: "sha256:code", identityOK: true,
+			want: StateStaleSpec,
+		},
+		{
+			name:   "design change is stale-spec",
+			mutate: func(r *Record) { r.DesignFingerprint = "sha256:old" },
+			task:   task, recorded: true, currentIdentity: "sha256:code", identityOK: true,
+			want: StateStaleSpec,
+		},
+		{
+			name:     "task definition change is stale-spec",
+			task:     LeafTask{ID: "1.1", Completed: true, Fingerprint: "sha256:edited"},
+			recorded: true, currentIdentity: "sha256:code", identityOK: true,
+			want: StateStaleSpec,
+		},
+		{
+			name:   "stale-spec beats stale-code",
+			mutate: func(r *Record) { r.RequirementsFingerprint = "sha256:old" },
+			task:   task, recorded: true, currentIdentity: "sha256:moved", identityOK: true,
+			want: StateStaleSpec,
+		},
+		{
+			name: "code change is stale-code",
+			task: task, recorded: true, currentIdentity: "sha256:moved", identityOK: true,
+			want: StateStaleCode,
+		},
+		{
+			name:   "absent identities compare equal",
+			mutate: func(r *Record) { r.CodeIdentity = "" },
+			task:   task, recorded: true, currentIdentity: "", identityOK: false,
+			want: StateVerified,
+		},
+		{
+			name: "recorded identity with absent current is stale-code",
+			task: task, recorded: true, currentIdentity: "", identityOK: false,
+			want: StateStaleCode,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			record := baseRecord()
+			if tc.mutate != nil {
+				tc.mutate(&record)
+			}
+			document := Document{Feature: "f", Tasks: map[string]Record{}}
+			if tc.recorded {
+				document.Tasks["1.1"] = record
+			}
+
+			derived := Derive(document, current, tc.currentIdentity, tc.identityOK, []LeafTask{tc.task})
+			if len(derived) != 1 {
+				t.Fatalf("derived %d entries, want 1", len(derived))
+			}
+			if derived[0].State != tc.want {
+				t.Fatalf("state = %s, want %s", derived[0].State, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeriveNeverConsultsTimestamps(t *testing.T) {
+	current := ChainFingerprints{Requirements: "sha256:req", Design: "sha256:des"}
+	record := Record{
+		TaskFingerprint:         "sha256:task",
+		RequirementsFingerprint: "sha256:req",
+		DesignFingerprint:       "sha256:des",
+		CodeIdentity:            "sha256:code",
+		Result:                  ResultPassed,
+		VerifiedAt:              "1999-01-01T00:00:00Z",
+	}
+	document := Document{Feature: "f", Tasks: map[string]Record{"1.1": record}}
+	tasks := []LeafTask{{ID: "1.1", Completed: true, Fingerprint: "sha256:task"}}
+
+	derived := Derive(document, current, "sha256:code", true, tasks)
+	if derived[0].State != StateVerified {
+		t.Fatalf("an ancient timestamp influenced the verdict: %s", derived[0].State)
+	}
+}

--- a/internal/evidence/identity.go
+++ b/internal/evidence/identity.go
@@ -1,0 +1,111 @@
+package evidence
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/andrearaponi/walden/internal/shell"
+)
+
+// waldenDir is excluded from the code identity at every layer: spec changes
+// invalidate through fingerprints, and committing the evidence document must
+// never invalidate the evidence it carries.
+const waldenDir = ".walden"
+
+// Identity derives a deterministic identity of the working tree as one
+// uniform path→blob map: the .walden-filtered HEAD listing seeds committed
+// blob ids, and every dirty or untracked path overrides its entry with the
+// blob id of its current content (git hash-object). Uniform blob ids on both
+// layers mean committing an unchanged file never moves the identity.
+// Identical content yields identical identities regardless of branch names,
+// timestamps, or .walden contents. The second return is false when git is
+// unavailable — callers record the absence and continue.
+func Identity(ctx context.Context, runner shell.Runner, root string) (string, bool) {
+	status, err := runner.Run(ctx, "git", "-C", root, "status", "--porcelain", "--untracked-files=all", "-z", "--", ".", ":(exclude)"+waldenDir)
+	if err != nil || status.ExitCode != 0 {
+		return "", false
+	}
+
+	// Unborn HEAD (no commits yet) degrades to the overlay alone; the
+	// repository itself is proven present by the successful status call.
+	blobs := map[string]string{}
+	if lsTree, err := runner.Run(ctx, "git", "-C", root, "ls-tree", "-r", "HEAD"); err == nil && lsTree.ExitCode == 0 {
+		seedListing(blobs, lsTree.Stdout)
+	}
+
+	if !applyOverlay(ctx, runner, root, status.Stdout, blobs) {
+		return "", false
+	}
+
+	entries := make([]string, 0, len(blobs))
+	for path, blob := range blobs {
+		entries = append(entries, path+":"+blob)
+	}
+	sort.Strings(entries)
+
+	sum := sha256.Sum256([]byte(strings.Join(entries, "\n")))
+	return "sha256:" + hex.EncodeToString(sum[:]), true
+}
+
+// seedListing fills the blob map from a `git ls-tree -r HEAD` listing
+// (format: "<mode> <type> <hash>\t<path>"), dropping .walden/ entries.
+func seedListing(blobs map[string]string, listing string) {
+	for _, line := range strings.Split(listing, "\n") {
+		meta, path, found := strings.Cut(line, "\t")
+		if !found || isWaldenPath(path) {
+			continue
+		}
+		fields := strings.Fields(meta)
+		if len(fields) < 3 {
+			continue
+		}
+		blobs[path] = fields[2]
+	}
+}
+
+// applyOverlay overrides the blob map with the current content of every
+// dirty or untracked path from NUL-separated porcelain output, using git
+// hash-object so the representation matches committed entries. Deleted
+// paths leave the map.
+func applyOverlay(ctx context.Context, runner shell.Runner, root, porcelain string, blobs map[string]string) bool {
+	fields := strings.Split(porcelain, "\x00")
+	for index := 0; index < len(fields); index++ {
+		entry := fields[index]
+		if len(entry) < 4 {
+			continue
+		}
+		statusCode, path := entry[:2], entry[3:]
+		if strings.HasPrefix(statusCode, "R") || strings.HasPrefix(statusCode, "C") {
+			// Renames and copies carry the source path as the next field.
+			index++
+		}
+		if isWaldenPath(path) {
+			continue
+		}
+
+		if _, err := os.Stat(filepath.Join(root, path)); os.IsNotExist(err) {
+			delete(blobs, path)
+			continue
+		}
+
+		hashed, err := runner.Run(ctx, "git", "-C", root, "hash-object", "--", path)
+		if err != nil || hashed.ExitCode != 0 {
+			return false
+		}
+		blob := strings.TrimSpace(hashed.Stdout)
+		if blob == "" {
+			return false
+		}
+		blobs[path] = blob
+	}
+	return true
+}
+
+func isWaldenPath(path string) bool {
+	return path == waldenDir || strings.HasPrefix(path, waldenDir+"/")
+}

--- a/internal/evidence/identity_test.go
+++ b/internal/evidence/identity_test.go
@@ -1,0 +1,218 @@
+package evidence
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/shell"
+)
+
+// fakeGit answers git subcommands from a canned map keyed by the second
+// argument after -C <root> (e.g. "status", "ls-tree").
+type fakeGit struct {
+	responses map[string]shell.Response
+	errors    map[string]error
+}
+
+func (f *fakeGit) Run(_ context.Context, name string, args ...string) (shell.Response, error) {
+	if name != "git" || len(args) < 3 {
+		return shell.Response{}, errors.New("unexpected invocation")
+	}
+	sub := args[2]
+	if err, exists := f.errors[sub]; exists {
+		return shell.Response{}, err
+	}
+	if sub == "hash-object" {
+		// Content-derived fake blob id: sha256 of the file, mirroring how
+		// real blob ids are stable functions of content.
+		root, path := args[1], args[len(args)-1]
+		content, err := os.ReadFile(filepath.Join(root, path))
+		if err != nil {
+			return shell.Response{ExitCode: 128, Stderr: err.Error()}, nil
+		}
+		sum := sha256.Sum256(content)
+		return shell.Response{ExitCode: 0, Stdout: hex.EncodeToString(sum[:]) + "\n"}, nil
+	}
+	if resp, exists := f.responses[sub]; exists {
+		return resp, nil
+	}
+	return shell.Response{ExitCode: 0}, nil
+}
+
+func lsTreeListing(lines ...string) string {
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func TestIdentityCleanTreeExcludesWalden(t *testing.T) {
+	root := t.TempDir()
+
+	withEvidence := &fakeGit{responses: map[string]shell.Response{
+		"status": {ExitCode: 0},
+		"ls-tree": {ExitCode: 0, Stdout: lsTreeListing(
+			"100644 blob aaa\tmain.go",
+			"100644 blob bbb\t.walden/evidence/f.json",
+		)},
+	}}
+	withoutEvidence := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0},
+		"ls-tree": {ExitCode: 0, Stdout: lsTreeListing("100644 blob aaa\tmain.go")},
+	}}
+	differentCode := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0},
+		"ls-tree": {ExitCode: 0, Stdout: lsTreeListing("100644 blob ccc\tmain.go")},
+	}}
+
+	first, ok := Identity(context.Background(), withEvidence, root)
+	if !ok {
+		t.Fatal("identity not computed")
+	}
+	second, ok := Identity(context.Background(), withoutEvidence, root)
+	if !ok {
+		t.Fatal("identity not computed")
+	}
+	third, ok := Identity(context.Background(), differentCode, root)
+	if !ok {
+		t.Fatal("identity not computed")
+	}
+
+	if first != second {
+		t.Fatalf("committing .walden content changed the identity: %s vs %s", first, second)
+	}
+	if first == third {
+		t.Fatal("a code change did not change the identity")
+	}
+	if !strings.HasPrefix(first, "sha256:") {
+		t.Fatalf("identity %q lacks the sha256 prefix", first)
+	}
+}
+
+func TestIdentityDirtyOverlayIsOrderIndependent(t *testing.T) {
+	root := t.TempDir()
+	for name, content := range map[string]string{"a.go": "alpha", "b.go": "beta"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	orderAB := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: " M a.go\x00?? b.go\x00"},
+		"ls-tree": {ExitCode: 0, Stdout: lsTreeListing("100644 blob aaa\tmain.go")},
+	}}
+	orderBA := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: "?? b.go\x00 M a.go\x00"},
+		"ls-tree": {ExitCode: 0, Stdout: lsTreeListing("100644 blob aaa\tmain.go")},
+	}}
+
+	first, _ := Identity(context.Background(), orderAB, root)
+	second, _ := Identity(context.Background(), orderBA, root)
+	if first != second {
+		t.Fatalf("status ordering changed the identity: %s vs %s", first, second)
+	}
+}
+
+func TestIdentityTracksUntrackedContent(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "new.go")
+	if err := os.WriteFile(path, []byte("v1"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	git := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: "?? new.go\x00"},
+		"ls-tree": {ExitCode: 0, Stdout: ""},
+	}}
+
+	before, _ := Identity(context.Background(), git, root)
+	if err := os.WriteFile(path, []byte("v2"), 0o644); err != nil {
+		t.Fatalf("rewrite file: %v", err)
+	}
+	after, _ := Identity(context.Background(), git, root)
+
+	if before == after {
+		t.Fatal("untracked content change did not change the identity")
+	}
+}
+
+func TestIdentityHandlesDeletedFiles(t *testing.T) {
+	root := t.TempDir()
+	git := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: " D gone.go\x00"},
+		"ls-tree": {ExitCode: 0, Stdout: lsTreeListing("100644 blob aaa\tgone.go")},
+	}}
+
+	identity, ok := Identity(context.Background(), git, root)
+	if !ok || identity == "" {
+		t.Fatal("deleted file broke identity computation")
+	}
+}
+
+func TestIdentityUnbornHeadUsesOverlayAlone(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "first.go"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	git := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: "?? first.go\x00"},
+		"ls-tree": {ExitCode: 128, Stderr: "fatal: not a valid object name HEAD"},
+	}}
+
+	identity, ok := Identity(context.Background(), git, root)
+	if !ok || identity == "" {
+		t.Fatal("unborn HEAD did not degrade to the overlay")
+	}
+}
+
+func TestIdentityGitFailureReturnsAbsent(t *testing.T) {
+	root := t.TempDir()
+
+	cases := []*fakeGit{
+		{responses: map[string]shell.Response{"status": {ExitCode: 128, Stderr: "fatal: not a git repository"}}},
+		{errors: map[string]error{"status": errors.New("executable file not found")}},
+	}
+	for _, git := range cases {
+		if identity, ok := Identity(context.Background(), git, root); ok || identity != "" {
+			t.Fatalf("git failure yielded identity %q ok=%t, want absent", identity, ok)
+		}
+	}
+}
+
+func TestIdentitySurvivesTheCommitTransition(t *testing.T) {
+	// The serpent's little sibling: an untracked file and the same file
+	// committed must produce the same identity — layer transitions are not
+	// content changes.
+	root := t.TempDir()
+	content := []byte("#!/bin/sh\necho 5\n")
+	if err := os.WriteFile(filepath.Join(root, "calc.sh"), content, 0o755); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	blob := sha256.Sum256(content)
+	blobID := hex.EncodeToString(blob[:])
+
+	untracked := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: "?? calc.sh\x00"},
+		"ls-tree": {ExitCode: 128, Stderr: "fatal: not a valid object name HEAD"},
+	}}
+	committed := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0},
+		"ls-tree": {ExitCode: 0, Stdout: "100644 blob " + blobID + "\tcalc.sh\n"},
+	}}
+
+	before, ok := Identity(context.Background(), untracked, root)
+	if !ok {
+		t.Fatal("untracked identity not computed")
+	}
+	after, ok := Identity(context.Background(), committed, root)
+	if !ok {
+		t.Fatal("committed identity not computed")
+	}
+	if before != after {
+		t.Fatalf("committing unchanged content moved the identity: %s vs %s", before, after)
+	}
+}

--- a/internal/evidence/record.go
+++ b/internal/evidence/record.go
@@ -1,0 +1,57 @@
+// Package evidence owns the execution-evidence ledger: durable records
+// binding each completed task's proof to the approved chain fingerprints and
+// to a code identity of the working tree, with states derived from those
+// bindings at read time — never stored.
+package evidence
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// SchemaVersion identifies the evidence document format, versioned
+// independently from the CLI output contract.
+const SchemaVersion = "v1alpha1"
+
+// StepResult captures one executed proof step.
+type StepResult struct {
+	Command      []string `json:"command"`
+	ExpectedExit int      `json:"expected_exit"`
+	ActualExit   int      `json:"actual_exit"`
+	OutputDigest string   `json:"output_digest"`
+}
+
+// Record is the evidence entry for one task: the proof outcome bound to the
+// chain fingerprints and code identity in force when it ran. VerifiedAt is
+// human context only and never influences a derived state.
+type Record struct {
+	TaskFingerprint         string       `json:"task_fingerprint"`
+	RequirementsFingerprint string       `json:"requirements_fingerprint"`
+	DesignFingerprint       string       `json:"design_fingerprint"`
+	TasksFingerprint        string       `json:"tasks_fingerprint"`
+	CodeIdentity            string       `json:"code_identity,omitempty"`
+	Steps                   []StepResult `json:"steps"`
+	Result                  string       `json:"result"`
+	VerifiedAt              string       `json:"verified_at"`
+}
+
+// Result values recorded on entries.
+const (
+	ResultPassed = "passed"
+	ResultFailed = "failed"
+)
+
+// DigestOutput hashes a proof step's combined output for the record: small,
+// deterministic, and free of secrets-in-logs concerns.
+func DigestOutput(output string) string {
+	sum := sha256.Sum256([]byte(output))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// Document is the per-feature evidence ledger: a current-state map keyed by
+// task id. History lives in git, not in the file.
+type Document struct {
+	SchemaVersion string            `json:"schema_version"`
+	Feature       string            `json:"feature"`
+	Tasks         map[string]Record `json:"tasks"`
+}

--- a/internal/evidence/store.go
+++ b/internal/evidence/store.go
@@ -1,0 +1,55 @@
+package evidence
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/andrearaponi/walden/internal/spec"
+)
+
+// DocumentPath returns the evidence document location for a feature. It
+// lives inside the committed .walden/ tree deliberately: evidence is shared
+// repository state, not a local cache.
+func DocumentPath(root, feature string) string {
+	return filepath.Join(root, ".walden", "evidence", feature+".json")
+}
+
+// Load reads the feature's evidence document. An absent file is an empty
+// ledger, not an error.
+func Load(root, feature string) (Document, error) {
+	data, err := os.ReadFile(DocumentPath(root, feature))
+	if errors.Is(err, os.ErrNotExist) {
+		return Document{SchemaVersion: SchemaVersion, Feature: feature, Tasks: map[string]Record{}}, nil
+	}
+	if err != nil {
+		return Document{}, fmt.Errorf("read evidence document: %w", err)
+	}
+
+	var document Document
+	if err := json.Unmarshal(data, &document); err != nil {
+		return Document{}, fmt.Errorf("parse evidence document %s: %w", DocumentPath(root, feature), err)
+	}
+	if document.Tasks == nil {
+		document.Tasks = map[string]Record{}
+	}
+	return document, nil
+}
+
+// Save persists the document atomically, stamping the schema version.
+func Save(root string, document Document) error {
+	document.SchemaVersion = SchemaVersion
+	path := DocumentPath(root, document.Feature)
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create evidence directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode evidence document: %w", err)
+	}
+	return spec.WriteFileAtomic(path, append(data, '\n'))
+}

--- a/internal/evidence/store_test.go
+++ b/internal/evidence/store_test.go
@@ -1,0 +1,104 @@
+package evidence
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func sampleRecord() Record {
+	return Record{
+		TaskFingerprint:         "sha256:task",
+		RequirementsFingerprint: "sha256:req",
+		DesignFingerprint:       "sha256:des",
+		TasksFingerprint:        "sha256:tasks",
+		CodeIdentity:            "sha256:code",
+		Steps: []StepResult{
+			{Command: []string{"go", "test", "./..."}, ExpectedExit: 0, ActualExit: 0, OutputDigest: "sha256:out"},
+		},
+		Result:     ResultPassed,
+		VerifiedAt: "2026-07-10T18:00:00Z",
+	}
+}
+
+func TestEvidenceStoreAbsentFileIsEmptyLedger(t *testing.T) {
+	document, err := Load(t.TempDir(), "user-auth")
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if document.SchemaVersion != SchemaVersion || document.Feature != "user-auth" {
+		t.Fatalf("empty ledger = %+v, want stamped schema and feature", document)
+	}
+	if len(document.Tasks) != 0 {
+		t.Fatalf("empty ledger carries %d tasks", len(document.Tasks))
+	}
+}
+
+func TestEvidenceStoreRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	saved := Document{Feature: "user-auth", Tasks: map[string]Record{"1.1": sampleRecord()}}
+
+	if err := Save(root, saved); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+
+	loaded, err := Load(root, "user-auth")
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if loaded.SchemaVersion != SchemaVersion {
+		t.Fatalf("schema_version = %q, want %q", loaded.SchemaVersion, SchemaVersion)
+	}
+	if !reflect.DeepEqual(loaded.Tasks["1.1"], sampleRecord()) {
+		t.Fatalf("round-trip mismatch:\n%+v\nwant\n%+v", loaded.Tasks["1.1"], sampleRecord())
+	}
+}
+
+func TestEvidenceStoreReplacesEntryPerTask(t *testing.T) {
+	root := t.TempDir()
+	first := sampleRecord()
+	if err := Save(root, Document{Feature: "f", Tasks: map[string]Record{"1.1": first}}); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+
+	replacement := sampleRecord()
+	replacement.CodeIdentity = "sha256:new"
+	if err := Save(root, Document{Feature: "f", Tasks: map[string]Record{"1.1": replacement}}); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+
+	loaded, err := Load(root, "f")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded.Tasks) != 1 || loaded.Tasks["1.1"].CodeIdentity != "sha256:new" {
+		t.Fatalf("entry not replaced: %+v", loaded.Tasks)
+	}
+}
+
+func TestEvidenceStoreWritesAtomicallyInsideWalden(t *testing.T) {
+	root := t.TempDir()
+	if err := Save(root, Document{Feature: "f", Tasks: map[string]Record{"1.1": sampleRecord()}}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	path := DocumentPath(root, "f")
+	if !strings.HasPrefix(path, filepath.Join(root, ".walden", "evidence")) {
+		t.Fatalf("evidence path %q escapes .walden/evidence", path)
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("read evidence dir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".walden-doc-") {
+			t.Fatalf("staging leftover %s", entry.Name())
+		}
+	}
+	if len(entries) != 1 {
+		t.Fatalf("evidence dir holds %d entries, want 1", len(entries))
+	}
+}

--- a/internal/output/result.go
+++ b/internal/output/result.go
@@ -32,9 +32,20 @@ type Result struct {
 	Coverage              *CoverageReport   `json:"coverage,omitempty"`
 	EARSDistribution      *EARSDistribution `json:"ears_distribution,omitempty"`
 	Skills                []SkillStatus     `json:"skills,omitempty"`
+	Evidence              []EvidenceStatus  `json:"evidence,omitempty"`
 	Update                *UpdateStatus     `json:"update,omitempty"`
 	Content               string            `json:"content,omitempty"`
 	ExitCode              int               `json:"exit_code"`
+}
+
+// EvidenceStatus is the JSON output view of one task's execution evidence.
+type EvidenceStatus struct {
+	TaskID           string `json:"task_id"`
+	State            string `json:"state"`
+	Passed           *bool  `json:"passed,omitempty"`
+	Failure          string `json:"failure,omitempty"`
+	RecordedIdentity string `json:"recorded_identity,omitempty"`
+	CurrentIdentity  string `json:"current_identity,omitempty"`
 }
 
 // UpdateStatus is the JSON output view of an update check or run.
@@ -213,6 +224,17 @@ func PrintText(w io.Writer, result Result) {
 			}
 			if skill.Installed {
 				_, _ = fmt.Fprintf(w, " path=%s", skill.Path)
+			}
+			_, _ = fmt.Fprintln(w)
+		}
+	}
+
+	if len(result.Evidence) > 0 {
+		_, _ = fmt.Fprintln(w, "Evidence:")
+		for _, entry := range result.Evidence {
+			_, _ = fmt.Fprintf(w, "- %s: %s", entry.TaskID, entry.State)
+			if entry.Failure != "" {
+				_, _ = fmt.Fprintf(w, " (%s)", entry.Failure)
 			}
 			_, _ = fmt.Fprintln(w)
 		}

--- a/internal/repo/init.go
+++ b/internal/repo/init.go
@@ -29,6 +29,7 @@ type InitReport struct {
 
 var repoBootstrapFiles = []bootstrapFile{
 	{Source: "walden/constitution.md", Target: ".walden/constitution.md"},
+	{Source: "walden/gitignore", Target: ".walden/.gitignore"},
 	{Source: "walden/lessons.md", Target: ".walden/lessons.md"},
 	{Source: "github/pull_request_template.md", Target: ".github/pull_request_template.md"},
 	{Source: "github/workflows/validate-walden.yml", Target: ".github/workflows/validate-walden.yml"},

--- a/internal/repo/init_gitignore_test.go
+++ b/internal/repo/init_gitignore_test.go
@@ -1,0 +1,38 @@
+package repo
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInitWritesWaldenGitignore(t *testing.T) {
+	root := t.TempDir()
+
+	report, err := Init(root, "v0.8.0")
+	if err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+
+	created := false
+	for _, path := range report.CreatedFiles {
+		if path == ".walden/.gitignore" {
+			created = true
+		}
+	}
+	if !created {
+		t.Fatalf("Init did not report .walden/.gitignore as created: %+v", report)
+	}
+
+	content, err := os.ReadFile(filepath.Join(root, ".walden", ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .walden/.gitignore: %v", err)
+	}
+	if !strings.Contains(string(content), ".walden-doc-*") {
+		t.Fatalf("gitignore does not exclude staging artifacts:\n%s", content)
+	}
+	if strings.Contains(string(content), "\nevidence") {
+		t.Fatalf("gitignore excludes the evidence directory:\n%s", content)
+	}
+}

--- a/internal/spec/expect_output_test.go
+++ b/internal/spec/expect_output_test.go
@@ -1,0 +1,79 @@
+package spec
+
+import (
+	"strings"
+	"testing"
+)
+
+func expectOutputPlan(field string) string {
+	return `# Implementation Plan
+
+- [ ] 1. Objective
+  - [ ] 1.1 Step
+    - Requirements: ` + "`R1.AC1`" + `
+    - Design: Section A
+    - Verification:
+` + field
+}
+
+func TestExpectOutputParsingVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "bare content",
+			body: expectOutputPlan("      - command: [\"go\", \"test\", \"./...\"]\n        expect_output: ok  \n"),
+			want: "ok",
+		},
+		{
+			name: "quoted content stripped",
+			body: expectOutputPlan("      - command: [\"go\", \"test\", \"./...\"]\n        expect_output: \"PASS: TestAuth\"\n"),
+			want: "PASS: TestAuth",
+		},
+		{
+			name: "combined with expect_exit and covers",
+			body: expectOutputPlan("      - command: [\"go\", \"test\", \"./...\"]\n        expect_exit: 0\n        expect_output: ok\n        covers: [\"R1.AC1\"]\n"),
+			want: "ok",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree, err := ParseTaskTree(Document{Exists: true, Path: "tasks.md", Body: tc.body})
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			steps := tree.LeafTasks()[0].Proof.Steps
+			if len(steps) != 1 || steps[0].ExpectOutput == nil {
+				t.Fatalf("expect_output not parsed: %+v", steps)
+			}
+			if *steps[0].ExpectOutput != tc.want {
+				t.Fatalf("expect_output = %q, want %q", *steps[0].ExpectOutput, tc.want)
+			}
+		})
+	}
+}
+
+func TestExpectOutputParsingRejectsOrphanField(t *testing.T) {
+	body := expectOutputPlan("      expect_output: ok\n")
+	_, err := ParseTaskTree(Document{Exists: true, Path: "tasks.md", Body: body})
+	if err == nil {
+		t.Fatal("orphan expect_output accepted")
+	}
+}
+
+func TestExpectOutputParsingLeavesPlainStepsUntouched(t *testing.T) {
+	body := expectOutputPlan("      - command: [\"go\", \"test\", \"./...\"]\n")
+	tree, err := ParseTaskTree(Document{Exists: true, Path: "tasks.md", Body: body})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if tree.LeafTasks()[0].Proof.Steps[0].ExpectOutput != nil {
+		t.Fatal("plain step gained an unexpected expect_output")
+	}
+	if !strings.Contains(tree.LeafTasks()[0].Verification, "go") {
+		t.Fatal("verification display broken")
+	}
+}

--- a/internal/spec/task_fingerprint.go
+++ b/internal/spec/task_fingerprint.go
@@ -1,0 +1,24 @@
+package spec
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// TaskDefinitionFingerprint hashes the canonical definition of one task: id,
+// title, requirement references, design references, and verification text.
+// Checkbox state and sibling tasks never enter it, so execution progress and
+// unrelated plan edits leave the fingerprint unmoved while any change to
+// this task's own contract moves it.
+func TaskDefinitionFingerprint(task *Task) string {
+	fields := []string{
+		task.ID,
+		task.Title,
+		strings.Join(task.Requirements, ","),
+		strings.Join(task.DesignRefs, ","),
+		task.Verification,
+	}
+	sum := sha256.Sum256([]byte(strings.Join(fields, "\x00")))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/spec/task_fingerprint_test.go
+++ b/internal/spec/task_fingerprint_test.go
@@ -1,0 +1,70 @@
+package spec
+
+import (
+	"strings"
+	"testing"
+)
+
+const fingerprintPlan = `# Implementation Plan
+
+- [%s] 1. Objective
+  - [%s] 1.1 First step
+    - Requirements: ` + "`R1.AC1`" + `
+    - Design: Section A
+    - Verification:
+      - command: ["go", "test", "./..."]
+  - [ ] 1.2 Sibling step
+    - Requirements: ` + "`R2.AC1`" + `
+    - Design: Section B
+    - Verification:
+      - command: ["go", "vet", "./..."]
+`
+
+func parsePlanTask(t *testing.T, body, id string) *Task {
+	t.Helper()
+	tree, err := ParseTaskTree(Document{Exists: true, Path: "tasks.md", Body: body})
+	if err != nil {
+		t.Fatalf("parse plan: %v", err)
+	}
+	for _, task := range tree.LeafTasks() {
+		if task.ID == id {
+			return task
+		}
+	}
+	t.Fatalf("task %s not found", id)
+	return nil
+}
+
+func planWith(checkTop, checkLeaf string) string {
+	return strings.Replace(strings.Replace(fingerprintPlan, "%s", checkTop, 1), "%s", checkLeaf, 1)
+}
+
+func TestTaskDefinitionFingerprintIgnoresProgressAndSiblings(t *testing.T) {
+	unchecked := TaskDefinitionFingerprint(parsePlanTask(t, planWith(" ", " "), "1.1"))
+	checked := TaskDefinitionFingerprint(parsePlanTask(t, planWith(" ", "x"), "1.1"))
+	if unchecked != checked {
+		t.Fatal("checkbox state moved the task definition fingerprint")
+	}
+
+	siblingEdited := strings.Replace(planWith(" ", " "), "Sibling step", "Renamed sibling", 1)
+	afterSibling := TaskDefinitionFingerprint(parsePlanTask(t, siblingEdited, "1.1"))
+	if unchecked != afterSibling {
+		t.Fatal("a sibling edit moved the task definition fingerprint")
+	}
+}
+
+func TestTaskDefinitionFingerprintTracksTheContract(t *testing.T) {
+	base := TaskDefinitionFingerprint(parsePlanTask(t, planWith(" ", " "), "1.1"))
+
+	verificationEdited := strings.Replace(planWith(" ", " "), `["go", "test", "./..."]`, `["go", "test", "-count=2", "./..."]`, 1)
+	moved := TaskDefinitionFingerprint(parsePlanTask(t, verificationEdited, "1.1"))
+	if base == moved {
+		t.Fatal("a verification edit did not move the task definition fingerprint")
+	}
+
+	titleEdited := strings.Replace(planWith(" ", " "), "First step", "First step, renamed", 1)
+	movedTitle := TaskDefinitionFingerprint(parsePlanTask(t, titleEdited, "1.1"))
+	if base == movedTitle {
+		t.Fatal("a title edit did not move the task definition fingerprint")
+	}
+}

--- a/internal/spec/tasks.go
+++ b/internal/spec/tasks.go
@@ -13,6 +13,7 @@ var (
 	metadataLinePattern = regexp.MustCompile(`^ {4}- (Requirements|Design|Verification):(.*)$`)
 	commandStepPattern  = regexp.MustCompile(`^ {6}- (?:command|argv): (\[.+\])\s*$`)
 	expectExitPattern   = regexp.MustCompile(`^ {8}expect_exit: ([0-9]+)\s*$`)
+	expectOutputPattern = regexp.MustCompile(`^ {8}expect_output: (.+?)\s*$`)
 	coversPattern       = regexp.MustCompile(`^ {8}covers: (\[.+\])\s*$`)
 	backtickRefPattern  = regexp.MustCompile("`([^`]+)`")
 )
@@ -26,9 +27,10 @@ type VerificationSpec struct {
 // VerificationStep is one structured proof step executed without shell interpolation.
 // Uses the Kubernetes command pattern: command: ["executable", "arg1", "arg2"].
 type VerificationStep struct {
-	Argv       []string
-	ExpectExit *int
-	Covers     []string
+	Argv         []string
+	ExpectExit   *int
+	ExpectOutput *string
+	Covers       []string
 }
 
 // Empty reports whether the verification spec contains any executable proof.
@@ -125,6 +127,21 @@ func ParseTaskTree(document Document) (TaskTree, error) {
 					return TaskTree{}, fmt.Errorf("line %d: invalid expect_exit value: %w", index+1, err)
 				}
 				steps[len(steps)-1].ExpectExit = &exitCode
+				continue
+			}
+			if match := expectOutputPattern.FindStringSubmatch(line); match != nil {
+				steps := pendingVerificationTask.Proof.Steps
+				if len(steps) == 0 {
+					return TaskTree{}, fmt.Errorf("line %d: expect_output declared before any command step for task %q", index+1, pendingVerificationTask.ID)
+				}
+				expected := strings.TrimSpace(match[1])
+				if len(expected) >= 2 && strings.HasPrefix(expected, "\"") && strings.HasSuffix(expected, "\"") {
+					expected = expected[1 : len(expected)-1]
+				}
+				if expected == "" {
+					return TaskTree{}, fmt.Errorf("line %d: expect_output requires non-empty content for task %q", index+1, pendingVerificationTask.ID)
+				}
+				steps[len(steps)-1].ExpectOutput = &expected
 				continue
 			}
 			if match := coversPattern.FindStringSubmatch(line); match != nil {

--- a/internal/spec/write.go
+++ b/internal/spec/write.go
@@ -37,13 +37,13 @@ func SaveDocument(document Document) error {
 		builder.WriteString("\n")
 	}
 
-	return writeAtomically(document.Path, []byte(builder.String()))
+	return WriteFileAtomic(document.Path, []byte(builder.String()))
 }
 
-// writeAtomically stages the content in a temp file inside the target's
+// WriteFileAtomic stages the content in a temp file inside the target's
 // directory and renames it into place, so no failure path — interruption,
-// full disk, permission error — can leave the document truncated or lost.
-func writeAtomically(path string, content []byte) error {
+// full disk, permission error — can leave the target truncated or lost.
+func WriteFileAtomic(path string, content []byte) error {
 	staged, err := os.CreateTemp(filepath.Dir(path), ".walden-doc-*")
 	if err != nil {
 		return fmt.Errorf("stage document %s: %w", path, err)

--- a/internal/workflow/complete_task_evidence_test.go
+++ b/internal/workflow/complete_task_evidence_test.go
@@ -1,0 +1,180 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/evidence"
+	"github.com/andrearaponi/walden/internal/shell"
+	"github.com/andrearaponi/walden/internal/spec"
+	"github.com/andrearaponi/walden/internal/testutil"
+)
+
+// scriptedIdentityRunner answers the git invocations behind the code
+// identity with fixed responses.
+type scriptedIdentityRunner struct {
+	statusResponse shell.Response
+	lsTreeResponse shell.Response
+	fail           bool
+}
+
+func (r *scriptedIdentityRunner) Run(_ context.Context, _ string, args ...string) (shell.Response, error) {
+	if r.fail {
+		return shell.Response{}, errors.New("git unavailable")
+	}
+	if len(args) >= 3 && args[2] == "ls-tree" {
+		return r.lsTreeResponse, nil
+	}
+	return r.statusResponse, nil
+}
+
+func overrideIdentityRunner(t *testing.T, runner shell.Runner) {
+	t.Helper()
+	previous := identityRunner
+	identityRunner = runner
+	t.Cleanup(func() { identityRunner = previous })
+}
+
+func writeEvidenceFixture(t *testing.T, root string) {
+	t.Helper()
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+status: approved
+approved_at: 2026-03-21T14:00:00Z
+last_modified: 2026-03-21T14:00:00Z
+---
+
+# Requirements Document
+`)
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+status: approved
+approved_at: 2026-03-21T14:10:00Z
+last_modified: 2026-03-21T14:10:00Z
+source_requirements_approved_at: 2026-03-21T14:00:00Z
+---
+
+# Feature Design
+`)
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+status: approved
+approved_at: 2026-03-21T14:20:00Z
+last_modified: 2026-03-21T14:20:00Z
+source_design_approved_at: 2026-03-21T14:10:00Z
+---
+
+# Implementation Plan
+
+- [ ] 1. Build parser
+  - [ ] 1.1 Implement parser
+    - Requirements: `+"`R1`"+`
+    - Design: Task Store
+    - Verification:
+      - command: ["go", "test", "./internal/spec"]
+`)
+}
+
+func TestCompleteTaskEvidenceRecordsChainAndIdentity(t *testing.T) {
+	root := t.TempDir()
+	writeEvidenceFixture(t, root)
+	overrideIdentityRunner(t, &scriptedIdentityRunner{
+		statusResponse: shell.Response{ExitCode: 0},
+		lsTreeResponse: shell.Response{ExitCode: 0, Stdout: "100644 blob aaa\tmain.go\n"},
+	})
+
+	runner := testutil.NewFakeRunner(testutil.Response{Stdout: "ok", ExitCode: 0})
+	result, err := CompleteTask(context.Background(), root, "todo-app-demo", "1.1", runner)
+	if err != nil {
+		t.Fatalf("CompleteTask returned error: %v", err)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", result.Warnings)
+	}
+
+	ledger, err := evidence.Load(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("load evidence: %v", err)
+	}
+	record, exists := ledger.Tasks["1.1"]
+	if !exists {
+		t.Fatal("no evidence entry recorded for the completed task")
+	}
+
+	feature, err := spec.LoadFeature(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("load feature: %v", err)
+	}
+	if record.RequirementsFingerprint != feature.Requirements.Fields["approved_fingerprint"] || record.RequirementsFingerprint == "" {
+		t.Fatalf("requirements fingerprint not bound: %q", record.RequirementsFingerprint)
+	}
+	if record.DesignFingerprint != feature.Design.Fields["approved_fingerprint"] || record.DesignFingerprint == "" {
+		t.Fatalf("design fingerprint not bound: %q", record.DesignFingerprint)
+	}
+	if !strings.HasPrefix(record.CodeIdentity, "sha256:") {
+		t.Fatalf("code identity not recorded: %q", record.CodeIdentity)
+	}
+	if !strings.HasPrefix(record.TaskFingerprint, "sha256:") {
+		t.Fatalf("task fingerprint not recorded: %q", record.TaskFingerprint)
+	}
+	if record.Result != evidence.ResultPassed || len(record.Steps) != 1 {
+		t.Fatalf("record outcome = %q with %d steps", record.Result, len(record.Steps))
+	}
+}
+
+func TestCompleteTaskEvidenceSaveFailureLeavesCheckboxUntouched(t *testing.T) {
+	root := t.TempDir()
+	writeEvidenceFixture(t, root)
+	overrideIdentityRunner(t, &scriptedIdentityRunner{fail: true})
+
+	// A file where the evidence directory must go makes Save fail.
+	if err := os.WriteFile(filepath.Join(root, ".walden", "evidence"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed blocking file: %v", err)
+	}
+
+	runner := testutil.NewFakeRunner(testutil.Response{Stdout: "ok", ExitCode: 0})
+	_, err := CompleteTask(context.Background(), root, "todo-app-demo", "1.1", runner)
+	if err == nil {
+		t.Fatal("CompleteTask succeeded despite an unpersistable evidence record")
+	}
+	if !strings.Contains(err.Error(), "evidence") {
+		t.Fatalf("error %q does not name the evidence failure", err)
+	}
+
+	tree, err := spec.LoadTaskTree(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("load task tree: %v", err)
+	}
+	for _, task := range tree.LeafTasks() {
+		if task.Completed {
+			t.Fatalf("task %s checkbox mutated despite the evidence failure", task.ID)
+		}
+	}
+}
+
+func TestCompleteTaskEvidenceNoGitDegradesWithWarning(t *testing.T) {
+	root := t.TempDir()
+	writeEvidenceFixture(t, root)
+	overrideIdentityRunner(t, &scriptedIdentityRunner{fail: true})
+
+	runner := testutil.NewFakeRunner(testutil.Response{Stdout: "ok", ExitCode: 0})
+	result, err := CompleteTask(context.Background(), root, "todo-app-demo", "1.1", runner)
+	if err != nil {
+		t.Fatalf("CompleteTask returned error: %v", err)
+	}
+	if len(result.Warnings) != 1 || !strings.Contains(result.Warnings[0], "identity") {
+		t.Fatalf("expected an identity warning, got %v", result.Warnings)
+	}
+
+	ledger, err := evidence.Load(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("load evidence: %v", err)
+	}
+	if ledger.Tasks["1.1"].CodeIdentity != "" {
+		t.Fatalf("identity recorded despite git being unavailable: %q", ledger.Tasks["1.1"].CodeIdentity)
+	}
+	if ledger.Tasks["1.1"].Result != evidence.ResultPassed {
+		t.Fatal("completion did not stay successful without git")
+	}
+}

--- a/internal/workflow/execute_proof_test.go
+++ b/internal/workflow/execute_proof_test.go
@@ -1,0 +1,88 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/evidence"
+	"github.com/andrearaponi/walden/internal/spec"
+	"github.com/andrearaponi/walden/internal/testutil"
+)
+
+func expectOutputTask(expect string) ExecutableTask {
+	step := spec.VerificationStep{Argv: []string{"go", "test", "-run", "TestX", "./pkg/"}}
+	if expect != "" {
+		step.ExpectOutput = &expect
+	}
+	proof := spec.VerificationSpec{Steps: []spec.VerificationStep{step}}
+	return ExecutableTask{
+		ID:           "1.1",
+		Title:        "Step",
+		Verification: proof.Display(),
+		Proof:        proof,
+	}
+}
+
+func TestExecuteProofCapturesStepOutcomes(t *testing.T) {
+	runner := testutil.NewFakeRunner(testutil.Response{Stdout: "ok  \tpkg\t0.1s\n", ExitCode: 0})
+
+	results, display, err := executeProof(context.Background(), runner, expectOutputTask(""))
+	if err != nil {
+		t.Fatalf("executeProof returned error: %v", err)
+	}
+	if display == "" {
+		t.Fatal("proof display is empty")
+	}
+	if len(results) != 1 {
+		t.Fatalf("captured %d step outcomes, want 1", len(results))
+	}
+
+	step := results[0]
+	if strings.Join(step.Command, " ") != "go test -run TestX ./pkg/" {
+		t.Fatalf("recorded command = %v", step.Command)
+	}
+	if step.ExpectedExit != 0 || step.ActualExit != 0 {
+		t.Fatalf("recorded exits = %d/%d, want 0/0", step.ExpectedExit, step.ActualExit)
+	}
+	if step.OutputDigest != evidence.DigestOutput("ok  \tpkg\t0.1s\n") {
+		t.Fatalf("output digest mismatch: %s", step.OutputDigest)
+	}
+}
+
+func TestExecuteProofPassesWhenOutputContainsExpectation(t *testing.T) {
+	runner := testutil.NewFakeRunner(testutil.Response{Stdout: "ok  \tpkg\t0.1s\n", ExitCode: 0})
+
+	if _, _, err := executeProof(context.Background(), runner, expectOutputTask("ok  ")); err != nil {
+		t.Fatalf("expectation unexpectedly failed: %v", err)
+	}
+}
+
+func TestExecuteProofFailsVacuousRuns(t *testing.T) {
+	// `go test -run NoMatch` exits 0 while printing "no tests to run" — the
+	// vacuous pass expect_output exists to catch.
+	runner := testutil.NewFakeRunner(testutil.Response{Stdout: "ok  \tpkg\t0.1s [no tests to run]\n", ExitCode: 0})
+
+	_, _, err := executeProof(context.Background(), runner, expectOutputTask("--- PASS: TestX"))
+	if err == nil {
+		t.Fatal("vacuous proof passed despite the output expectation")
+	}
+	if !strings.Contains(err.Error(), "--- PASS: TestX") {
+		t.Fatalf("error %q does not name the expected content", err)
+	}
+}
+
+func TestExecuteProofStopsAtExitMismatchBeforeOutputCheck(t *testing.T) {
+	runner := testutil.NewFakeRunner(testutil.Response{Stderr: "build failed", ExitCode: 2})
+
+	results, _, err := executeProof(context.Background(), runner, expectOutputTask("ok"))
+	if err == nil {
+		t.Fatal("exit mismatch accepted")
+	}
+	if !strings.Contains(err.Error(), "exited with code 2") {
+		t.Fatalf("error %q does not report the exit mismatch", err)
+	}
+	if len(results) != 1 || results[0].ActualExit != 2 {
+		t.Fatalf("failing step outcome not captured: %+v", results)
+	}
+}

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/andrearaponi/walden/internal/evidence"
 	"github.com/andrearaponi/walden/internal/shell"
 	"github.com/andrearaponi/walden/internal/spec"
 )
@@ -38,6 +39,10 @@ type ExecutionReadiness struct {
 	// exhausted implementation plan: gates must fail commands, a finished
 	// plan must not.
 	GateBlocked bool
+	// EvidenceWarnings surface completed tasks whose evidence is not
+	// verified — the honest answer to "the plan is complete" after specs
+	// or code moved underneath it.
+	EvidenceWarnings []string
 }
 
 // TaskStartContext is the deterministic execution context returned when a task starts.
@@ -56,6 +61,7 @@ type TaskCompletionResult struct {
 	CompletedTasks []string
 	ProofCommand   string
 	NextAction     string
+	Warnings       []string
 }
 
 // BatchCompletionResult is the deterministic outcome of completing multiple runnable leaf tasks in order.
@@ -77,7 +83,62 @@ func LoadExecutionReadiness(root, featureName string) (ExecutionReadiness, error
 		return ExecutionReadiness{}, err
 	}
 
-	return ResolveExecutionReadiness(feature)
+	readiness, err := ResolveExecutionReadiness(feature)
+	if err != nil {
+		return ExecutionReadiness{}, err
+	}
+	if !readiness.GateBlocked {
+		readiness.EvidenceWarnings = evidenceWarnings(context.Background(), root, feature)
+	}
+	return readiness, nil
+}
+
+// evidenceWarnings derives the evidence states of completed tasks and
+// summarizes every non-verified one. Gate blockers already tell the chain
+// story, so this runs only on an unblocked chain.
+func evidenceWarnings(ctx context.Context, root string, feature spec.Feature) []string {
+	tree, err := spec.ParseTaskTree(feature.Tasks)
+	if err != nil {
+		return nil
+	}
+
+	leafs := []evidence.LeafTask{}
+	anyCompleted := false
+	for _, task := range tree.LeafTasks() {
+		if task.Completed {
+			anyCompleted = true
+		}
+		leafs = append(leafs, evidence.LeafTask{
+			ID:          task.ID,
+			Completed:   task.Completed,
+			Fingerprint: executableTaskFingerprint(toExecutableTask(task)),
+		})
+	}
+	if !anyCompleted {
+		return nil
+	}
+
+	ledger, err := evidence.Load(root, feature.Name)
+	if err != nil {
+		return nil
+	}
+	identity, identityOK := evidence.Identity(ctx, identityRunner, root)
+	current := evidence.ChainFingerprints{
+		Requirements: feature.Requirements.Fields["approved_fingerprint"],
+		Design:       feature.Design.Fields["approved_fingerprint"],
+	}
+
+	notVerified := []string{}
+	for _, derived := range evidence.Derive(ledger, current, identity, identityOK, leafs) {
+		if derived.State == evidence.StateVerified || derived.State == evidence.StatePending {
+			continue
+		}
+		notVerified = append(notVerified, fmt.Sprintf("%s (%s)", derived.TaskID, derived.State))
+	}
+	if len(notVerified) == 0 {
+		return nil
+	}
+	return []string{fmt.Sprintf("evidence: %d completed task(s) not verified — %s; run `walden verify %s`", len(notVerified), strings.Join(notVerified, ", "), feature.Name)}
 }
 
 // ResolveExecutionReadiness determines whether execution can start and which task is next.
@@ -241,6 +302,11 @@ func nextRunnableTask(tree spec.TaskTree) *ExecutableTask {
 	return nil
 }
 
+// identityRunner executes the read-only git invocations behind the code
+// identity. It is a seam so tests control identity outcomes without
+// consuming the proof runner's scripted responses.
+var identityRunner shell.Runner = shell.NewExecRunner()
+
 // CompleteTask runs the declared proof for a leaf task and marks it complete only if the proof succeeds.
 func CompleteTask(ctx context.Context, root, featureName, taskID string, runner shell.Runner) (TaskCompletionResult, error) {
 	if runner == nil {
@@ -252,30 +318,9 @@ func CompleteTask(ctx context.Context, root, featureName, taskID string, runner 
 		return TaskCompletionResult{}, err
 	}
 
-	proofCommands, proofCommand, err := resolveProofCommands(startContext.Task)
+	stepResults, proofCommand, err := executeProof(ctx, runner, startContext.Task)
 	if err != nil {
 		return TaskCompletionResult{}, err
-	}
-
-	for _, proofStep := range proofCommands {
-		response, err := runner.Run(ctx, proofStep.Name, proofStep.Args...)
-		if err != nil {
-			hint := ""
-			if strings.Contains(err.Error(), "executable file not found") {
-				hint = " (hint: shell operators require command: [\"sh\", \"-c\", \"...\"])"
-			}
-			return TaskCompletionResult{}, fmt.Errorf("verification failed for task %q: %w%s", startContext.Task.ID, err, hint)
-		}
-		if response.ExitCode != proofStep.ExpectExit {
-			detail := strings.TrimSpace(response.Stderr)
-			if detail == "" {
-				detail = strings.TrimSpace(response.Stdout)
-			}
-			if detail != "" {
-				return TaskCompletionResult{}, fmt.Errorf("verification failed for task %q: command %q exited with code %d (expected %d): %s", startContext.Task.ID, proofStep.Display, response.ExitCode, proofStep.ExpectExit, detail)
-			}
-			return TaskCompletionResult{}, fmt.Errorf("verification failed for task %q: command %q exited with code %d (expected %d)", startContext.Task.ID, proofStep.Display, response.ExitCode, proofStep.ExpectExit)
-		}
 	}
 
 	feature, err := spec.LoadFeature(root, featureName)
@@ -284,6 +329,33 @@ func CompleteTask(ctx context.Context, root, featureName, taskID string, runner 
 	}
 
 	completedAt := time.Now().UTC().Format("2006-01-02T15:04:05Z")
+
+	// Evidence is recorded before the checkbox moves: a completion the
+	// ledger cannot remember is a completion that did not happen.
+	identity, identityOK := evidence.Identity(ctx, identityRunner, root)
+	warnings := []string{}
+	if !identityOK {
+		warnings = append(warnings, "code identity unavailable (git not usable here); evidence recorded without it")
+	}
+
+	ledger, err := evidence.Load(root, feature.Name)
+	if err != nil {
+		return TaskCompletionResult{}, err
+	}
+	ledger.Feature = feature.Name
+	ledger.Tasks[startContext.Task.ID] = evidence.Record{
+		TaskFingerprint:         executableTaskFingerprint(startContext.Task),
+		RequirementsFingerprint: feature.Requirements.Fields["approved_fingerprint"],
+		DesignFingerprint:       feature.Design.Fields["approved_fingerprint"],
+		TasksFingerprint:        feature.Tasks.Fields["approved_fingerprint"],
+		CodeIdentity:            identity,
+		Steps:                   stepResults,
+		Result:                  evidence.ResultPassed,
+		VerifiedAt:              completedAt,
+	}
+	if err := evidence.Save(root, ledger); err != nil {
+		return TaskCompletionResult{}, fmt.Errorf("record evidence before completion: %w", err)
+	}
 	updatedTasks, completedTasks, err := spec.MarkTaskCompleteWithCascade(feature.Tasks, startContext.Task.ID, completedAt)
 	if err != nil {
 		return TaskCompletionResult{}, err
@@ -305,6 +377,7 @@ func CompleteTask(ctx context.Context, root, featureName, taskID string, runner 
 		CompletedTasks: completedTasks,
 		ProofCommand:   proofCommand,
 		NextAction:     readiness.NextAction,
+		Warnings:       warnings,
 	}, nil
 }
 
@@ -369,10 +442,11 @@ func CompleteAllTasks(ctx context.Context, root, featureName string, runner shel
 }
 
 type proofCommand struct {
-	Name       string
-	Args       []string
-	Display    string
-	ExpectExit int
+	Name         string
+	Args         []string
+	Display      string
+	ExpectExit   int
+	ExpectOutput string
 }
 
 func resolveProofCommands(task ExecutableTask) ([]proofCommand, string, error) {
@@ -386,11 +460,16 @@ func resolveProofCommands(task ExecutableTask) ([]proofCommand, string, error) {
 			if step.ExpectExit != nil {
 				expectExit = *step.ExpectExit
 			}
+			expectOutput := ""
+			if step.ExpectOutput != nil {
+				expectOutput = *step.ExpectOutput
+			}
 			commands = append(commands, proofCommand{
-				Name:       step.Argv[0],
-				Args:       append([]string(nil), step.Argv[1:]...),
-				Display:    formatCommandProofStep(step.Argv),
-				ExpectExit: expectExit,
+				Name:         step.Argv[0],
+				Args:         append([]string(nil), step.Argv[1:]...),
+				Display:      formatCommandProofStep(step.Argv),
+				ExpectExit:   expectExit,
+				ExpectOutput: expectOutput,
 			})
 		}
 		return commands, task.Verification, nil
@@ -401,6 +480,63 @@ func resolveProofCommands(task ExecutableTask) ([]proofCommand, string, error) {
 		return nil, "", err
 	}
 	return []proofCommand{{Name: name, Args: args, Display: display}}, display, nil
+}
+
+// executableTaskFingerprint bridges the execution view back to the spec
+// task-definition fingerprint.
+func executableTaskFingerprint(task ExecutableTask) string {
+	return spec.TaskDefinitionFingerprint(&spec.Task{
+		ID:           task.ID,
+		Title:        task.Title,
+		Requirements: task.Requirements,
+		DesignRefs:   task.DesignRefs,
+		Verification: task.Verification,
+	})
+}
+
+// executeProof runs every proof step in order, enforcing exit-code and
+// output expectations, and returns per-step outcomes for the evidence
+// record along with the human-readable proof command.
+func executeProof(ctx context.Context, runner shell.Runner, task ExecutableTask) ([]evidence.StepResult, string, error) {
+	proofCommands, display, err := resolveProofCommands(task)
+	if err != nil {
+		return nil, "", err
+	}
+
+	results := make([]evidence.StepResult, 0, len(proofCommands))
+	for _, proofStep := range proofCommands {
+		response, err := runner.Run(ctx, proofStep.Name, proofStep.Args...)
+		if err != nil {
+			hint := ""
+			if strings.Contains(err.Error(), "executable file not found") {
+				hint = " (hint: shell operators require command: [\"sh\", \"-c\", \"...\"])"
+			}
+			return results, display, fmt.Errorf("verification failed for task %q: %w%s", task.ID, err, hint)
+		}
+
+		combined := response.Stdout + response.Stderr
+		results = append(results, evidence.StepResult{
+			Command:      append([]string{proofStep.Name}, proofStep.Args...),
+			ExpectedExit: proofStep.ExpectExit,
+			ActualExit:   response.ExitCode,
+			OutputDigest: evidence.DigestOutput(combined),
+		})
+
+		if response.ExitCode != proofStep.ExpectExit {
+			detail := strings.TrimSpace(response.Stderr)
+			if detail == "" {
+				detail = strings.TrimSpace(response.Stdout)
+			}
+			if detail != "" {
+				return results, display, fmt.Errorf("verification failed for task %q: command %q exited with code %d (expected %d): %s", task.ID, proofStep.Display, response.ExitCode, proofStep.ExpectExit, detail)
+			}
+			return results, display, fmt.Errorf("verification failed for task %q: command %q exited with code %d (expected %d)", task.ID, proofStep.Display, response.ExitCode, proofStep.ExpectExit)
+		}
+		if proofStep.ExpectOutput != "" && !strings.Contains(combined, proofStep.ExpectOutput) {
+			return results, display, fmt.Errorf("verification failed for task %q: command %q output does not contain expected content %q", task.ID, proofStep.Display, proofStep.ExpectOutput)
+		}
+	}
+	return results, display, nil
 }
 
 func parseVerificationCommand(verification string) (string, []string, string, error) {

--- a/internal/workflow/readiness_evidence_test.go
+++ b/internal/workflow/readiness_evidence_test.go
@@ -1,0 +1,129 @@
+package workflow
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/evidence"
+	"github.com/andrearaponi/walden/internal/testutil"
+)
+
+func TestReadinessEvidenceSilentWhenVerified(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+
+	readiness, err := LoadExecutionReadiness(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("LoadExecutionReadiness: %v", err)
+	}
+	if len(readiness.EvidenceWarnings) != 0 {
+		t.Fatalf("verified plan raised warnings: %v", readiness.EvidenceWarnings)
+	}
+}
+
+func TestReadinessEvidenceWarnsOnStaleCode(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+
+	// The code moves under the completed plan.
+	overrideIdentityRunner(t, identityYielding("100644 blob bbb\tmain.go\n"))
+
+	readiness, err := LoadExecutionReadiness(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("LoadExecutionReadiness: %v", err)
+	}
+	if len(readiness.EvidenceWarnings) != 1 {
+		t.Fatalf("warnings = %v, want one evidence warning", readiness.EvidenceWarnings)
+	}
+	warning := readiness.EvidenceWarnings[0]
+	if !strings.Contains(warning, "stale-code") || !strings.Contains(warning, "walden verify") {
+		t.Fatalf("warning %q does not name stale-code and the remedy", warning)
+	}
+}
+
+func TestReadinessEvidenceWarnsOnStaleSpecAfterReapproval(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+
+	// The WDN-002 replay: requirements change and the chain is re-approved
+	// with fresh fingerprints, but no proof ever reruns.
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+status: approved
+approved_at: 2026-03-22T09:00:00Z
+last_modified: 2026-03-22T09:00:00Z
+---
+
+# Requirements Document
+
+## R2 A brand new requirement
+`)
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+status: approved
+approved_at: 2026-03-22T09:10:00Z
+last_modified: 2026-03-22T09:10:00Z
+source_requirements_approved_at: 2026-03-22T09:00:00Z
+---
+
+# Feature Design
+`)
+
+	readiness, err := LoadExecutionReadiness(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("LoadExecutionReadiness: %v", err)
+	}
+	if readiness.GateBlocked {
+		t.Fatalf("fixture chain unexpectedly blocked: %v", readiness.Blockers)
+	}
+	if len(readiness.EvidenceWarnings) != 1 || !strings.Contains(readiness.EvidenceWarnings[0], "stale-spec") {
+		t.Fatalf("warnings = %v, want a stale-spec warning", readiness.EvidenceWarnings)
+	}
+}
+
+func TestReadinessEvidenceFlagsUnrecordedLegacyCompletions(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+
+	// Complete without the ledger by checking the box the pre-ledger way:
+	// run one completion, then delete the evidence document.
+	completeBoth(t, root)
+	if err := removeEvidence(root, "todo-app-demo"); err != nil {
+		t.Fatalf("remove evidence: %v", err)
+	}
+
+	readiness, err := LoadExecutionReadiness(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("LoadExecutionReadiness: %v", err)
+	}
+	if len(readiness.EvidenceWarnings) != 1 || !strings.Contains(readiness.EvidenceWarnings[0], "unrecorded") {
+		t.Fatalf("warnings = %v, want an unrecorded warning", readiness.EvidenceWarnings)
+	}
+
+	// verify --all upgrades legacy completions into recorded evidence.
+	runner := testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+	)
+	if _, err := Verify(context.Background(), root, "todo-app-demo", true, false, runner); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	readiness, err = LoadExecutionReadiness(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("LoadExecutionReadiness after verify: %v", err)
+	}
+	if len(readiness.EvidenceWarnings) != 0 {
+		t.Fatalf("warnings persisted after verify --all: %v", readiness.EvidenceWarnings)
+	}
+}
+
+func removeEvidence(root, feature string) error {
+	return os.Remove(evidence.DocumentPath(root, feature))
+}

--- a/internal/workflow/verify.go
+++ b/internal/workflow/verify.go
@@ -1,0 +1,171 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/andrearaponi/walden/internal/evidence"
+	"github.com/andrearaponi/walden/internal/shell"
+	"github.com/andrearaponi/walden/internal/spec"
+)
+
+// VerifyOutcome describes one task touched by a verify run.
+type VerifyOutcome struct {
+	TaskID  string
+	State   string
+	Passed  bool
+	Failure string
+}
+
+// VerifyResult is the outcome of re-proving a feature's completed tasks.
+type VerifyResult struct {
+	Feature  string
+	Outcomes []VerifyOutcome
+	Failed   []string
+	Checked  bool
+	Skipped  []string
+}
+
+// Verify re-executes the proofs of completed tasks against the current
+// working tree: non-verified ones by default, every one with all. Fresh
+// evidence replaces each task's entry unless check is set, which reports
+// without persisting anything. A failing proof never aborts the run — every
+// selected task is re-proven and failures are collected.
+func Verify(ctx context.Context, root, featureName string, all, check bool, runner shell.Runner) (VerifyResult, error) {
+	if runner == nil {
+		return VerifyResult{}, fmt.Errorf("proof runner is required")
+	}
+
+	readiness, err := LoadExecutionReadiness(root, featureName)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	if readiness.GateBlocked && len(readiness.Blockers) > 0 {
+		return VerifyResult{}, fmt.Errorf("%s", readiness.Blockers[0])
+	}
+
+	feature, err := spec.LoadFeature(root, featureName)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	tree, err := spec.ParseTaskTree(feature.Tasks)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+
+	ledger, err := evidence.Load(root, feature.Name)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	ledger.Feature = feature.Name
+
+	identity, _ := evidence.Identity(ctx, identityRunner, root)
+	current := evidence.ChainFingerprints{
+		Requirements: feature.Requirements.Fields["approved_fingerprint"],
+		Design:       feature.Design.Fields["approved_fingerprint"],
+	}
+
+	result := VerifyResult{Feature: feature.Name, Checked: check}
+	verifiedAt := time.Now().UTC().Format("2006-01-02T15:04:05Z")
+
+	for _, task := range tree.LeafTasks() {
+		if !task.Completed {
+			continue
+		}
+
+		executable := toExecutableTask(task)
+		fingerprint := executableTaskFingerprint(executable)
+
+		if !all {
+			derived := evidence.Derive(ledger, current, identity, identity != "", []evidence.LeafTask{
+				{ID: task.ID, Completed: true, Fingerprint: fingerprint},
+			})
+			if derived[0].State == evidence.StateVerified {
+				result.Skipped = append(result.Skipped, task.ID)
+				continue
+			}
+		}
+
+		stepResults, _, proofErr := executeProof(ctx, runner, executable)
+		record := evidence.Record{
+			TaskFingerprint:         fingerprint,
+			RequirementsFingerprint: current.Requirements,
+			DesignFingerprint:       current.Design,
+			TasksFingerprint:        feature.Tasks.Fields["approved_fingerprint"],
+			CodeIdentity:            identity,
+			Steps:                   stepResults,
+			Result:                  evidence.ResultPassed,
+			VerifiedAt:              verifiedAt,
+		}
+
+		outcome := VerifyOutcome{TaskID: task.ID, State: evidence.StateVerified, Passed: true}
+		if proofErr != nil {
+			record.Result = evidence.ResultFailed
+			outcome.State = evidence.StateFailed
+			outcome.Passed = false
+			outcome.Failure = proofErr.Error()
+			result.Failed = append(result.Failed, task.ID)
+		}
+
+		if !check {
+			ledger.Tasks[task.ID] = record
+		}
+		result.Outcomes = append(result.Outcomes, outcome)
+	}
+
+	if !check && len(result.Outcomes) > 0 {
+		if err := evidence.Save(root, ledger); err != nil {
+			return VerifyResult{}, fmt.Errorf("persist refreshed evidence: %w", err)
+		}
+	}
+	return result, nil
+}
+
+// toExecutableTask bridges a parsed task into the execution view.
+func toExecutableTask(task *spec.Task) ExecutableTask {
+	return ExecutableTask{
+		ID:           task.ID,
+		Title:        task.Title,
+		ParentID:     task.ParentID,
+		Completed:    task.Completed,
+		Level:        task.Level,
+		Requirements: append([]string(nil), task.Requirements...),
+		DesignRefs:   append([]string(nil), task.DesignRefs...),
+		Verification: task.Verification,
+		Proof:        task.Proof,
+	}
+}
+
+// EvidenceReport derives every leaf task's execution-evidence state for a
+// feature. It is a pure read: no gate, no writes, usable on any chain state.
+func EvidenceReport(ctx context.Context, root, featureName string) (string, []evidence.TaskEvidence, error) {
+	feature, err := spec.LoadFeature(root, featureName)
+	if err != nil {
+		return "", nil, err
+	}
+	tree, err := spec.ParseTaskTree(feature.Tasks)
+	if err != nil {
+		return "", nil, err
+	}
+
+	leafs := []evidence.LeafTask{}
+	for _, task := range tree.LeafTasks() {
+		leafs = append(leafs, evidence.LeafTask{
+			ID:          task.ID,
+			Completed:   task.Completed,
+			Fingerprint: executableTaskFingerprint(toExecutableTask(task)),
+		})
+	}
+
+	ledger, err := evidence.Load(root, feature.Name)
+	if err != nil {
+		return "", nil, err
+	}
+	identity, identityOK := evidence.Identity(ctx, identityRunner, root)
+	current := evidence.ChainFingerprints{
+		Requirements: feature.Requirements.Fields["approved_fingerprint"],
+		Design:       feature.Design.Fields["approved_fingerprint"],
+	}
+	return feature.Name, evidence.Derive(ledger, current, identity, identityOK, leafs), nil
+}

--- a/internal/workflow/verify_test.go
+++ b/internal/workflow/verify_test.go
@@ -1,0 +1,231 @@
+package workflow
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/evidence"
+	"github.com/andrearaponi/walden/internal/shell"
+	"github.com/andrearaponi/walden/internal/testutil"
+)
+
+func writeVerifyFixture(t *testing.T, root string) {
+	t.Helper()
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+status: approved
+approved_at: 2026-03-21T14:00:00Z
+last_modified: 2026-03-21T14:00:00Z
+---
+
+# Requirements Document
+`)
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+status: approved
+approved_at: 2026-03-21T14:10:00Z
+last_modified: 2026-03-21T14:10:00Z
+source_requirements_approved_at: 2026-03-21T14:00:00Z
+---
+
+# Feature Design
+`)
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+status: approved
+approved_at: 2026-03-21T14:20:00Z
+last_modified: 2026-03-21T14:20:00Z
+source_design_approved_at: 2026-03-21T14:10:00Z
+---
+
+# Implementation Plan
+
+- [ ] 1. Build parser
+  - [ ] 1.1 Implement parser
+    - Requirements: `+"`R1`"+`
+    - Design: Task Store
+    - Verification:
+      - command: ["go", "test", "./internal/spec"]
+  - [ ] 1.2 Implement readiness
+    - Requirements: `+"`R1`"+`
+    - Design: Execution Service
+    - Verification:
+      - command: ["go", "test", "./internal/workflow"]
+`)
+}
+
+func identityYielding(listing string) shell.Runner {
+	return &scriptedIdentityRunner{
+		statusResponse: shell.Response{ExitCode: 0},
+		lsTreeResponse: shell.Response{ExitCode: 0, Stdout: listing},
+	}
+}
+
+// completeBoth completes both fixture tasks under the current identity runner.
+func completeBoth(t *testing.T, root string) {
+	t.Helper()
+	runner := testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+	)
+	if _, err := CompleteAllTasks(context.Background(), root, "todo-app-demo", runner); err != nil {
+		t.Fatalf("complete fixture tasks: %v", err)
+	}
+}
+
+func TestVerifyDefaultSkipsVerifiedTasks(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+
+	runner := testutil.NewFakeRunner()
+	result, err := Verify(context.Background(), root, "todo-app-demo", false, false, runner)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if len(runner.Calls()) != 0 {
+		t.Fatalf("verified tasks were re-executed: %v", runner.Calls())
+	}
+	if len(result.Skipped) != 2 || len(result.Outcomes) != 0 {
+		t.Fatalf("result = %+v, want both tasks skipped", result)
+	}
+}
+
+func TestVerifyRefreshesStaleCode(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+
+	// The code moves: identity changes, both tasks go stale-code.
+	overrideIdentityRunner(t, identityYielding("100644 blob bbb\tmain.go\n"))
+
+	runner := testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+	)
+	result, err := Verify(context.Background(), root, "todo-app-demo", false, false, runner)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if len(result.Outcomes) != 2 || len(result.Failed) != 0 {
+		t.Fatalf("result = %+v, want two passing re-executions", result)
+	}
+
+	ledger, err := evidence.Load(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("load evidence: %v", err)
+	}
+	for _, id := range []string{"1.1", "1.2"} {
+		if !strings.HasPrefix(ledger.Tasks[id].CodeIdentity, "sha256:") {
+			t.Fatalf("task %s identity not refreshed", id)
+		}
+	}
+
+	// A second default verify now has nothing to do.
+	idle := testutil.NewFakeRunner()
+	again, err := Verify(context.Background(), root, "todo-app-demo", false, false, idle)
+	if err != nil {
+		t.Fatalf("second Verify: %v", err)
+	}
+	if len(idle.Calls()) != 0 || len(again.Skipped) != 2 {
+		t.Fatalf("refresh did not restore verified: %+v", again)
+	}
+}
+
+func TestVerifyAllReexecutesVerifiedTasks(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+
+	runner := testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+	)
+	result, err := Verify(context.Background(), root, "todo-app-demo", true, false, runner)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if len(runner.Calls()) != 2 || len(result.Outcomes) != 2 {
+		t.Fatalf("--all did not re-execute everything: %+v", result)
+	}
+}
+
+func TestVerifyCheckPersistsNothing(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob bbb\tmain.go\n"))
+
+	before, err := os.ReadFile(evidence.DocumentPath(root, "todo-app-demo"))
+	if err != nil {
+		t.Fatalf("read ledger before: %v", err)
+	}
+
+	runner := testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+	)
+	result, err := Verify(context.Background(), root, "todo-app-demo", false, true, runner)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if !result.Checked || len(result.Outcomes) != 2 {
+		t.Fatalf("check mode outcome = %+v", result)
+	}
+
+	after, err := os.ReadFile(evidence.DocumentPath(root, "todo-app-demo"))
+	if err != nil {
+		t.Fatalf("read ledger after: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Fatal("check mode modified the evidence document")
+	}
+}
+
+func TestVerifyCollectsFailuresAcrossTasks(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob bbb\tmain.go\n"))
+
+	runner := testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stderr: "assertion blew up", ExitCode: 1},
+	)
+	result, err := Verify(context.Background(), root, "todo-app-demo", false, false, runner)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if len(result.Failed) != 1 || result.Failed[0] != "1.2" {
+		t.Fatalf("failed = %v, want [1.2]", result.Failed)
+	}
+
+	ledger, err := evidence.Load(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("load evidence: %v", err)
+	}
+	if ledger.Tasks["1.1"].Result != evidence.ResultPassed {
+		t.Fatal("passing task not refreshed as passed")
+	}
+	if ledger.Tasks["1.2"].Result != evidence.ResultFailed {
+		t.Fatal("failing task not recorded as failed")
+	}
+}
+
+func TestVerifyBlockedByStaleChain(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+
+	overrideFrontmatterField(t, root, "todo-app-demo", "requirements.md", "approved_fingerprint", "sha256:0000000000000000000000000000000000000000000000000000000000000000")
+
+	_, err := Verify(context.Background(), root, "todo-app-demo", false, false, testutil.NewFakeRunner())
+	if err == nil {
+		t.Fatal("Verify accepted a stale chain")
+	}
+}

--- a/templates/embed_test.go
+++ b/templates/embed_test.go
@@ -12,6 +12,7 @@ func TestRepoFSExposesBootstrapTemplates(t *testing.T) {
 	// Paths are relative to the "repo" subtree, so the "repo/" prefix is gone.
 	want := []string{
 		"walden/constitution.md",
+		"walden/gitignore",
 		"walden/lessons.md",
 		"github/pull_request_template.md",
 		"github/workflows/validate-walden.yml",

--- a/templates/repo/walden/gitignore
+++ b/templates/repo/walden/gitignore
@@ -1,0 +1,4 @@
+# Transient Walden staging artifacts — never commit these.
+# Evidence documents (evidence/*.json) are deliberately NOT excluded:
+# they are shared repository state, reviewed like the specs they prove.
+.walden-doc-*


### PR DESCRIPTION
## Summary

The certainty chain no longer stops at the approved plan. Every task completion records durable evidence binding the proof to the approved chain fingerprints and to a deterministic **code identity** of the working tree; states are **derived at read time, never stored**; `walden verify` re-proves the current code on demand; and `expect_output` closes the vacuous-proof hole. The checkbox stays the human projection — `.walden/evidence/<feature>.json` is the authoritative execution state, committed and reviewed like the specs it proves.

This is the direct answer to the external review's central finding: *Walden proved a command once passed, but not that the current implementation still satisfies the current specification.*

## Design highlights

- **Current-state map, not a log** — one JSON document per feature keyed by task id (schema `v1alpha1`, independent of the CLI envelope); history comes free from `git log`; bounded size; per-task merge granularity.
- **Derived states** — `verified` / `stale-spec` / `stale-code` / `failed` / `unrecorded` / `pending` computed from record vs current fingerprints and identity. `reconcile` never touches evidence: stale-spec falls out of the comparison. Task-definition fingerprints keep plan edits precise — editing one task never stales its siblings. Timestamps are context, never verdicts.
- **The serpent constraint** — the identity is a uniform path→blob map (`git ls-tree` seeded, dirty paths overlaid via `git hash-object`) with `.walden/` excluded at every layer: committing the evidence never invalidates it, and the untracked→committed transition never reads as a change. Read-only git through the existing runner seam; no git degrades to a warned, absent identity.
- **Fail-closed ordering** — evidence is written before the checkbox mutates.
- **`walden verify [--all] [--check]`** — re-proves completed tasks (non-verified by default); `--check` writes nothing and leaves the checkout byte-identical for CI gates. `walden evidence status` is a report, not a gate (always exit 0). `task status` warns when completed tasks are no longer verified.
- **`expect_output` on proof steps** — a test command matching zero tests can no longer complete a task vacuously.
- **`repo init` writes `.walden/.gitignore`** — the first explicit local/shared boundary (staging temps excluded; evidence deliberately committed).

## Evaluation

Six end-to-end evals on toy repositories with real git, replaying the review's reproductions against the new binary — **18/18 assertions green**:

| Eval | Old behavior | New behavior |
| --- | --- | --- |
| WDN-001: implementation broken after completion | "plan complete", forever | `stale-code` surfaced, `verify` fails, ledger records `failed`, `task status` warns |
| WDN-002: spec change + reconcile + re-approval | checkboxes revive silently | `stale-spec` warned; `verify` re-proves and heals |
| Vacuous proof (zero tests matched, exit 0) | task completes | refused, expected content named |
| CI `verify --check` | — | exit by outcome, checkout byte-identical |
| No git available | — | completion succeeds with warning; no stale-code noise when identity stays absent |
| **Il serpente**: commit evidence+specs+code | — | still `verified`; a real code change still detected |

## Process

Developed through the Walden gated workflow (7 requirements, 28 EARS ACs, 100% task and proof reference coverage, 10/10 tasks closed through `walden task complete`). Mid-execution, the serpent-eval walkthrough exposed an identity representation split (tracked = blob id, dirty = raw sha256 → commits read as changes): design updated, chain reconciled and re-approved, fix implemented with a layer-transition unit test, lesson logged.

Full suite green with vet and race; the v0.7.1 gates (demo smoke, contract matrix — extended with `verify` and `evidence-status` rows) run on this PR.