### PR TITLE
fix: pin generated CI only to installable release tags

### DIFF
--- a/internal/repo/init.go
+++ b/internal/repo/init.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/andrearaponi/walden/templates"
@@ -84,13 +85,31 @@ func Init(root string, version string) (InitReport, error) {
 	return report, nil
 }
 
-// installPin maps the generating binary's version to the go install target:
-// an exact release pin, or "latest" for source builds with no release info.
+// installPin maps the generating binary's version to the go install target.
+// Only an exact vMAJOR.MINOR.PATCH release tag is pinnable: dev builds and
+// git-describe suffixed versions (v0.7.1-2-gabc1234, what setup.sh stamps on
+// clone builds) are not resolvable by `go install` and fall back to latest.
 func installPin(version string) string {
-	if version == "" || version == "dev" {
-		return "latest"
+	if isReleaseTag(version) {
+		return version
 	}
-	return version
+	return "latest"
+}
+
+func isReleaseTag(version string) bool {
+	if !strings.HasPrefix(version, "v") {
+		return false
+	}
+	parts := strings.Split(version[1:], ".")
+	if len(parts) != 3 {
+		return false
+	}
+	for _, part := range parts {
+		if value, err := strconv.Atoi(part); err != nil || value < 0 {
+			return false
+		}
+	}
+	return true
 }
 
 type gitRepositoryState struct {

--- a/internal/repo/init_pin_test.go
+++ b/internal/repo/init_pin_test.go
@@ -77,3 +77,29 @@ func TestInitRefreshesPinOnRerunWithNewerBinary(t *testing.T) {
 		t.Fatalf("workflow pin not refreshed:\n%s", workflow)
 	}
 }
+
+func TestInitNonReleaseVersionsFallBackToLatest(t *testing.T) {
+	// go install resolves release tags and pseudo-versions, never
+	// git-describe strings — pinning one breaks every generated CI run.
+	cases := []string{
+		"v0.7.1-2-gc360063",
+		"v0.7.2-0.20260711060210-abcdef123456",
+		"(devel)",
+		"v0.7",
+		"dev",
+		"",
+	}
+
+	for _, version := range cases {
+		t.Run(version, func(t *testing.T) {
+			root := t.TempDir()
+			if _, err := Init(root, version); err != nil {
+				t.Fatalf("Init returned error: %v", err)
+			}
+			workflow := readWorkflow(t, root)
+			if !strings.Contains(workflow, "cmd/walden@latest") {
+				t.Fatalf("version %q did not fall back to @latest:\n%s", version, workflow)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`repo init` stamps the generating binary's version into the `validate-walden.yml` it writes (v0.7.1, WDN-004). It stamped the version **verbatim**: a binary built from a clone via `setup.sh` carries a git-describe version (`v0.7.1-2-gabc1234`), which `go install` cannot resolve — the generated workflow failed its very first run with `invalid version: unknown revision`.

Found in the wild on the first dogfooded project's CI, one day after v0.7.1 shipped.

## Fix

`installPin` inverts its logic from a two-string blocklist (`""`, `"dev"`) to an allowlist of the only installable shape: strict `vMAJOR.MINOR.PATCH` tags are pinned; everything else — dev builds, describe suffixes, pseudo-versions, `(devel)` — falls back to `@latest`.

## Testing

New table-driven test covering the six non-release shapes (including the exact string that broke the CI), all asserting the `@latest` fallback; existing pin tests (release pin, re-init refresh) unchanged and green; full suite with vet and race gates on this PR.

Release users are unaffected (release binaries stamp real tags); this fixes source-build users generating CI from a clone.