### PR TITLE
feat: execution evidence ledger — done becomes a provable, re-checkable claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ walden lesson log --feature user-auth --phase execute \
 | `task start <feature> [task-id] [--json]` | Get execution context for the next or a specific task |
 | `task complete <feature> <task-id> [--json]` | Run verification proof and mark task complete |
 | `task complete-all <feature> [--json]` | Complete all runnable tasks in order, stop on first failure |
+| `verify <feature> [--all] [--check] [--json]` | Re-prove completed tasks against the current code and refresh evidence |
+| `evidence status <feature> [--json]` | Report each task's derived execution-evidence state |
 | `reconcile <feature> [--json]` | Repair stale approval chains after upstream edits |
 | `lesson log [--json]` | Append a lesson to `.walden/lessons.md` |
 | `version [--json]` | Print build version and schema version |
@@ -313,6 +315,16 @@ For pipes, `&&`, or globbing, use the Kubernetes shell pattern:
   - command: ["sh", "-c", "test -d .walden && go test ./..."]
 ```
 
+### Output Assertions
+
+`expect_output` requires the step's combined output to contain the declared content — closing the vacuous-pass hole where a test command matching zero tests exits 0:
+
+```markdown
+- Verification:
+  - command: ["go", "test", "-run", "TestAuth", "./internal/auth/"]
+    expect_output: "--- PASS: TestAuth"
+```
+
 ### Multi-Step Verification
 
 Steps run in order, stopping on first failure:
@@ -330,6 +342,31 @@ Single-line format is deprecated. It does not support quotes, pipes, or shell op
 ```markdown
 - Verification: go test ./...
 ```
+
+## Evidence
+
+Completing a task records durable execution evidence in `.walden/evidence/<feature>.json`: the proof's steps (argv, exit codes, output digests) bound to the approved chain fingerprints and to a **code identity** — a deterministic hash of the working tree with `.walden/` excluded, so committing the evidence never invalidates it. The checkbox in `tasks.md` stays the human-readable projection; the evidence document is the authoritative execution state, committed and reviewed like the specs it proves.
+
+States are **derived at read time**, never stored:
+
+| State | Meaning |
+| --- | --- |
+| `verified` | The recorded proof matches the current spec chain and the current code |
+| `stale-spec` | Requirements, design, or this task's definition changed since the proof ran |
+| `stale-code` | The working tree changed since the proof ran |
+| `failed` | The last re-verification failed |
+| `unrecorded` | Completed before the ledger existed (`walden verify` upgrades it) |
+| `pending` | Not completed yet |
+
+Re-prove the current code on demand:
+
+```bash
+walden verify <feature>          # re-run proofs for non-verified completed tasks
+walden verify <feature> --all    # re-run every completed task's proof
+walden verify <feature> --check  # report only — writes nothing (CI-friendly)
+```
+
+`walden evidence status <feature>` reports the derived states without running anything (always exit 0). `walden task status` warns when completed tasks are no longer verified — a spec change or code change is visible as staleness instead of hiding behind a checked box. Timestamps in evidence records are human context only: every verdict depends exclusively on content identities.
 
 ## EARS
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ You don't need to remember a single CLI command. `walden validate`, `walden revi
 | Designs architecture, evaluates alternatives | AC traceability (100% coverage required) |
 | Generates implementation tasks with proofs | Verification proofs on every task |
 | Reviews lessons before similar work | Stale document detection and reconciliation |
+| Runs `walden verify` when evidence goes stale | Execution evidence: derived states bound to spec fingerprints and code identity |
 
 Human review and approval remain your responsibility. The skill drafts and proposes — it never approves on your behalf.
 
@@ -395,6 +396,10 @@ Each acceptance criterion gets a stable ID (e.g., `R1.AC1`) and uses exactly one
 | Proof coverage per AC (via covers: field) | Yes | - |
 | Proof execution | Yes | - |
 | Structured proof format | Yes | Legacy deprecation active |
+| Task completion bound to the current code (evidence + code identity) | Yes | - |
+| Completed-task re-verification (`walden verify`) | Yes | - |
+| Vacuous-proof rejection (`expect_output`) | Yes | Opt-in per step |
+| Aggregate release gate | - | `release check` (planned) |
 
 ## Constitution
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ walden verify <feature> --all    # re-run every completed task's proof
 walden verify <feature> --check  # report only — writes nothing (CI-friendly)
 ```
 
-`walden evidence status <feature>` reports the derived states without running anything (always exit 0). `walden task status` warns when completed tasks are no longer verified — a spec change or code change is visible as staleness instead of hiding behind a checked box. Timestamps in evidence records are human context only: every verdict depends exclusively on content identities.
+`walden evidence status <feature>` reports the derived states without running anything (always exit 0). Evidence writes replace the whole document atomically: concurrent walden processes can never corrupt the ledger — at worst a record is lost to the last writer, surfaces as `unrecorded`, and `walden verify` regenerates it. `walden task status` warns when completed tasks are no longer verified — a spec change or code change is visible as staleness instead of hiding behind a checked box. Timestamps in evidence records are human context only: every verdict depends exclusively on content identities.
 
 ## EARS
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -77,6 +77,10 @@ Proofs use structured `command` format to avoid shell-quoting issues:
   - command: ["go", "test", "./internal/workflow/..."]
 ```
 
+## Evidence
+
+Completing a task records durable execution evidence in `.walden/evidence/<feature>.json`: the proof's steps bound to the approved chain fingerprints and to a deterministic code identity of the working tree (`.walden/` excluded, so committing the evidence never invalidates it). States are derived at read time — `verified`, `stale-spec`, `stale-code`, `failed`, `unrecorded`, `pending` — never stored. `walden verify` re-executes the proofs of completed tasks against the current code; `--check` reports without writing. The checkbox in `tasks.md` remains the human-readable projection; the evidence document is the authoritative execution state, committed and reviewed like the specs it proves.
+
 ## Constitution
 
 `.walden/constitution.md` is an optional repo-wide file that captures stable project context: tech stack, conventions, sanity checks, key files, and hard rules. Unlike the three per-feature documents (`requirements.md`, `design.md`, `tasks.md`), the constitution is not part of the approval workflow. It does not block any phase transition, does not have freshness rules, and is not validated by the CLI. The skill reads it when present to reduce context rediscovery across features.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -167,3 +167,16 @@ All `--json` commands return a versioned envelope:
   }
 }
 ```
+
+## 6. Verify
+
+Execution leaves evidence behind: every completed task's proof is recorded in `.walden/evidence/<feature>.json`, bound to the approved chain and to a code identity of the working tree. When the code or the specs move, `walden task status` warns that completed tasks are no longer verified.
+
+```bash
+walden evidence status <feature>   # derived state per task, always exit 0
+walden verify <feature>            # re-prove what is no longer verified
+walden verify <feature> --all      # re-prove everything
+walden verify <feature> --check    # CI mode: report only, write nothing
+```
+
+A code-only bugfix needs no spec ceremony: the evidence goes `stale-code`, and one `verify` proves the acceptance criteria still hold — or names the task whose proof broke.

--- a/examples/todo-app-demo/README.md
+++ b/examples/todo-app-demo/README.md
@@ -64,3 +64,14 @@ scripts/verify.sh 1.1
 - **Verification proofs use wrapper scripts** — `scripts/verify.sh` takes a task ID and runs the appropriate check. This avoids shell-quoting issues in task definitions.
 - **Tasks reference requirements and design** — every leaf task traces back to its source requirement and design section.
 - **Documents are approved** — this example ships with all phases approved so you can focus on the execution flow.
+
+## Evidence
+
+Every completion above records execution evidence in `.walden/evidence/todo-app.json`, bound to the spec fingerprints and to a code identity of this directory. Try it:
+
+```bash
+walden evidence status todo-app    # verified / stale-code / unrecorded per task
+walden verify todo-app --check     # re-run every proof against the current code, write nothing
+```
+
+Break something the proofs cover, and `walden task status` stops claiming the plan is complete.

--- a/internal/app/evidence.go
+++ b/internal/app/evidence.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/andrearaponi/walden/internal/output"
+	"github.com/andrearaponi/walden/internal/workflow"
+)
+
+func runEvidence(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) > 0 && args[0] == "status" {
+		return runEvidenceStatus(args[1:], stdout, stderr)
+	}
+
+	_, _ = fmt.Fprintf(stderr, "unknown command: evidence %s\n\n", strings.Join(args, " "))
+	printUsage(stderr)
+	return 1
+}
+
+func runEvidenceStatus(args []string, stdout io.Writer, stderr io.Writer) int {
+	jsonMode := false
+	positional := make([]string, 0, len(args))
+	for _, arg := range args {
+		if arg == "--json" {
+			jsonMode = true
+			continue
+		}
+		positional = append(positional, arg)
+	}
+
+	if len(positional) != 1 {
+		return emitResult("evidence-status", errorResult(errors.New("evidence status requires exactly one feature name")), jsonMode, stdout, stderr)
+	}
+
+	root, err := os.Getwd()
+	if err != nil {
+		return emitResult("evidence-status", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
+	}
+
+	featureName, entries, err := workflow.EvidenceReport(context.Background(), root, positional[0])
+	if err != nil {
+		return emitResult("evidence-status", errorResult(err), jsonMode, stdout, stderr)
+	}
+
+	counts := map[string]int{}
+	rendered := make([]output.EvidenceStatus, 0, len(entries))
+	for _, entry := range entries {
+		counts[entry.State]++
+		rendered = append(rendered, output.EvidenceStatus{
+			TaskID:           entry.TaskID,
+			State:            entry.State,
+			RecordedIdentity: entry.RecordedIdentity,
+			CurrentIdentity:  entry.CurrentIdentity,
+		})
+	}
+
+	summaryParts := []string{}
+	for _, state := range []string{"verified", "failed", "stale-spec", "stale-code", "unrecorded", "pending"} {
+		if counts[state] > 0 {
+			summaryParts = append(summaryParts, fmt.Sprintf("%d %s", counts[state], state))
+		}
+	}
+	summary := fmt.Sprintf("evidence status for %s", featureName)
+	if len(summaryParts) > 0 {
+		summary = fmt.Sprintf("evidence status for %s: %s", featureName, strings.Join(summaryParts, ", "))
+	}
+
+	// Evidence status is a report, not a gate: derived states never change
+	// the exit code.
+	result := output.Result{Summary: summary, Evidence: rendered, ExitCode: 0}
+	if counts["stale-spec"]+counts["stale-code"]+counts["failed"]+counts["unrecorded"] > 0 {
+		result.NextAction = fmt.Sprintf("Run walden verify %s to re-prove the current code", featureName)
+	}
+	return emitResult("evidence-status", result, jsonMode, stdout, stderr)
+}

--- a/internal/app/evidence_status_command_test.go
+++ b/internal/app/evidence_status_command_test.go
@@ -1,0 +1,108 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/output"
+)
+
+func TestEvidenceStatusCommandReportsVerified(t *testing.T) {
+	setupEvidenceFeature(t)
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"evidence", "status", "todo-app-demo", "--json"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("evidence status exited %d: %s", exitCode, stderr.String())
+	}
+
+	var envelope output.Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if envelope.Command != "evidence-status" || !envelope.OK {
+		t.Fatalf("envelope = %s ok=%t", envelope.Command, envelope.OK)
+	}
+	if len(envelope.Result.Evidence) != 1 || envelope.Result.Evidence[0].State != "verified" {
+		t.Fatalf("evidence = %+v, want one verified entry", envelope.Result.Evidence)
+	}
+	if !strings.Contains(envelope.Result.Summary, "1 verified") {
+		t.Fatalf("summary %q lacks state counts", envelope.Result.Summary)
+	}
+}
+
+func TestEvidenceStatusCommandStaysZeroOnStaleSpec(t *testing.T) {
+	root := setupEvidenceFeature(t)
+
+	// Requirements change and the chain is re-approved with fresh
+	// fingerprints — the WDN-002 revival — while proofs never rerun.
+	writeStatusFeatureFile(t, root, "todo-app-demo", "requirements.md", `---
+status: approved
+approved_at: 2026-03-22T09:00:00Z
+last_modified: 2026-03-22T09:00:00Z
+---
+
+# Requirements Document
+
+## R2 Brand new behavior
+`)
+	writeStatusFeatureFile(t, root, "todo-app-demo", "design.md", `---
+status: approved
+approved_at: 2026-03-22T09:10:00Z
+last_modified: 2026-03-22T09:10:00Z
+source_requirements_approved_at: 2026-03-22T09:00:00Z
+---
+
+# Feature Design
+`)
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"evidence", "status", "todo-app-demo"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("report-not-gate violated: exit %d (%s)", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "stale-spec") {
+		t.Fatalf("output does not surface stale-spec: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "walden verify") {
+		t.Fatalf("output does not point at the remedy: %s", stdout.String())
+	}
+}
+
+func TestEvidenceStatusCommandTaskStatusWarningPassthrough(t *testing.T) {
+	root := setupEvidenceFeature(t)
+
+	writeStatusFeatureFile(t, root, "todo-app-demo", "requirements.md", `---
+status: approved
+approved_at: 2026-03-22T09:00:00Z
+last_modified: 2026-03-22T09:00:00Z
+---
+
+# Requirements Document
+
+## R2 Brand new behavior
+`)
+	writeStatusFeatureFile(t, root, "todo-app-demo", "design.md", `---
+status: approved
+approved_at: 2026-03-22T09:10:00Z
+last_modified: 2026-03-22T09:10:00Z
+source_requirements_approved_at: 2026-03-22T09:00:00Z
+---
+
+# Feature Design
+`)
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"task", "status", "todo-app-demo"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("task status exited %d: %s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "stale-spec") || !strings.Contains(stdout.String(), "evidence") {
+		t.Fatalf("task status does not surface the evidence warning: %s", stdout.String())
+	}
+}

--- a/internal/app/json_contract_test.go
+++ b/internal/app/json_contract_test.go
@@ -145,6 +145,16 @@ func TestJSONErrorContract(t *testing.T) {
 			args:        []string{"skill", "uninstall", "--all", "--project", "--json"},
 			wantCommand: "skill-uninstall",
 		},
+		{
+			name:        "verify with invalid feature name",
+			args:        []string{"verify", "!!!", "--json"},
+			wantCommand: "verify",
+		},
+		{
+			name:        "evidence status with invalid feature name",
+			args:        []string{"evidence", "status", "!!!", "--json"},
+			wantCommand: "evidence-status",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -42,6 +42,8 @@ var commandUsages = []commandUsage{
 	{"task start <feature> [task-id] [--json]", "Resolve normalized execution context for a task"},
 	{"task complete <feature> <task-id> [--json]", "Run a task's proofs and mark it complete"},
 	{"task complete-all <feature> [--json]", "Complete all runnable tasks in order"},
+	{"verify <feature> [--all] [--check] [--json]", "Re-prove completed tasks against the current code and refresh evidence"},
+	{"evidence status <feature> [--json]", "Report each completed task's derived execution-evidence state"},
 	{"validate <feature> [--all] [--json]", "Check EARS, traceability, and freshness"},
 	{"review open <feature> --phase <phase> [--json]", "Open the review gate (move to in-review)"},
 	{"review approve <feature> --phase <phase> [--json]", "Approve the review gate (move to approved)"},
@@ -82,6 +84,10 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 		return runTask(args[1:], stdout, stderr)
 	case "validate":
 		return runValidate(args[1:], stdout, stderr)
+	case "verify":
+		return runVerify(args[1:], stdout, stderr)
+	case "evidence":
+		return runEvidence(args[1:], stdout, stderr)
 	case "review":
 		return runReview(args[1:], stdout, stderr)
 	case "skill":
@@ -961,6 +967,7 @@ func taskStatusSuccessResult(readiness workflow.ExecutionReadiness) output.Resul
 	if readiness.NextTask != nil {
 		result.Task = toOutputTaskStatus(*readiness.NextTask)
 	}
+	result.Warnings = append(result.Warnings, readiness.EvidenceWarnings...)
 
 	return result
 }
@@ -1069,8 +1076,9 @@ func taskCompleteSuccessResult(result workflow.TaskCompletionResult) output.Resu
 		Summary:      fmt.Sprintf("task completed for %s", result.Feature),
 		CurrentPhase: string(result.CurrentPhase),
 		Task:         toOutputTaskStatus(result.Task),
-		ChangedFiles: []string{".walden/specs/" + result.Feature + "/tasks.md"},
+		ChangedFiles: []string{".walden/specs/" + result.Feature + "/tasks.md", ".walden/evidence/" + result.Feature + ".json"},
 		NextAction:   result.NextAction,
+		Warnings:     result.Warnings,
 		ExitCode:     0,
 	}
 }

--- a/internal/app/verify.go
+++ b/internal/app/verify.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/andrearaponi/walden/internal/output"
+	"github.com/andrearaponi/walden/internal/workflow"
+)
+
+func runVerify(args []string, stdout io.Writer, stderr io.Writer) int {
+	jsonMode := false
+	all := false
+	check := false
+	positional := make([]string, 0, len(args))
+	for _, arg := range args {
+		switch arg {
+		case "--json":
+			jsonMode = true
+		case "--all":
+			all = true
+		case "--check":
+			check = true
+		default:
+			positional = append(positional, arg)
+		}
+	}
+
+	if len(positional) != 1 {
+		return emitResult("verify", errorResult(errors.New("verify requires exactly one feature name")), jsonMode, stdout, stderr)
+	}
+
+	root, err := os.Getwd()
+	if err != nil {
+		return emitResult("verify", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
+	}
+
+	verifyResult, err := workflow.Verify(context.Background(), root, positional[0], all, check, commandRunner)
+	if err != nil {
+		return emitResult("verify", errorResult(err), jsonMode, stdout, stderr)
+	}
+
+	result := verifyOutputResult(verifyResult)
+	return emitResult("verify", result, jsonMode, stdout, stderr)
+}
+
+func verifyOutputResult(verifyResult workflow.VerifyResult) output.Result {
+	entries := make([]output.EvidenceStatus, 0, len(verifyResult.Outcomes))
+	for _, outcome := range verifyResult.Outcomes {
+		passed := outcome.Passed
+		entries = append(entries, output.EvidenceStatus{
+			TaskID:  outcome.TaskID,
+			State:   outcome.State,
+			Passed:  &passed,
+			Failure: outcome.Failure,
+		})
+	}
+
+	suffix := ""
+	if verifyResult.Checked {
+		suffix = " (check mode: nothing persisted)"
+	}
+
+	result := output.Result{Evidence: entries, ExitCode: 0}
+	switch {
+	case len(verifyResult.Failed) > 0:
+		result.Summary = fmt.Sprintf("verification failed for %s: %s%s", verifyResult.Feature, strings.Join(verifyResult.Failed, ", "), suffix)
+		result.NextAction = fmt.Sprintf("Fix the failing proofs and rerun walden verify %s", verifyResult.Feature)
+		result.ExitCode = 1
+	case len(verifyResult.Outcomes) == 0:
+		result.Summary = fmt.Sprintf("nothing to verify for %s: %d completed task(s) already verified%s", verifyResult.Feature, len(verifyResult.Skipped), suffix)
+	default:
+		result.Summary = fmt.Sprintf("verification passed for %s: %d task(s) re-proven, %d skipped as verified%s", verifyResult.Feature, len(verifyResult.Outcomes), len(verifyResult.Skipped), suffix)
+	}
+	return result
+}

--- a/internal/app/verify.go
+++ b/internal/app/verify.go
@@ -66,6 +66,9 @@ func verifyOutputResult(verifyResult workflow.VerifyResult) output.Result {
 	}
 
 	result := output.Result{Evidence: entries, ExitCode: 0}
+	if len(verifyResult.Pruned) > 0 && !verifyResult.Checked {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("pruned %d orphaned evidence entr%s no longer in the plan: %s", len(verifyResult.Pruned), map[bool]string{true: "y", false: "ies"}[len(verifyResult.Pruned) == 1], strings.Join(verifyResult.Pruned, ", ")))
+	}
 	switch {
 	case len(verifyResult.Failed) > 0:
 		result.Summary = fmt.Sprintf("verification failed for %s: %s%s", verifyResult.Feature, strings.Join(verifyResult.Failed, ", "), suffix)

--- a/internal/app/verify_command_test.go
+++ b/internal/app/verify_command_test.go
@@ -1,0 +1,163 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/output"
+	"github.com/andrearaponi/walden/internal/testutil"
+)
+
+// setupEvidenceFeature bootstraps a real repository in a temp cwd, approves a
+// one-task feature, and completes it through the CLI so evidence exists.
+func setupEvidenceFeature(t *testing.T) string {
+	t.Helper()
+	root := chdirContract(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"repo", "init"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("repo init failed: %s", stderr.String())
+	}
+	if code := Run([]string{"feature", "init", "Todo App Demo"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("feature init failed: %s", stderr.String())
+	}
+
+	writeStatusFeatureFile(t, root, "todo-app-demo", "requirements.md", `---
+status: approved
+approved_at: 2026-03-22T07:00:00Z
+last_modified: 2026-03-22T07:00:00Z
+---
+
+# Requirements Document
+`)
+	writeStatusFeatureFile(t, root, "todo-app-demo", "design.md", `---
+status: approved
+approved_at: 2026-03-22T07:10:00Z
+last_modified: 2026-03-22T07:10:00Z
+source_requirements_approved_at: 2026-03-22T07:00:00Z
+---
+
+# Feature Design
+`)
+	writeStatusFeatureFile(t, root, "todo-app-demo", "tasks.md", `---
+status: approved
+approved_at: 2026-03-22T07:20:00Z
+last_modified: 2026-03-22T07:20:00Z
+source_design_approved_at: 2026-03-22T07:10:00Z
+---
+
+# Implementation Plan
+
+- [ ] 1. Build parser
+  - [ ] 1.1 Implement parser
+    - Requirements: `+"`R1`"+`
+    - Design: Task Store
+    - Verification:
+      - command: ["go", "test", "./internal/spec"]
+`)
+
+	overrideCommandRunner(t, testutil.NewFakeRunner(testutil.Response{Stdout: "ok", ExitCode: 0}))
+	if code := Run([]string{"task", "complete", "todo-app-demo", "1.1"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("task complete failed: %s", stderr.String())
+	}
+	return root
+}
+
+func overrideCommandRunner(t *testing.T, runner *testutil.FakeRunner) *testutil.FakeRunner {
+	t.Helper()
+	previous := commandRunner
+	commandRunner = runner
+	t.Cleanup(func() { commandRunner = previous })
+	return runner
+}
+
+func TestRunVerifyDefaultSkipsVerifiedTasks(t *testing.T) {
+	setupEvidenceFeature(t)
+	runner := overrideCommandRunner(t, testutil.NewFakeRunner())
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"verify", "todo-app-demo"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("verify exited %d: %s", exitCode, stderr.String())
+	}
+	if len(runner.Calls()) != 0 {
+		t.Fatalf("verified task re-executed: %v", runner.Calls())
+	}
+	if !strings.Contains(stdout.String(), "already verified") {
+		t.Fatalf("summary does not report the skip: %s", stdout.String())
+	}
+}
+
+func TestRunVerifyAllReprovesAndReportsJSON(t *testing.T) {
+	setupEvidenceFeature(t)
+	overrideCommandRunner(t, testutil.NewFakeRunner(testutil.Response{Stdout: "ok", ExitCode: 0}))
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"verify", "todo-app-demo", "--all", "--json"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("verify --all exited %d: %s", exitCode, stderr.String())
+	}
+
+	var envelope output.Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if envelope.Command != "verify" || !envelope.OK {
+		t.Fatalf("envelope = %s ok=%t", envelope.Command, envelope.OK)
+	}
+	if len(envelope.Result.Evidence) != 1 {
+		t.Fatalf("evidence entries = %d, want 1", len(envelope.Result.Evidence))
+	}
+	entry := envelope.Result.Evidence[0]
+	if entry.TaskID != "1.1" || entry.State != "verified" || entry.Passed == nil || !*entry.Passed {
+		t.Fatalf("entry = %+v, want 1.1 verified passed", entry)
+	}
+}
+
+func TestRunVerifyFailureExitsNonZeroNamingTasks(t *testing.T) {
+	setupEvidenceFeature(t)
+	overrideCommandRunner(t, testutil.NewFakeRunner(testutil.Response{Stderr: "boom", ExitCode: 1}))
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"verify", "todo-app-demo", "--all"}, &stdout, &stderr)
+
+	if exitCode == 0 {
+		t.Fatal("failing verify exited zero")
+	}
+	if !strings.Contains(stderr.String(), "verification failed") || !strings.Contains(stderr.String(), "1.1") {
+		t.Fatalf("stderr %q does not name the failed task", stderr.String())
+	}
+}
+
+func TestRunVerifyCheckPersistsNothing(t *testing.T) {
+	root := setupEvidenceFeature(t)
+	overrideCommandRunner(t, testutil.NewFakeRunner(testutil.Response{Stdout: "ok", ExitCode: 0}))
+
+	ledgerPath := root + "/.walden/evidence/todo-app-demo.json"
+	before, err := os.ReadFile(ledgerPath)
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"verify", "todo-app-demo", "--all", "--check"}, &stdout, &stderr)
+	if exitCode != 0 {
+		t.Fatalf("verify --check exited %d: %s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "check mode") {
+		t.Fatalf("summary does not note check mode: %s", stdout.String())
+	}
+
+	after, err := os.ReadFile(ledgerPath)
+	if err != nil {
+		t.Fatalf("read ledger after: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Fatal("check mode modified the ledger")
+	}
+}

--- a/internal/e2e/evidence_e2e_test.go
+++ b/internal/e2e/evidence_e2e_test.go
@@ -1,0 +1,324 @@
+// Package e2e replays the evidence-ledger evaluation battery as compiled
+// tests: real git repositories, the real process runner, every step driven
+// through app.Run exactly as a user or agent would. The feature that
+// promises proofs is itself pinned by executable ones.
+package e2e
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/app"
+)
+
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+}
+
+// cli runs one walden invocation from dir, returning combined output and exit code.
+func cli(t *testing.T, dir string, args ...string) (string, int) {
+	t.Helper()
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(previous) })
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := app.Run(args, &stdout, &stderr)
+	_ = os.Chdir(previous)
+	return stdout.String() + stderr.String(), code
+}
+
+func mustCLI(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, code := cli(t, dir, args...)
+	if code != 0 {
+		t.Fatalf("walden %s failed (%d): %s", strings.Join(args, " "), code, out)
+	}
+	return out
+}
+
+func gitIn(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	command := exec.Command("git", args...)
+	command.Dir = dir
+	if out, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, out)
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filepath.Join(dir, name)), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", name, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// fixtureRepo bootstraps a real git repo with an approved, completed
+// two-task feature whose proofs grep markers out of src.txt.
+func fixtureRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	gitIn(t, dir, "init", "-q", "-b", "main")
+	gitIn(t, dir, "config", "user.email", "e2e@walden.dev")
+	gitIn(t, dir, "config", "user.name", "E2E")
+
+	mustCLI(t, dir, "repo", "init")
+	mustCLI(t, dir, "feature", "init", "ledger-demo")
+
+	writeFile(t, dir, ".walden/specs/ledger-demo/requirements.md", `---
+status: draft
+approved_at:
+last_modified: 2026-07-11T10:00:00Z
+approved_fingerprint:
+---
+
+# Requirements Document
+
+## Introduction
+
+End-to-end evidence fixture.
+
+## Requirements
+
+### R1 Markers
+
+**User Story:** As a tester, I want provable markers, so that evidence binds to code.
+
+#### Acceptance Criteria
+
+1. `+"`R1.AC1`"+` WHEN the first proof runs, the system SHALL find marker A in the source.
+2. `+"`R1.AC2`"+` WHEN the second proof runs, the system SHALL find marker B in the source.
+`)
+	writeFile(t, dir, ".walden/specs/ledger-demo/design.md", `---
+status: draft
+approved_at:
+last_modified: 2026-07-11T10:00:00Z
+approved_fingerprint:
+source_requirements_approved_at:
+source_requirements_fingerprint:
+---
+
+# Feature Design
+
+## Overview
+
+A source file carries two grep-provable markers.
+
+## Requirement Coverage
+
+| Requirement | Covered By |
+| --- | --- |
+| `+"`R1`"+` | src.txt |
+`)
+	writeFile(t, dir, ".walden/specs/ledger-demo/tasks.md", `---
+status: draft
+approved_at:
+last_modified: 2026-07-11T10:00:00Z
+approved_fingerprint:
+source_design_approved_at:
+source_design_fingerprint:
+---
+
+# Implementation Plan
+
+- [ ] 1. Markers
+  - [ ] 1.1 Place marker A
+    - Requirements: `+"`R1.AC1`"+`
+    - Design: Overview
+    - Verification:
+      - command: ["sh", "-c", "grep -q MARKER-A src.txt"]
+        covers: ["R1.AC1"]
+  - [ ] 1.2 Place marker B
+    - Requirements: `+"`R1.AC2`"+`
+    - Design: Overview
+    - Verification:
+      - command: ["sh", "-c", "grep -q MARKER-B src.txt"]
+        covers: ["R1.AC2"]
+`)
+
+	for _, phase := range []string{"requirements", "design", "tasks"} {
+		mustCLI(t, dir, "review", "open", "ledger-demo", "--phase", phase)
+		mustCLI(t, dir, "review", "approve", "ledger-demo", "--phase", phase)
+	}
+
+	writeFile(t, dir, "src.txt", "MARKER-A\nMARKER-B\n")
+	mustCLI(t, dir, "task", "complete-all", "ledger-demo")
+	return dir
+}
+
+func evidenceSummary(t *testing.T, dir string) string {
+	t.Helper()
+	out, _ := cli(t, dir, "evidence", "status", "ledger-demo")
+	return out
+}
+
+func TestE2ESerpentCommitTransitions(t *testing.T) {
+	requireGit(t)
+	dir := fixtureRepo(t)
+
+	if err := os.Symlink("src.txt", filepath.Join(dir, "link.txt")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if err := os.Chmod(filepath.Join(dir, "src.txt"), 0o755); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	mustCLI(t, dir, "verify", "ledger-demo", "--all")
+
+	if out := evidenceSummary(t, dir); !strings.Contains(out, "2 verified") {
+		t.Fatalf("pre-commit baseline not verified: %s", out)
+	}
+
+	// The serpent: committing everything — code, symlink, executable bit,
+	// specs, evidence — must not move the identity.
+	gitIn(t, dir, "add", "-A")
+	gitIn(t, dir, "commit", "-qm", "everything, evidence included")
+
+	if out := evidenceSummary(t, dir); !strings.Contains(out, "2 verified") {
+		t.Fatalf("committing the evidence invalidated it: %s", out)
+	}
+
+	// A mode-only flip is a code change and must surface.
+	if err := os.Chmod(filepath.Join(dir, "src.txt"), 0o644); err != nil {
+		t.Fatalf("chmod back: %v", err)
+	}
+	if out := evidenceSummary(t, dir); !strings.Contains(out, "stale-code") {
+		t.Fatalf("executable-bit flip stayed invisible: %s", out)
+	}
+}
+
+func TestE2EBrokenImplementationSurfaces(t *testing.T) {
+	requireGit(t)
+	dir := fixtureRepo(t)
+
+	// WDN-001 replay: the implementation regresses after completion.
+	writeFile(t, dir, "src.txt", "MARKER-A\n")
+
+	if out := evidenceSummary(t, dir); !strings.Contains(out, "stale-code") {
+		t.Fatalf("regression invisible to evidence status: %s", out)
+	}
+	out, code := cli(t, dir, "task", "status", "ledger-demo")
+	if code != 0 || !strings.Contains(out, "evidence") {
+		t.Fatalf("task status hides the regression: %s", out)
+	}
+
+	out, code = cli(t, dir, "verify", "ledger-demo")
+	if code == 0 {
+		t.Fatalf("verify passed on broken code: %s", out)
+	}
+	if !strings.Contains(out, "1.2") {
+		t.Fatalf("verify does not name the failing task: %s", out)
+	}
+	if summary := evidenceSummary(t, dir); !strings.Contains(summary, "failed") {
+		t.Fatalf("failure not recorded: %s", summary)
+	}
+}
+
+func TestE2ESpecRevivalSurfaces(t *testing.T) {
+	requireGit(t)
+	dir := fixtureRepo(t)
+
+	// WDN-002 replay: requirements change, the chain is reconciled and
+	// re-approved, and no proof reruns — the checkbox must not lie.
+	requirements := filepath.Join(dir, ".walden/specs/ledger-demo/requirements.md")
+	content, err := os.ReadFile(requirements)
+	if err != nil {
+		t.Fatalf("read requirements: %v", err)
+	}
+	if err := os.WriteFile(requirements, []byte(strings.Replace(string(content), "find marker A", "find the renamed marker A", 1)), 0o644); err != nil {
+		t.Fatalf("edit requirements: %v", err)
+	}
+
+	mustCLI(t, dir, "reconcile", "ledger-demo")
+	for _, phase := range []string{"requirements", "design", "tasks"} {
+		mustCLI(t, dir, "review", "open", "ledger-demo", "--phase", phase)
+		mustCLI(t, dir, "review", "approve", "ledger-demo", "--phase", phase)
+	}
+
+	out, code := cli(t, dir, "task", "status", "ledger-demo")
+	if code != 0 || !strings.Contains(out, "stale-spec") {
+		t.Fatalf("re-approved plan hides stale evidence: %s", out)
+	}
+
+	mustCLI(t, dir, "verify", "ledger-demo")
+	if out := evidenceSummary(t, dir); !strings.Contains(out, "2 verified") {
+		t.Fatalf("verify did not heal the chain: %s", out)
+	}
+}
+
+func TestE2ECorruptedLedgerRecovery(t *testing.T) {
+	requireGit(t)
+	dir := fixtureRepo(t)
+
+	ledger := filepath.Join(dir, ".walden/evidence/ledger-demo.json")
+	if err := os.WriteFile(ledger, []byte("{truncated"), 0o644); err != nil {
+		t.Fatalf("corrupt ledger: %v", err)
+	}
+
+	out, code := cli(t, dir, "task", "status", "ledger-demo")
+	if code != 0 || !strings.Contains(out, "unreadable") {
+		t.Fatalf("corruption invisible on task status: %s", out)
+	}
+	if _, code := cli(t, dir, "verify", "ledger-demo", "--all"); code == 0 {
+		t.Fatal("verify accepted a corrupt ledger")
+	}
+
+	if err := os.Remove(ledger); err != nil {
+		t.Fatalf("remove ledger: %v", err)
+	}
+	mustCLI(t, dir, "verify", "ledger-demo", "--all")
+	if out := evidenceSummary(t, dir); !strings.Contains(out, "2 verified") {
+		t.Fatalf("recovery did not regenerate the truth: %s", out)
+	}
+}
+
+func TestE2EOrphanPruning(t *testing.T) {
+	requireGit(t)
+	dir := fixtureRepo(t)
+
+	tasks := filepath.Join(dir, ".walden/specs/ledger-demo/tasks.md")
+	content, err := os.ReadFile(tasks)
+	if err != nil {
+		t.Fatalf("read tasks: %v", err)
+	}
+	renumbered := strings.Replace(string(content), "1.2 Place marker B", "1.3 Place marker B", 1)
+	if err := os.WriteFile(tasks, []byte(renumbered), 0o644); err != nil {
+		t.Fatalf("renumber: %v", err)
+	}
+
+	mustCLI(t, dir, "reconcile", "ledger-demo")
+	for _, phase := range []string{"requirements", "design", "tasks"} {
+		mustCLI(t, dir, "review", "open", "ledger-demo", "--phase", phase)
+		mustCLI(t, dir, "review", "approve", "ledger-demo", "--phase", phase)
+	}
+
+	out := mustCLI(t, dir, "verify", "ledger-demo")
+	if !strings.Contains(out, "pruned") || !strings.Contains(out, "1.2") {
+		t.Fatalf("orphan pruning not reported: %s", out)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, ".walden/evidence/ledger-demo.json"))
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+	if strings.Contains(string(data), "\"1.2\"") {
+		t.Fatal("orphan entry survived in the ledger")
+	}
+	if summary := evidenceSummary(t, dir); !strings.Contains(summary, "2 verified") {
+		t.Fatalf("final state incoherent: %s", summary)
+	}
+}

--- a/internal/e2e/evidence_e2e_test.go
+++ b/internal/e2e/evidence_e2e_test.go
@@ -322,3 +322,101 @@ func TestE2EOrphanPruning(t *testing.T) {
 		t.Fatalf("final state incoherent: %s", summary)
 	}
 }
+
+func TestE2ELegacyProofVerify(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	gitIn(t, dir, "init", "-q", "-b", "main")
+	gitIn(t, dir, "config", "user.email", "e2e@walden.dev")
+	gitIn(t, dir, "config", "user.name", "E2E")
+
+	mustCLI(t, dir, "repo", "init")
+	mustCLI(t, dir, "feature", "init", "legacy-demo")
+
+	writeFile(t, dir, ".walden/specs/legacy-demo/requirements.md", `---
+status: draft
+approved_at:
+last_modified: 2026-07-11T10:00:00Z
+approved_fingerprint:
+---
+
+# Requirements Document
+
+## Introduction
+
+Legacy proof fixture.
+
+## Requirements
+
+### R1 Marker
+
+**User Story:** As a tester, I want legacy proofs exercised, so that old plans keep verifying.
+
+#### Acceptance Criteria
+
+1. `+"`R1.AC1`"+` WHEN the legacy proof runs, the system SHALL find the marker.
+`)
+	writeFile(t, dir, ".walden/specs/legacy-demo/design.md", `---
+status: draft
+approved_at:
+last_modified: 2026-07-11T10:00:00Z
+approved_fingerprint:
+source_requirements_approved_at:
+source_requirements_fingerprint:
+---
+
+# Feature Design
+
+## Overview
+
+One legacy single-line proof.
+
+## Requirement Coverage
+
+| Requirement | Covered By |
+| --- | --- |
+| `+"`R1`"+` | src.txt |
+`)
+	writeFile(t, dir, ".walden/specs/legacy-demo/tasks.md", `---
+status: draft
+approved_at:
+last_modified: 2026-07-11T10:00:00Z
+approved_fingerprint:
+source_design_approved_at:
+source_design_fingerprint:
+---
+
+# Implementation Plan
+
+- [ ] 1. Marker
+  - [ ] 1.1 Place the marker
+    - Requirements: `+"`R1.AC1`"+`
+    - Design: Overview
+    - Verification: `+"`grep -q MARKER src.txt`"+`
+`)
+
+	for _, phase := range []string{"requirements", "design", "tasks"} {
+		mustCLI(t, dir, "review", "open", "legacy-demo", "--phase", phase)
+		mustCLI(t, dir, "review", "approve", "legacy-demo", "--phase", phase)
+	}
+	writeFile(t, dir, "src.txt", "MARKER\n")
+	mustCLI(t, dir, "task", "complete-all", "legacy-demo")
+
+	out, _ := cli(t, dir, "evidence", "status", "legacy-demo")
+	if !strings.Contains(out, "1 verified") {
+		t.Fatalf("legacy completion not recorded as verified: %s", out)
+	}
+
+	// The legacy path must survive re-verification too.
+	mustCLI(t, dir, "verify", "legacy-demo", "--all")
+	out, _ = cli(t, dir, "evidence", "status", "legacy-demo")
+	if !strings.Contains(out, "1 verified") {
+		t.Fatalf("legacy verify broke the state: %s", out)
+	}
+
+	// And a regression is still caught through the legacy proof.
+	writeFile(t, dir, "src.txt", "nothing here\n")
+	if _, code := cli(t, dir, "verify", "legacy-demo"); code == 0 {
+		t.Fatal("legacy verify passed on broken code")
+	}
+}

--- a/internal/evidence/derive.go
+++ b/internal/evidence/derive.go
@@ -1,0 +1,78 @@
+package evidence
+
+// Derived task states, ordered by precedence: failed > stale-spec >
+// stale-code > verified; unrecorded and pending stand apart.
+const (
+	StateVerified   = "verified"
+	StateFailed     = "failed"
+	StateStaleSpec  = "stale-spec"
+	StateStaleCode  = "stale-code"
+	StateUnrecorded = "unrecorded"
+	StatePending    = "pending"
+)
+
+// ChainFingerprints carries the current approved fingerprints records are
+// compared against. Task-definition fingerprints travel on each LeafTask.
+type ChainFingerprints struct {
+	Requirements string
+	Design       string
+}
+
+// LeafTask is the minimal task view derivation needs.
+type LeafTask struct {
+	ID          string
+	Completed   bool
+	Fingerprint string
+}
+
+// TaskEvidence is one task's derived execution state.
+type TaskEvidence struct {
+	TaskID           string
+	State            string
+	RecordedIdentity string
+	CurrentIdentity  string
+}
+
+// Derive computes every task's state from facts at read time — the record's
+// bindings against the current chain and code identity. Nothing here reads
+// or writes stored status labels, and timestamps never participate.
+func Derive(document Document, current ChainFingerprints, currentIdentity string, identityOK bool, tasks []LeafTask) []TaskEvidence {
+	derived := make([]TaskEvidence, 0, len(tasks))
+	if !identityOK {
+		currentIdentity = ""
+	}
+
+	for _, task := range tasks {
+		record, recorded := document.Tasks[task.ID]
+
+		entry := TaskEvidence{TaskID: task.ID, CurrentIdentity: currentIdentity}
+		switch {
+		case !task.Completed:
+			entry.State = StatePending
+		case !recorded:
+			entry.State = StateUnrecorded
+		default:
+			entry.RecordedIdentity = record.CodeIdentity
+			entry.State = recordState(record, current, task, currentIdentity)
+		}
+		derived = append(derived, entry)
+	}
+	return derived
+}
+
+func recordState(record Record, current ChainFingerprints, task LeafTask, currentIdentity string) string {
+	switch {
+	case record.Result != ResultPassed:
+		return StateFailed
+	case record.RequirementsFingerprint != current.Requirements,
+		record.DesignFingerprint != current.Design,
+		record.TaskFingerprint != task.Fingerprint:
+		return StateStaleSpec
+	case record.CodeIdentity != currentIdentity:
+		// Two absent identities compare equal: no-git repositories never
+		// drown in stale-code noise.
+		return StateStaleCode
+	default:
+		return StateVerified
+	}
+}

--- a/internal/evidence/derive_test.go
+++ b/internal/evidence/derive_test.go
@@ -1,0 +1,137 @@
+package evidence
+
+import "testing"
+
+func TestDeriveStatesAndPrecedence(t *testing.T) {
+	current := ChainFingerprints{Requirements: "sha256:req", Design: "sha256:des"}
+	baseRecord := func() Record {
+		return Record{
+			TaskFingerprint:         "sha256:task",
+			RequirementsFingerprint: "sha256:req",
+			DesignFingerprint:       "sha256:des",
+			TasksFingerprint:        "sha256:tasks",
+			CodeIdentity:            "sha256:code",
+			Result:                  ResultPassed,
+		}
+	}
+	task := LeafTask{ID: "1.1", Completed: true, Fingerprint: "sha256:task"}
+
+	cases := []struct {
+		name            string
+		mutate          func(*Record)
+		task            LeafTask
+		recorded        bool
+		currentIdentity string
+		identityOK      bool
+		want            string
+	}{
+		{
+			name: "verified when every binding matches",
+			task: task, recorded: true, currentIdentity: "sha256:code", identityOK: true,
+			want: StateVerified,
+		},
+		{
+			name: "pending when the task is unchecked",
+			task: LeafTask{ID: "1.1", Completed: false}, recorded: true,
+			currentIdentity: "sha256:code", identityOK: true,
+			want: StatePending,
+		},
+		{
+			name: "unrecorded when completed without an entry",
+			task: task, recorded: false, currentIdentity: "sha256:code", identityOK: true,
+			want: StateUnrecorded,
+		},
+		{
+			name:   "failed result wins",
+			mutate: func(r *Record) { r.Result = ResultFailed },
+			task:   task, recorded: true, currentIdentity: "sha256:code", identityOK: true,
+			want: StateFailed,
+		},
+		{
+			name:   "failed beats stale-spec",
+			mutate: func(r *Record) { r.Result = ResultFailed; r.RequirementsFingerprint = "sha256:old" },
+			task:   task, recorded: true, currentIdentity: "sha256:code", identityOK: true,
+			want: StateFailed,
+		},
+		{
+			name:   "requirements change is stale-spec",
+			mutate: func(r *Record) { r.RequirementsFingerprint = "sha256:old" },
+			task:   task, recorded: true, currentIdentity: "sha256:code", identityOK: true,
+			want: StateStaleSpec,
+		},
+		{
+			name:   "design change is stale-spec",
+			mutate: func(r *Record) { r.DesignFingerprint = "sha256:old" },
+			task:   task, recorded: true, currentIdentity: "sha256:code", identityOK: true,
+			want: StateStaleSpec,
+		},
+		{
+			name:     "task definition change is stale-spec",
+			task:     LeafTask{ID: "1.1", Completed: true, Fingerprint: "sha256:edited"},
+			recorded: true, currentIdentity: "sha256:code", identityOK: true,
+			want: StateStaleSpec,
+		},
+		{
+			name:   "stale-spec beats stale-code",
+			mutate: func(r *Record) { r.RequirementsFingerprint = "sha256:old" },
+			task:   task, recorded: true, currentIdentity: "sha256:moved", identityOK: true,
+			want: StateStaleSpec,
+		},
+		{
+			name: "code change is stale-code",
+			task: task, recorded: true, currentIdentity: "sha256:moved", identityOK: true,
+			want: StateStaleCode,
+		},
+		{
+			name:   "absent identities compare equal",
+			mutate: func(r *Record) { r.CodeIdentity = "" },
+			task:   task, recorded: true, currentIdentity: "", identityOK: false,
+			want: StateVerified,
+		},
+		{
+			name: "recorded identity with absent current is stale-code",
+			task: task, recorded: true, currentIdentity: "", identityOK: false,
+			want: StateStaleCode,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			record := baseRecord()
+			if tc.mutate != nil {
+				tc.mutate(&record)
+			}
+			document := Document{Feature: "f", Tasks: map[string]Record{}}
+			if tc.recorded {
+				document.Tasks["1.1"] = record
+			}
+
+			derived := Derive(document, current, tc.currentIdentity, tc.identityOK, []LeafTask{tc.task})
+			if len(derived) != 1 {
+				t.Fatalf("derived %d entries, want 1", len(derived))
+			}
+			if derived[0].State != tc.want {
+				t.Fatalf("state = %s, want %s", derived[0].State, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeriveNeverConsultsTimestamps(t *testing.T) {
+	current := ChainFingerprints{Requirements: "sha256:req", Design: "sha256:des"}
+	record := Record{
+		TaskFingerprint:         "sha256:task",
+		RequirementsFingerprint: "sha256:req",
+		DesignFingerprint:       "sha256:des",
+		CodeIdentity:            "sha256:code",
+		Result:                  ResultPassed,
+		VerifiedAt:              "1999-01-01T00:00:00Z",
+	}
+	document := Document{Feature: "f", Tasks: map[string]Record{"1.1": record}}
+	tasks := []LeafTask{{ID: "1.1", Completed: true, Fingerprint: "sha256:task"}}
+
+	derived := Derive(document, current, "sha256:code", true, tasks)
+	if derived[0].State != StateVerified {
+		t.Fatalf("an ancient timestamp influenced the verdict: %s", derived[0].State)
+	}
+}

--- a/internal/evidence/identity.go
+++ b/internal/evidence/identity.go
@@ -88,12 +88,41 @@ func applyOverlay(ctx context.Context, runner shell.Runner, root, porcelain stri
 			continue
 		}
 
-		if _, err := os.Stat(filepath.Join(root, path)); os.IsNotExist(err) {
+		info, err := os.Lstat(filepath.Join(root, path))
+		if os.IsNotExist(err) {
 			delete(blobs, path)
 			continue
 		}
+		if err != nil {
+			return false
+		}
 
-		hashed, err := runner.Run(ctx, "git", "-C", root, "hash-object", "--", path)
+		hashPath := path
+		if info.Mode()&os.ModeSymlink != 0 {
+			// Git stores a symlink as a blob of its target string, while
+			// hash-object on the link path would follow it and hash the
+			// target's content — a representation split that would make the
+			// untracked→committed transition read as a code change. Hash a
+			// staged copy of the target string instead.
+			target, err := os.Readlink(filepath.Join(root, path))
+			if err != nil {
+				return false
+			}
+			staged, err := os.CreateTemp("", ".walden-linkblob-*")
+			if err != nil {
+				return false
+			}
+			if _, err := staged.WriteString(target); err != nil {
+				_ = staged.Close()
+				_ = os.Remove(staged.Name())
+				return false
+			}
+			_ = staged.Close()
+			defer func(name string) { _ = os.Remove(name) }(staged.Name())
+			hashPath = staged.Name()
+		}
+
+		hashed, err := runner.Run(ctx, "git", "-C", root, "hash-object", "--", hashPath)
 		if err != nil || hashed.ExitCode != 0 {
 			return false
 		}

--- a/internal/evidence/identity.go
+++ b/internal/evidence/identity.go
@@ -52,8 +52,10 @@ func Identity(ctx context.Context, runner shell.Runner, root string) (string, bo
 	return "sha256:" + hex.EncodeToString(sum[:]), true
 }
 
-// seedListing fills the blob map from a `git ls-tree -r HEAD` listing
-// (format: "<mode> <type> <hash>\t<path>"), dropping .walden/ entries.
+// seedListing fills the map from a `git ls-tree -r HEAD` listing (format:
+// "<mode> <type> <hash>\t<path>"), dropping .walden/ entries. Entries carry
+// "<mode>:<blob>": the executable bit is code, so mode changes must move
+// the identity.
 func seedListing(blobs map[string]string, listing string) {
 	for _, line := range strings.Split(listing, "\n") {
 		meta, path, found := strings.Cut(line, "\t")
@@ -64,7 +66,7 @@ func seedListing(blobs map[string]string, listing string) {
 		if len(fields) < 3 {
 			continue
 		}
-		blobs[path] = fields[2]
+		blobs[path] = fields[0] + ":" + fields[2]
 	}
 }
 
@@ -76,6 +78,7 @@ func seedListing(blobs map[string]string, listing string) {
 func applyOverlay(ctx context.Context, runner shell.Runner, root, porcelain string, blobs map[string]string) bool {
 	pending := []string{}  // repo-relative paths, hashed in batches
 	hashArgs := []string{} // the argv actually passed for each pending path
+	modes := []string{}    // canonical git mode per pending path
 	cleanups := []string{}
 
 	defer func() {
@@ -109,7 +112,12 @@ func applyOverlay(ctx context.Context, runner shell.Runner, root, porcelain stri
 		}
 
 		hashArg := path
+		mode := "100644"
+		if info.Mode().Perm()&0o111 != 0 {
+			mode = "100755"
+		}
 		if info.Mode()&os.ModeSymlink != 0 {
+			mode = "120000"
 			// Git stores a symlink as a blob of its target string, while
 			// hash-object on the link path would follow it and hash the
 			// target's content — a representation split that would make the
@@ -134,6 +142,7 @@ func applyOverlay(ctx context.Context, runner shell.Runner, root, porcelain stri
 		}
 		pending = append(pending, path)
 		hashArgs = append(hashArgs, hashArg)
+		modes = append(modes, mode)
 	}
 
 	const chunkSize = 500
@@ -153,7 +162,7 @@ func applyOverlay(ctx context.Context, runner shell.Runner, root, porcelain stri
 			return false
 		}
 		for offset, blob := range lines {
-			blobs[pending[start+offset]] = blob
+			blobs[pending[start+offset]] = modes[start+offset] + ":" + blob
 		}
 	}
 	return true

--- a/internal/evidence/identity.go
+++ b/internal/evidence/identity.go
@@ -1,0 +1,111 @@
+package evidence
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/andrearaponi/walden/internal/shell"
+)
+
+// waldenDir is excluded from the code identity at every layer: spec changes
+// invalidate through fingerprints, and committing the evidence document must
+// never invalidate the evidence it carries.
+const waldenDir = ".walden"
+
+// Identity derives a deterministic identity of the working tree as one
+// uniform path→blob map: the .walden-filtered HEAD listing seeds committed
+// blob ids, and every dirty or untracked path overrides its entry with the
+// blob id of its current content (git hash-object). Uniform blob ids on both
+// layers mean committing an unchanged file never moves the identity.
+// Identical content yields identical identities regardless of branch names,
+// timestamps, or .walden contents. The second return is false when git is
+// unavailable — callers record the absence and continue.
+func Identity(ctx context.Context, runner shell.Runner, root string) (string, bool) {
+	status, err := runner.Run(ctx, "git", "-C", root, "status", "--porcelain", "--untracked-files=all", "-z", "--", ".", ":(exclude)"+waldenDir)
+	if err != nil || status.ExitCode != 0 {
+		return "", false
+	}
+
+	// Unborn HEAD (no commits yet) degrades to the overlay alone; the
+	// repository itself is proven present by the successful status call.
+	blobs := map[string]string{}
+	if lsTree, err := runner.Run(ctx, "git", "-C", root, "ls-tree", "-r", "HEAD"); err == nil && lsTree.ExitCode == 0 {
+		seedListing(blobs, lsTree.Stdout)
+	}
+
+	if !applyOverlay(ctx, runner, root, status.Stdout, blobs) {
+		return "", false
+	}
+
+	entries := make([]string, 0, len(blobs))
+	for path, blob := range blobs {
+		entries = append(entries, path+":"+blob)
+	}
+	sort.Strings(entries)
+
+	sum := sha256.Sum256([]byte(strings.Join(entries, "\n")))
+	return "sha256:" + hex.EncodeToString(sum[:]), true
+}
+
+// seedListing fills the blob map from a `git ls-tree -r HEAD` listing
+// (format: "<mode> <type> <hash>\t<path>"), dropping .walden/ entries.
+func seedListing(blobs map[string]string, listing string) {
+	for _, line := range strings.Split(listing, "\n") {
+		meta, path, found := strings.Cut(line, "\t")
+		if !found || isWaldenPath(path) {
+			continue
+		}
+		fields := strings.Fields(meta)
+		if len(fields) < 3 {
+			continue
+		}
+		blobs[path] = fields[2]
+	}
+}
+
+// applyOverlay overrides the blob map with the current content of every
+// dirty or untracked path from NUL-separated porcelain output, using git
+// hash-object so the representation matches committed entries. Deleted
+// paths leave the map.
+func applyOverlay(ctx context.Context, runner shell.Runner, root, porcelain string, blobs map[string]string) bool {
+	fields := strings.Split(porcelain, "\x00")
+	for index := 0; index < len(fields); index++ {
+		entry := fields[index]
+		if len(entry) < 4 {
+			continue
+		}
+		statusCode, path := entry[:2], entry[3:]
+		if strings.HasPrefix(statusCode, "R") || strings.HasPrefix(statusCode, "C") {
+			// Renames and copies carry the source path as the next field.
+			index++
+		}
+		if isWaldenPath(path) {
+			continue
+		}
+
+		if _, err := os.Stat(filepath.Join(root, path)); os.IsNotExist(err) {
+			delete(blobs, path)
+			continue
+		}
+
+		hashed, err := runner.Run(ctx, "git", "-C", root, "hash-object", "--", path)
+		if err != nil || hashed.ExitCode != 0 {
+			return false
+		}
+		blob := strings.TrimSpace(hashed.Stdout)
+		if blob == "" {
+			return false
+		}
+		blobs[path] = blob
+	}
+	return true
+}
+
+func isWaldenPath(path string) bool {
+	return path == waldenDir || strings.HasPrefix(path, waldenDir+"/")
+}

--- a/internal/evidence/identity.go
+++ b/internal/evidence/identity.go
@@ -71,8 +71,19 @@ func seedListing(blobs map[string]string, listing string) {
 // applyOverlay overrides the blob map with the current content of every
 // dirty or untracked path from NUL-separated porcelain output, using git
 // hash-object so the representation matches committed entries. Deleted
-// paths leave the map.
+// paths leave the map. Regular files are hashed in chunked batches — one
+// git spawn per file made a 400-file dirty tree cost seconds per status.
 func applyOverlay(ctx context.Context, runner shell.Runner, root, porcelain string, blobs map[string]string) bool {
+	pending := []string{}  // repo-relative paths, hashed in batches
+	hashArgs := []string{} // the argv actually passed for each pending path
+	cleanups := []string{}
+
+	defer func() {
+		for _, name := range cleanups {
+			_ = os.Remove(name)
+		}
+	}()
+
 	fields := strings.Split(porcelain, "\x00")
 	for index := 0; index < len(fields); index++ {
 		entry := fields[index]
@@ -97,7 +108,7 @@ func applyOverlay(ctx context.Context, runner shell.Runner, root, porcelain stri
 			return false
 		}
 
-		hashPath := path
+		hashArg := path
 		if info.Mode()&os.ModeSymlink != 0 {
 			// Git stores a symlink as a blob of its target string, while
 			// hash-object on the link path would follow it and hash the
@@ -118,19 +129,32 @@ func applyOverlay(ctx context.Context, runner shell.Runner, root, porcelain stri
 				return false
 			}
 			_ = staged.Close()
-			defer func(name string) { _ = os.Remove(name) }(staged.Name())
-			hashPath = staged.Name()
+			cleanups = append(cleanups, staged.Name())
+			hashArg = staged.Name()
+		}
+		pending = append(pending, path)
+		hashArgs = append(hashArgs, hashArg)
+	}
+
+	const chunkSize = 500
+	for start := 0; start < len(pending); start += chunkSize {
+		end := start + chunkSize
+		if end > len(pending) {
+			end = len(pending)
 		}
 
-		hashed, err := runner.Run(ctx, "git", "-C", root, "hash-object", "--", hashPath)
+		args := append([]string{"-C", root, "hash-object", "--"}, hashArgs[start:end]...)
+		hashed, err := runner.Run(ctx, "git", args...)
 		if err != nil || hashed.ExitCode != 0 {
 			return false
 		}
-		blob := strings.TrimSpace(hashed.Stdout)
-		if blob == "" {
+		lines := strings.Fields(hashed.Stdout)
+		if len(lines) != end-start {
 			return false
 		}
-		blobs[path] = blob
+		for offset, blob := range lines {
+			blobs[pending[start+offset]] = blob
+		}
 	}
 	return true
 }

--- a/internal/evidence/identity_test.go
+++ b/internal/evidence/identity_test.go
@@ -328,3 +328,61 @@ func TestIdentityTracksModeChanges(t *testing.T) {
 		t.Fatal("an executable-bit flip did not move the identity: the mode is code")
 	}
 }
+
+func TestIdentityHandlesPathologicalFilenames(t *testing.T) {
+	root := t.TempDir()
+	names := []string{"file with spaces.txt", "città-über.txt"}
+	for _, name := range names {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("v1:"+name), 0o644); err != nil {
+			t.Fatalf("seed %q: %v", name, err)
+		}
+	}
+
+	porcelain := "?? file with spaces.txt\x00?? città-über.txt\x00"
+	git := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: porcelain},
+		"ls-tree": {ExitCode: 0, Stdout: ""},
+	}}
+
+	first, ok := Identity(context.Background(), git, root)
+	if !ok {
+		t.Fatal("identity not computed with pathological names")
+	}
+	second, _ := Identity(context.Background(), git, root)
+	if first != second {
+		t.Fatal("identity unstable across runs with pathological names")
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "città-über.txt"), []byte("v2"), 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	third, _ := Identity(context.Background(), git, root)
+	if first == third {
+		t.Fatal("unicode filename content change did not move the identity")
+	}
+}
+
+func TestIdentityHandlesRenameEntries(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "renamed.txt"), []byte("content"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Porcelain -z rename entries carry the source path as a separate
+	// NUL field, which the parser must consume without hashing it.
+	git := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: "R  renamed.txt\x00original.txt\x00"},
+		"ls-tree": {ExitCode: 0, Stdout: "100644 blob aaa\toriginal.txt\n"},
+	}}
+
+	identity, ok := Identity(context.Background(), git, root)
+	if !ok {
+		t.Fatal("identity not computed on a rename")
+	}
+
+	// The old path stays in the map only via the listing; the source field
+	// must not be treated as a live file (it does not exist on disk).
+	if identity == "" {
+		t.Fatal("empty identity")
+	}
+}

--- a/internal/evidence/identity_test.go
+++ b/internal/evidence/identity_test.go
@@ -216,7 +216,7 @@ func TestIdentitySurvivesTheCommitTransition(t *testing.T) {
 	}}
 	committed := &fakeGit{responses: map[string]shell.Response{
 		"status":  {ExitCode: 0},
-		"ls-tree": {ExitCode: 0, Stdout: "100644 blob " + blobID + "\tcalc.sh\n"},
+		"ls-tree": {ExitCode: 0, Stdout: "100755 blob " + blobID + "\tcalc.sh\n"},
 	}}
 
 	before, ok := Identity(context.Background(), untracked, root)
@@ -303,5 +303,28 @@ func TestIdentityBatchesDirtyHashing(t *testing.T) {
 	}
 	if counting.hashSpawns != 1 {
 		t.Fatalf("hash-object spawned %d times for 4 dirty files, want 1 batched call", counting.hashSpawns)
+	}
+}
+
+func TestIdentityTracksModeChanges(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "run.sh")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\ntrue\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	git := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: " M run.sh\x00"},
+		"ls-tree": {ExitCode: 0, Stdout: "100644 blob aaa\trun.sh\n"},
+	}}
+
+	plain, _ := Identity(context.Background(), git, root)
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	executable, _ := Identity(context.Background(), git, root)
+
+	if plain == executable {
+		t.Fatal("an executable-bit flip did not move the identity: the mode is code")
 	}
 }

--- a/internal/evidence/identity_test.go
+++ b/internal/evidence/identity_test.go
@@ -1,0 +1,218 @@
+package evidence
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/shell"
+)
+
+// fakeGit answers git subcommands from a canned map keyed by the second
+// argument after -C <root> (e.g. "status", "ls-tree").
+type fakeGit struct {
+	responses map[string]shell.Response
+	errors    map[string]error
+}
+
+func (f *fakeGit) Run(_ context.Context, name string, args ...string) (shell.Response, error) {
+	if name != "git" || len(args) < 3 {
+		return shell.Response{}, errors.New("unexpected invocation")
+	}
+	sub := args[2]
+	if err, exists := f.errors[sub]; exists {
+		return shell.Response{}, err
+	}
+	if sub == "hash-object" {
+		// Content-derived fake blob id: sha256 of the file, mirroring how
+		// real blob ids are stable functions of content.
+		root, path := args[1], args[len(args)-1]
+		content, err := os.ReadFile(filepath.Join(root, path))
+		if err != nil {
+			return shell.Response{ExitCode: 128, Stderr: err.Error()}, nil
+		}
+		sum := sha256.Sum256(content)
+		return shell.Response{ExitCode: 0, Stdout: hex.EncodeToString(sum[:]) + "\n"}, nil
+	}
+	if resp, exists := f.responses[sub]; exists {
+		return resp, nil
+	}
+	return shell.Response{ExitCode: 0}, nil
+}
+
+func lsTreeListing(lines ...string) string {
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func TestIdentityCleanTreeExcludesWalden(t *testing.T) {
+	root := t.TempDir()
+
+	withEvidence := &fakeGit{responses: map[string]shell.Response{
+		"status": {ExitCode: 0},
+		"ls-tree": {ExitCode: 0, Stdout: lsTreeListing(
+			"100644 blob aaa\tmain.go",
+			"100644 blob bbb\t.walden/evidence/f.json",
+		)},
+	}}
+	withoutEvidence := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0},
+		"ls-tree": {ExitCode: 0, Stdout: lsTreeListing("100644 blob aaa\tmain.go")},
+	}}
+	differentCode := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0},
+		"ls-tree": {ExitCode: 0, Stdout: lsTreeListing("100644 blob ccc\tmain.go")},
+	}}
+
+	first, ok := Identity(context.Background(), withEvidence, root)
+	if !ok {
+		t.Fatal("identity not computed")
+	}
+	second, ok := Identity(context.Background(), withoutEvidence, root)
+	if !ok {
+		t.Fatal("identity not computed")
+	}
+	third, ok := Identity(context.Background(), differentCode, root)
+	if !ok {
+		t.Fatal("identity not computed")
+	}
+
+	if first != second {
+		t.Fatalf("committing .walden content changed the identity: %s vs %s", first, second)
+	}
+	if first == third {
+		t.Fatal("a code change did not change the identity")
+	}
+	if !strings.HasPrefix(first, "sha256:") {
+		t.Fatalf("identity %q lacks the sha256 prefix", first)
+	}
+}
+
+func TestIdentityDirtyOverlayIsOrderIndependent(t *testing.T) {
+	root := t.TempDir()
+	for name, content := range map[string]string{"a.go": "alpha", "b.go": "beta"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	orderAB := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: " M a.go\x00?? b.go\x00"},
+		"ls-tree": {ExitCode: 0, Stdout: lsTreeListing("100644 blob aaa\tmain.go")},
+	}}
+	orderBA := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: "?? b.go\x00 M a.go\x00"},
+		"ls-tree": {ExitCode: 0, Stdout: lsTreeListing("100644 blob aaa\tmain.go")},
+	}}
+
+	first, _ := Identity(context.Background(), orderAB, root)
+	second, _ := Identity(context.Background(), orderBA, root)
+	if first != second {
+		t.Fatalf("status ordering changed the identity: %s vs %s", first, second)
+	}
+}
+
+func TestIdentityTracksUntrackedContent(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "new.go")
+	if err := os.WriteFile(path, []byte("v1"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	git := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: "?? new.go\x00"},
+		"ls-tree": {ExitCode: 0, Stdout: ""},
+	}}
+
+	before, _ := Identity(context.Background(), git, root)
+	if err := os.WriteFile(path, []byte("v2"), 0o644); err != nil {
+		t.Fatalf("rewrite file: %v", err)
+	}
+	after, _ := Identity(context.Background(), git, root)
+
+	if before == after {
+		t.Fatal("untracked content change did not change the identity")
+	}
+}
+
+func TestIdentityHandlesDeletedFiles(t *testing.T) {
+	root := t.TempDir()
+	git := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: " D gone.go\x00"},
+		"ls-tree": {ExitCode: 0, Stdout: lsTreeListing("100644 blob aaa\tgone.go")},
+	}}
+
+	identity, ok := Identity(context.Background(), git, root)
+	if !ok || identity == "" {
+		t.Fatal("deleted file broke identity computation")
+	}
+}
+
+func TestIdentityUnbornHeadUsesOverlayAlone(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "first.go"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	git := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: "?? first.go\x00"},
+		"ls-tree": {ExitCode: 128, Stderr: "fatal: not a valid object name HEAD"},
+	}}
+
+	identity, ok := Identity(context.Background(), git, root)
+	if !ok || identity == "" {
+		t.Fatal("unborn HEAD did not degrade to the overlay")
+	}
+}
+
+func TestIdentityGitFailureReturnsAbsent(t *testing.T) {
+	root := t.TempDir()
+
+	cases := []*fakeGit{
+		{responses: map[string]shell.Response{"status": {ExitCode: 128, Stderr: "fatal: not a git repository"}}},
+		{errors: map[string]error{"status": errors.New("executable file not found")}},
+	}
+	for _, git := range cases {
+		if identity, ok := Identity(context.Background(), git, root); ok || identity != "" {
+			t.Fatalf("git failure yielded identity %q ok=%t, want absent", identity, ok)
+		}
+	}
+}
+
+func TestIdentitySurvivesTheCommitTransition(t *testing.T) {
+	// The serpent's little sibling: an untracked file and the same file
+	// committed must produce the same identity — layer transitions are not
+	// content changes.
+	root := t.TempDir()
+	content := []byte("#!/bin/sh\necho 5\n")
+	if err := os.WriteFile(filepath.Join(root, "calc.sh"), content, 0o755); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	blob := sha256.Sum256(content)
+	blobID := hex.EncodeToString(blob[:])
+
+	untracked := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: "?? calc.sh\x00"},
+		"ls-tree": {ExitCode: 128, Stderr: "fatal: not a valid object name HEAD"},
+	}}
+	committed := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0},
+		"ls-tree": {ExitCode: 0, Stdout: "100644 blob " + blobID + "\tcalc.sh\n"},
+	}}
+
+	before, ok := Identity(context.Background(), untracked, root)
+	if !ok {
+		t.Fatal("untracked identity not computed")
+	}
+	after, ok := Identity(context.Background(), committed, root)
+	if !ok {
+		t.Fatal("committed identity not computed")
+	}
+	if before != after {
+		t.Fatalf("committing unchanged content moved the identity: %s vs %s", before, after)
+	}
+}

--- a/internal/evidence/identity_test.go
+++ b/internal/evidence/identity_test.go
@@ -30,9 +30,13 @@ func (f *fakeGit) Run(_ context.Context, name string, args ...string) (shell.Res
 	}
 	if sub == "hash-object" {
 		// Content-derived fake blob id: sha256 of the file, mirroring how
-		// real blob ids are stable functions of content.
+		// real blob ids are stable functions of content. Absolute paths
+		// (the staged symlink-target copies) are honored as git does.
 		root, path := args[1], args[len(args)-1]
-		content, err := os.ReadFile(filepath.Join(root, path))
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(root, path)
+		}
+		content, err := os.ReadFile(path)
 		if err != nil {
 			return shell.Response{ExitCode: 128, Stderr: err.Error()}, nil
 		}
@@ -214,5 +218,43 @@ func TestIdentitySurvivesTheCommitTransition(t *testing.T) {
 	}
 	if before != after {
 		t.Fatalf("committing unchanged content moved the identity: %s vs %s", before, after)
+	}
+}
+
+func TestIdentitySurvivesTheSymlinkCommitTransition(t *testing.T) {
+	// Git stores a symlink blob as its target string; following the link
+	// would hash the target's content instead. Both layers must agree.
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "Makefile"), []byte("build:\n\ttrue\n"), 0o644); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	if err := os.Symlink("Makefile", filepath.Join(root, "link.mk")); err != nil {
+		t.Fatalf("seed symlink: %v", err)
+	}
+	targetBlob := sha256.Sum256([]byte("Makefile"))
+	linkBlobID := hex.EncodeToString(targetBlob[:])
+	fileBlob := sha256.Sum256([]byte("build:\n\ttrue\n"))
+	fileBlobID := hex.EncodeToString(fileBlob[:])
+
+	untracked := &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: "?? Makefile\x00?? link.mk\x00"},
+		"ls-tree": {ExitCode: 128, Stderr: "fatal: not a valid object name HEAD"},
+	}}
+	committed := &fakeGit{responses: map[string]shell.Response{
+		"status": {ExitCode: 0},
+		"ls-tree": {ExitCode: 0, Stdout: "100644 blob " + fileBlobID + "\tMakefile\n" +
+			"120000 blob " + linkBlobID + "\tlink.mk\n"},
+	}}
+
+	before, ok := Identity(context.Background(), untracked, root)
+	if !ok {
+		t.Fatal("untracked identity not computed")
+	}
+	after, ok := Identity(context.Background(), committed, root)
+	if !ok {
+		t.Fatal("committed identity not computed")
+	}
+	if before != after {
+		t.Fatalf("committing an unchanged symlink moved the identity: %s vs %s", before, after)
 	}
 }

--- a/internal/evidence/identity_test.go
+++ b/internal/evidence/identity_test.go
@@ -29,19 +29,30 @@ func (f *fakeGit) Run(_ context.Context, name string, args ...string) (shell.Res
 		return shell.Response{}, err
 	}
 	if sub == "hash-object" {
-		// Content-derived fake blob id: sha256 of the file, mirroring how
-		// real blob ids are stable functions of content. Absolute paths
-		// (the staged symlink-target copies) are honored as git does.
-		root, path := args[1], args[len(args)-1]
-		if !filepath.IsAbs(path) {
-			path = filepath.Join(root, path)
+		// Content-derived fake blob ids, one line per path after "--",
+		// mirroring git's batched output. Absolute paths (staged symlink
+		// targets) are honored as git does.
+		root := args[1]
+		separator := -1
+		for i, a := range args {
+			if a == "--" {
+				separator = i
+				break
+			}
 		}
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return shell.Response{ExitCode: 128, Stderr: err.Error()}, nil
+		lines := ""
+		for _, path := range args[separator+1:] {
+			if !filepath.IsAbs(path) {
+				path = filepath.Join(root, path)
+			}
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return shell.Response{ExitCode: 128, Stderr: err.Error()}, nil
+			}
+			sum := sha256.Sum256(content)
+			lines += hex.EncodeToString(sum[:]) + "\n"
 		}
-		sum := sha256.Sum256(content)
-		return shell.Response{ExitCode: 0, Stdout: hex.EncodeToString(sum[:]) + "\n"}, nil
+		return shell.Response{ExitCode: 0, Stdout: lines}, nil
 	}
 	if resp, exists := f.responses[sub]; exists {
 		return resp, nil
@@ -256,5 +267,41 @@ func TestIdentitySurvivesTheSymlinkCommitTransition(t *testing.T) {
 	}
 	if before != after {
 		t.Fatalf("committing an unchanged symlink moved the identity: %s vs %s", before, after)
+	}
+}
+
+// countingGit wraps fakeGit and counts hash-object invocations.
+type countingGit struct {
+	inner      *fakeGit
+	hashSpawns int
+}
+
+func (c *countingGit) Run(ctx context.Context, name string, args ...string) (shell.Response, error) {
+	if len(args) >= 3 && args[2] == "hash-object" {
+		c.hashSpawns++
+	}
+	return c.inner.Run(ctx, name, args...)
+}
+
+func TestIdentityBatchesDirtyHashing(t *testing.T) {
+	root := t.TempDir()
+	porcelain := ""
+	for _, name := range []string{"a.go", "b.go", "c.go", "d.go"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(name), 0o644); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+		porcelain += "?? " + name + "\x00"
+	}
+
+	counting := &countingGit{inner: &fakeGit{responses: map[string]shell.Response{
+		"status":  {ExitCode: 0, Stdout: porcelain},
+		"ls-tree": {ExitCode: 0, Stdout: ""},
+	}}}
+
+	if _, ok := Identity(context.Background(), counting, root); !ok {
+		t.Fatal("identity not computed")
+	}
+	if counting.hashSpawns != 1 {
+		t.Fatalf("hash-object spawned %d times for 4 dirty files, want 1 batched call", counting.hashSpawns)
 	}
 }

--- a/internal/evidence/record.go
+++ b/internal/evidence/record.go
@@ -1,0 +1,57 @@
+// Package evidence owns the execution-evidence ledger: durable records
+// binding each completed task's proof to the approved chain fingerprints and
+// to a code identity of the working tree, with states derived from those
+// bindings at read time — never stored.
+package evidence
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// SchemaVersion identifies the evidence document format, versioned
+// independently from the CLI output contract.
+const SchemaVersion = "v1alpha1"
+
+// StepResult captures one executed proof step.
+type StepResult struct {
+	Command      []string `json:"command"`
+	ExpectedExit int      `json:"expected_exit"`
+	ActualExit   int      `json:"actual_exit"`
+	OutputDigest string   `json:"output_digest"`
+}
+
+// Record is the evidence entry for one task: the proof outcome bound to the
+// chain fingerprints and code identity in force when it ran. VerifiedAt is
+// human context only and never influences a derived state.
+type Record struct {
+	TaskFingerprint         string       `json:"task_fingerprint"`
+	RequirementsFingerprint string       `json:"requirements_fingerprint"`
+	DesignFingerprint       string       `json:"design_fingerprint"`
+	TasksFingerprint        string       `json:"tasks_fingerprint"`
+	CodeIdentity            string       `json:"code_identity,omitempty"`
+	Steps                   []StepResult `json:"steps"`
+	Result                  string       `json:"result"`
+	VerifiedAt              string       `json:"verified_at"`
+}
+
+// Result values recorded on entries.
+const (
+	ResultPassed = "passed"
+	ResultFailed = "failed"
+)
+
+// DigestOutput hashes a proof step's combined output for the record: small,
+// deterministic, and free of secrets-in-logs concerns.
+func DigestOutput(output string) string {
+	sum := sha256.Sum256([]byte(output))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// Document is the per-feature evidence ledger: a current-state map keyed by
+// task id. History lives in git, not in the file.
+type Document struct {
+	SchemaVersion string            `json:"schema_version"`
+	Feature       string            `json:"feature"`
+	Tasks         map[string]Record `json:"tasks"`
+}

--- a/internal/evidence/store.go
+++ b/internal/evidence/store.go
@@ -1,0 +1,55 @@
+package evidence
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/andrearaponi/walden/internal/spec"
+)
+
+// DocumentPath returns the evidence document location for a feature. It
+// lives inside the committed .walden/ tree deliberately: evidence is shared
+// repository state, not a local cache.
+func DocumentPath(root, feature string) string {
+	return filepath.Join(root, ".walden", "evidence", feature+".json")
+}
+
+// Load reads the feature's evidence document. An absent file is an empty
+// ledger, not an error.
+func Load(root, feature string) (Document, error) {
+	data, err := os.ReadFile(DocumentPath(root, feature))
+	if errors.Is(err, os.ErrNotExist) {
+		return Document{SchemaVersion: SchemaVersion, Feature: feature, Tasks: map[string]Record{}}, nil
+	}
+	if err != nil {
+		return Document{}, fmt.Errorf("read evidence document: %w", err)
+	}
+
+	var document Document
+	if err := json.Unmarshal(data, &document); err != nil {
+		return Document{}, fmt.Errorf("parse evidence document %s: %w", DocumentPath(root, feature), err)
+	}
+	if document.Tasks == nil {
+		document.Tasks = map[string]Record{}
+	}
+	return document, nil
+}
+
+// Save persists the document atomically, stamping the schema version.
+func Save(root string, document Document) error {
+	document.SchemaVersion = SchemaVersion
+	path := DocumentPath(root, document.Feature)
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create evidence directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode evidence document: %w", err)
+	}
+	return spec.WriteFileAtomic(path, append(data, '\n'))
+}

--- a/internal/evidence/store.go
+++ b/internal/evidence/store.go
@@ -32,6 +32,9 @@ func Load(root, feature string) (Document, error) {
 	if err := json.Unmarshal(data, &document); err != nil {
 		return Document{}, fmt.Errorf("parse evidence document %s: %w", DocumentPath(root, feature), err)
 	}
+	if document.SchemaVersion != "" && document.SchemaVersion != SchemaVersion {
+		return Document{}, fmt.Errorf("evidence document %s carries schema %s; this binary speaks %s (upgrade walden, or remove the file and rerun `walden verify --all`)", DocumentPath(root, feature), document.SchemaVersion, SchemaVersion)
+	}
 	if document.Tasks == nil {
 		document.Tasks = map[string]Record{}
 	}

--- a/internal/evidence/store_test.go
+++ b/internal/evidence/store_test.go
@@ -1,0 +1,104 @@
+package evidence
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func sampleRecord() Record {
+	return Record{
+		TaskFingerprint:         "sha256:task",
+		RequirementsFingerprint: "sha256:req",
+		DesignFingerprint:       "sha256:des",
+		TasksFingerprint:        "sha256:tasks",
+		CodeIdentity:            "sha256:code",
+		Steps: []StepResult{
+			{Command: []string{"go", "test", "./..."}, ExpectedExit: 0, ActualExit: 0, OutputDigest: "sha256:out"},
+		},
+		Result:     ResultPassed,
+		VerifiedAt: "2026-07-10T18:00:00Z",
+	}
+}
+
+func TestEvidenceStoreAbsentFileIsEmptyLedger(t *testing.T) {
+	document, err := Load(t.TempDir(), "user-auth")
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if document.SchemaVersion != SchemaVersion || document.Feature != "user-auth" {
+		t.Fatalf("empty ledger = %+v, want stamped schema and feature", document)
+	}
+	if len(document.Tasks) != 0 {
+		t.Fatalf("empty ledger carries %d tasks", len(document.Tasks))
+	}
+}
+
+func TestEvidenceStoreRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	saved := Document{Feature: "user-auth", Tasks: map[string]Record{"1.1": sampleRecord()}}
+
+	if err := Save(root, saved); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+
+	loaded, err := Load(root, "user-auth")
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if loaded.SchemaVersion != SchemaVersion {
+		t.Fatalf("schema_version = %q, want %q", loaded.SchemaVersion, SchemaVersion)
+	}
+	if !reflect.DeepEqual(loaded.Tasks["1.1"], sampleRecord()) {
+		t.Fatalf("round-trip mismatch:\n%+v\nwant\n%+v", loaded.Tasks["1.1"], sampleRecord())
+	}
+}
+
+func TestEvidenceStoreReplacesEntryPerTask(t *testing.T) {
+	root := t.TempDir()
+	first := sampleRecord()
+	if err := Save(root, Document{Feature: "f", Tasks: map[string]Record{"1.1": first}}); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+
+	replacement := sampleRecord()
+	replacement.CodeIdentity = "sha256:new"
+	if err := Save(root, Document{Feature: "f", Tasks: map[string]Record{"1.1": replacement}}); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+
+	loaded, err := Load(root, "f")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded.Tasks) != 1 || loaded.Tasks["1.1"].CodeIdentity != "sha256:new" {
+		t.Fatalf("entry not replaced: %+v", loaded.Tasks)
+	}
+}
+
+func TestEvidenceStoreWritesAtomicallyInsideWalden(t *testing.T) {
+	root := t.TempDir()
+	if err := Save(root, Document{Feature: "f", Tasks: map[string]Record{"1.1": sampleRecord()}}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	path := DocumentPath(root, "f")
+	if !strings.HasPrefix(path, filepath.Join(root, ".walden", "evidence")) {
+		t.Fatalf("evidence path %q escapes .walden/evidence", path)
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("read evidence dir: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".walden-doc-") {
+			t.Fatalf("staging leftover %s", entry.Name())
+		}
+	}
+	if len(entries) != 1 {
+		t.Fatalf("evidence dir holds %d entries, want 1", len(entries))
+	}
+}

--- a/internal/evidence/store_test.go
+++ b/internal/evidence/store_test.go
@@ -102,3 +102,23 @@ func TestEvidenceStoreWritesAtomicallyInsideWalden(t *testing.T) {
 		t.Fatalf("evidence dir holds %d entries, want 1", len(entries))
 	}
 }
+
+func TestEvidenceStoreRejectsUnknownSchema(t *testing.T) {
+	root := t.TempDir()
+	if err := Save(root, Document{Feature: "f", Tasks: map[string]Record{"1.1": sampleRecord()}}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	path := DocumentPath(root, "f")
+	data, _ := os.ReadFile(path)
+	if err := os.WriteFile(path, []byte(strings.Replace(string(data), SchemaVersion, "v9alpha9", 1)), 0o644); err != nil {
+		t.Fatalf("tamper schema: %v", err)
+	}
+
+	_, err := Load(root, "f")
+	if err == nil {
+		t.Fatal("unknown evidence schema accepted silently")
+	}
+	if !strings.Contains(err.Error(), "v9alpha9") || !strings.Contains(err.Error(), SchemaVersion) {
+		t.Fatalf("error %q does not name both schemas", err)
+	}
+}

--- a/internal/output/result.go
+++ b/internal/output/result.go
@@ -32,9 +32,20 @@ type Result struct {
 	Coverage              *CoverageReport   `json:"coverage,omitempty"`
 	EARSDistribution      *EARSDistribution `json:"ears_distribution,omitempty"`
 	Skills                []SkillStatus     `json:"skills,omitempty"`
+	Evidence              []EvidenceStatus  `json:"evidence,omitempty"`
 	Update                *UpdateStatus     `json:"update,omitempty"`
 	Content               string            `json:"content,omitempty"`
 	ExitCode              int               `json:"exit_code"`
+}
+
+// EvidenceStatus is the JSON output view of one task's execution evidence.
+type EvidenceStatus struct {
+	TaskID           string `json:"task_id"`
+	State            string `json:"state"`
+	Passed           *bool  `json:"passed,omitempty"`
+	Failure          string `json:"failure,omitempty"`
+	RecordedIdentity string `json:"recorded_identity,omitempty"`
+	CurrentIdentity  string `json:"current_identity,omitempty"`
 }
 
 // UpdateStatus is the JSON output view of an update check or run.
@@ -213,6 +224,17 @@ func PrintText(w io.Writer, result Result) {
 			}
 			if skill.Installed {
 				_, _ = fmt.Fprintf(w, " path=%s", skill.Path)
+			}
+			_, _ = fmt.Fprintln(w)
+		}
+	}
+
+	if len(result.Evidence) > 0 {
+		_, _ = fmt.Fprintln(w, "Evidence:")
+		for _, entry := range result.Evidence {
+			_, _ = fmt.Fprintf(w, "- %s: %s", entry.TaskID, entry.State)
+			if entry.Failure != "" {
+				_, _ = fmt.Fprintf(w, " (%s)", entry.Failure)
 			}
 			_, _ = fmt.Fprintln(w)
 		}

--- a/internal/repo/init.go
+++ b/internal/repo/init.go
@@ -29,6 +29,7 @@ type InitReport struct {
 
 var repoBootstrapFiles = []bootstrapFile{
 	{Source: "walden/constitution.md", Target: ".walden/constitution.md"},
+	{Source: "walden/gitignore", Target: ".walden/.gitignore"},
 	{Source: "walden/lessons.md", Target: ".walden/lessons.md"},
 	{Source: "github/pull_request_template.md", Target: ".github/pull_request_template.md"},
 	{Source: "github/workflows/validate-walden.yml", Target: ".github/workflows/validate-walden.yml"},

--- a/internal/repo/init_gitignore_test.go
+++ b/internal/repo/init_gitignore_test.go
@@ -1,0 +1,38 @@
+package repo
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInitWritesWaldenGitignore(t *testing.T) {
+	root := t.TempDir()
+
+	report, err := Init(root, "v0.8.0")
+	if err != nil {
+		t.Fatalf("Init returned error: %v", err)
+	}
+
+	created := false
+	for _, path := range report.CreatedFiles {
+		if path == ".walden/.gitignore" {
+			created = true
+		}
+	}
+	if !created {
+		t.Fatalf("Init did not report .walden/.gitignore as created: %+v", report)
+	}
+
+	content, err := os.ReadFile(filepath.Join(root, ".walden", ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .walden/.gitignore: %v", err)
+	}
+	if !strings.Contains(string(content), ".walden-doc-*") {
+		t.Fatalf("gitignore does not exclude staging artifacts:\n%s", content)
+	}
+	if strings.Contains(string(content), "\nevidence") {
+		t.Fatalf("gitignore excludes the evidence directory:\n%s", content)
+	}
+}

--- a/internal/spec/expect_output_test.go
+++ b/internal/spec/expect_output_test.go
@@ -1,0 +1,79 @@
+package spec
+
+import (
+	"strings"
+	"testing"
+)
+
+func expectOutputPlan(field string) string {
+	return `# Implementation Plan
+
+- [ ] 1. Objective
+  - [ ] 1.1 Step
+    - Requirements: ` + "`R1.AC1`" + `
+    - Design: Section A
+    - Verification:
+` + field
+}
+
+func TestExpectOutputParsingVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "bare content",
+			body: expectOutputPlan("      - command: [\"go\", \"test\", \"./...\"]\n        expect_output: ok  \n"),
+			want: "ok",
+		},
+		{
+			name: "quoted content stripped",
+			body: expectOutputPlan("      - command: [\"go\", \"test\", \"./...\"]\n        expect_output: \"PASS: TestAuth\"\n"),
+			want: "PASS: TestAuth",
+		},
+		{
+			name: "combined with expect_exit and covers",
+			body: expectOutputPlan("      - command: [\"go\", \"test\", \"./...\"]\n        expect_exit: 0\n        expect_output: ok\n        covers: [\"R1.AC1\"]\n"),
+			want: "ok",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree, err := ParseTaskTree(Document{Exists: true, Path: "tasks.md", Body: tc.body})
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			steps := tree.LeafTasks()[0].Proof.Steps
+			if len(steps) != 1 || steps[0].ExpectOutput == nil {
+				t.Fatalf("expect_output not parsed: %+v", steps)
+			}
+			if *steps[0].ExpectOutput != tc.want {
+				t.Fatalf("expect_output = %q, want %q", *steps[0].ExpectOutput, tc.want)
+			}
+		})
+	}
+}
+
+func TestExpectOutputParsingRejectsOrphanField(t *testing.T) {
+	body := expectOutputPlan("      expect_output: ok\n")
+	_, err := ParseTaskTree(Document{Exists: true, Path: "tasks.md", Body: body})
+	if err == nil {
+		t.Fatal("orphan expect_output accepted")
+	}
+}
+
+func TestExpectOutputParsingLeavesPlainStepsUntouched(t *testing.T) {
+	body := expectOutputPlan("      - command: [\"go\", \"test\", \"./...\"]\n")
+	tree, err := ParseTaskTree(Document{Exists: true, Path: "tasks.md", Body: body})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if tree.LeafTasks()[0].Proof.Steps[0].ExpectOutput != nil {
+		t.Fatal("plain step gained an unexpected expect_output")
+	}
+	if !strings.Contains(tree.LeafTasks()[0].Verification, "go") {
+		t.Fatal("verification display broken")
+	}
+}

--- a/internal/spec/task_fingerprint.go
+++ b/internal/spec/task_fingerprint.go
@@ -1,0 +1,24 @@
+package spec
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// TaskDefinitionFingerprint hashes the canonical definition of one task: id,
+// title, requirement references, design references, and verification text.
+// Checkbox state and sibling tasks never enter it, so execution progress and
+// unrelated plan edits leave the fingerprint unmoved while any change to
+// this task's own contract moves it.
+func TaskDefinitionFingerprint(task *Task) string {
+	fields := []string{
+		task.ID,
+		task.Title,
+		strings.Join(task.Requirements, ","),
+		strings.Join(task.DesignRefs, ","),
+		task.Verification,
+	}
+	sum := sha256.Sum256([]byte(strings.Join(fields, "\x00")))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/spec/task_fingerprint_test.go
+++ b/internal/spec/task_fingerprint_test.go
@@ -1,0 +1,70 @@
+package spec
+
+import (
+	"strings"
+	"testing"
+)
+
+const fingerprintPlan = `# Implementation Plan
+
+- [%s] 1. Objective
+  - [%s] 1.1 First step
+    - Requirements: ` + "`R1.AC1`" + `
+    - Design: Section A
+    - Verification:
+      - command: ["go", "test", "./..."]
+  - [ ] 1.2 Sibling step
+    - Requirements: ` + "`R2.AC1`" + `
+    - Design: Section B
+    - Verification:
+      - command: ["go", "vet", "./..."]
+`
+
+func parsePlanTask(t *testing.T, body, id string) *Task {
+	t.Helper()
+	tree, err := ParseTaskTree(Document{Exists: true, Path: "tasks.md", Body: body})
+	if err != nil {
+		t.Fatalf("parse plan: %v", err)
+	}
+	for _, task := range tree.LeafTasks() {
+		if task.ID == id {
+			return task
+		}
+	}
+	t.Fatalf("task %s not found", id)
+	return nil
+}
+
+func planWith(checkTop, checkLeaf string) string {
+	return strings.Replace(strings.Replace(fingerprintPlan, "%s", checkTop, 1), "%s", checkLeaf, 1)
+}
+
+func TestTaskDefinitionFingerprintIgnoresProgressAndSiblings(t *testing.T) {
+	unchecked := TaskDefinitionFingerprint(parsePlanTask(t, planWith(" ", " "), "1.1"))
+	checked := TaskDefinitionFingerprint(parsePlanTask(t, planWith(" ", "x"), "1.1"))
+	if unchecked != checked {
+		t.Fatal("checkbox state moved the task definition fingerprint")
+	}
+
+	siblingEdited := strings.Replace(planWith(" ", " "), "Sibling step", "Renamed sibling", 1)
+	afterSibling := TaskDefinitionFingerprint(parsePlanTask(t, siblingEdited, "1.1"))
+	if unchecked != afterSibling {
+		t.Fatal("a sibling edit moved the task definition fingerprint")
+	}
+}
+
+func TestTaskDefinitionFingerprintTracksTheContract(t *testing.T) {
+	base := TaskDefinitionFingerprint(parsePlanTask(t, planWith(" ", " "), "1.1"))
+
+	verificationEdited := strings.Replace(planWith(" ", " "), `["go", "test", "./..."]`, `["go", "test", "-count=2", "./..."]`, 1)
+	moved := TaskDefinitionFingerprint(parsePlanTask(t, verificationEdited, "1.1"))
+	if base == moved {
+		t.Fatal("a verification edit did not move the task definition fingerprint")
+	}
+
+	titleEdited := strings.Replace(planWith(" ", " "), "First step", "First step, renamed", 1)
+	movedTitle := TaskDefinitionFingerprint(parsePlanTask(t, titleEdited, "1.1"))
+	if base == movedTitle {
+		t.Fatal("a title edit did not move the task definition fingerprint")
+	}
+}

--- a/internal/spec/tasks.go
+++ b/internal/spec/tasks.go
@@ -13,6 +13,7 @@ var (
 	metadataLinePattern = regexp.MustCompile(`^ {4}- (Requirements|Design|Verification):(.*)$`)
 	commandStepPattern  = regexp.MustCompile(`^ {6}- (?:command|argv): (\[.+\])\s*$`)
 	expectExitPattern   = regexp.MustCompile(`^ {8}expect_exit: ([0-9]+)\s*$`)
+	expectOutputPattern = regexp.MustCompile(`^ {8}expect_output: (.+?)\s*$`)
 	coversPattern       = regexp.MustCompile(`^ {8}covers: (\[.+\])\s*$`)
 	backtickRefPattern  = regexp.MustCompile("`([^`]+)`")
 )
@@ -26,9 +27,10 @@ type VerificationSpec struct {
 // VerificationStep is one structured proof step executed without shell interpolation.
 // Uses the Kubernetes command pattern: command: ["executable", "arg1", "arg2"].
 type VerificationStep struct {
-	Argv       []string
-	ExpectExit *int
-	Covers     []string
+	Argv         []string
+	ExpectExit   *int
+	ExpectOutput *string
+	Covers       []string
 }
 
 // Empty reports whether the verification spec contains any executable proof.
@@ -125,6 +127,21 @@ func ParseTaskTree(document Document) (TaskTree, error) {
 					return TaskTree{}, fmt.Errorf("line %d: invalid expect_exit value: %w", index+1, err)
 				}
 				steps[len(steps)-1].ExpectExit = &exitCode
+				continue
+			}
+			if match := expectOutputPattern.FindStringSubmatch(line); match != nil {
+				steps := pendingVerificationTask.Proof.Steps
+				if len(steps) == 0 {
+					return TaskTree{}, fmt.Errorf("line %d: expect_output declared before any command step for task %q", index+1, pendingVerificationTask.ID)
+				}
+				expected := strings.TrimSpace(match[1])
+				if len(expected) >= 2 && strings.HasPrefix(expected, "\"") && strings.HasSuffix(expected, "\"") {
+					expected = expected[1 : len(expected)-1]
+				}
+				if expected == "" {
+					return TaskTree{}, fmt.Errorf("line %d: expect_output requires non-empty content for task %q", index+1, pendingVerificationTask.ID)
+				}
+				steps[len(steps)-1].ExpectOutput = &expected
 				continue
 			}
 			if match := coversPattern.FindStringSubmatch(line); match != nil {

--- a/internal/spec/write.go
+++ b/internal/spec/write.go
@@ -37,13 +37,13 @@ func SaveDocument(document Document) error {
 		builder.WriteString("\n")
 	}
 
-	return writeAtomically(document.Path, []byte(builder.String()))
+	return WriteFileAtomic(document.Path, []byte(builder.String()))
 }
 
-// writeAtomically stages the content in a temp file inside the target's
+// WriteFileAtomic stages the content in a temp file inside the target's
 // directory and renames it into place, so no failure path — interruption,
-// full disk, permission error — can leave the document truncated or lost.
-func writeAtomically(path string, content []byte) error {
+// full disk, permission error — can leave the target truncated or lost.
+func WriteFileAtomic(path string, content []byte) error {
 	staged, err := os.CreateTemp(filepath.Dir(path), ".walden-doc-*")
 	if err != nil {
 		return fmt.Errorf("stage document %s: %w", path, err)

--- a/internal/workflow/complete_task_evidence_test.go
+++ b/internal/workflow/complete_task_evidence_test.go
@@ -1,0 +1,180 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/evidence"
+	"github.com/andrearaponi/walden/internal/shell"
+	"github.com/andrearaponi/walden/internal/spec"
+	"github.com/andrearaponi/walden/internal/testutil"
+)
+
+// scriptedIdentityRunner answers the git invocations behind the code
+// identity with fixed responses.
+type scriptedIdentityRunner struct {
+	statusResponse shell.Response
+	lsTreeResponse shell.Response
+	fail           bool
+}
+
+func (r *scriptedIdentityRunner) Run(_ context.Context, _ string, args ...string) (shell.Response, error) {
+	if r.fail {
+		return shell.Response{}, errors.New("git unavailable")
+	}
+	if len(args) >= 3 && args[2] == "ls-tree" {
+		return r.lsTreeResponse, nil
+	}
+	return r.statusResponse, nil
+}
+
+func overrideIdentityRunner(t *testing.T, runner shell.Runner) {
+	t.Helper()
+	previous := identityRunner
+	identityRunner = runner
+	t.Cleanup(func() { identityRunner = previous })
+}
+
+func writeEvidenceFixture(t *testing.T, root string) {
+	t.Helper()
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+status: approved
+approved_at: 2026-03-21T14:00:00Z
+last_modified: 2026-03-21T14:00:00Z
+---
+
+# Requirements Document
+`)
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+status: approved
+approved_at: 2026-03-21T14:10:00Z
+last_modified: 2026-03-21T14:10:00Z
+source_requirements_approved_at: 2026-03-21T14:00:00Z
+---
+
+# Feature Design
+`)
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+status: approved
+approved_at: 2026-03-21T14:20:00Z
+last_modified: 2026-03-21T14:20:00Z
+source_design_approved_at: 2026-03-21T14:10:00Z
+---
+
+# Implementation Plan
+
+- [ ] 1. Build parser
+  - [ ] 1.1 Implement parser
+    - Requirements: `+"`R1`"+`
+    - Design: Task Store
+    - Verification:
+      - command: ["go", "test", "./internal/spec"]
+`)
+}
+
+func TestCompleteTaskEvidenceRecordsChainAndIdentity(t *testing.T) {
+	root := t.TempDir()
+	writeEvidenceFixture(t, root)
+	overrideIdentityRunner(t, &scriptedIdentityRunner{
+		statusResponse: shell.Response{ExitCode: 0},
+		lsTreeResponse: shell.Response{ExitCode: 0, Stdout: "100644 blob aaa\tmain.go\n"},
+	})
+
+	runner := testutil.NewFakeRunner(testutil.Response{Stdout: "ok", ExitCode: 0})
+	result, err := CompleteTask(context.Background(), root, "todo-app-demo", "1.1", runner)
+	if err != nil {
+		t.Fatalf("CompleteTask returned error: %v", err)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", result.Warnings)
+	}
+
+	ledger, err := evidence.Load(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("load evidence: %v", err)
+	}
+	record, exists := ledger.Tasks["1.1"]
+	if !exists {
+		t.Fatal("no evidence entry recorded for the completed task")
+	}
+
+	feature, err := spec.LoadFeature(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("load feature: %v", err)
+	}
+	if record.RequirementsFingerprint != feature.Requirements.Fields["approved_fingerprint"] || record.RequirementsFingerprint == "" {
+		t.Fatalf("requirements fingerprint not bound: %q", record.RequirementsFingerprint)
+	}
+	if record.DesignFingerprint != feature.Design.Fields["approved_fingerprint"] || record.DesignFingerprint == "" {
+		t.Fatalf("design fingerprint not bound: %q", record.DesignFingerprint)
+	}
+	if !strings.HasPrefix(record.CodeIdentity, "sha256:") {
+		t.Fatalf("code identity not recorded: %q", record.CodeIdentity)
+	}
+	if !strings.HasPrefix(record.TaskFingerprint, "sha256:") {
+		t.Fatalf("task fingerprint not recorded: %q", record.TaskFingerprint)
+	}
+	if record.Result != evidence.ResultPassed || len(record.Steps) != 1 {
+		t.Fatalf("record outcome = %q with %d steps", record.Result, len(record.Steps))
+	}
+}
+
+func TestCompleteTaskEvidenceSaveFailureLeavesCheckboxUntouched(t *testing.T) {
+	root := t.TempDir()
+	writeEvidenceFixture(t, root)
+	overrideIdentityRunner(t, &scriptedIdentityRunner{fail: true})
+
+	// A file where the evidence directory must go makes Save fail.
+	if err := os.WriteFile(filepath.Join(root, ".walden", "evidence"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed blocking file: %v", err)
+	}
+
+	runner := testutil.NewFakeRunner(testutil.Response{Stdout: "ok", ExitCode: 0})
+	_, err := CompleteTask(context.Background(), root, "todo-app-demo", "1.1", runner)
+	if err == nil {
+		t.Fatal("CompleteTask succeeded despite an unpersistable evidence record")
+	}
+	if !strings.Contains(err.Error(), "evidence") {
+		t.Fatalf("error %q does not name the evidence failure", err)
+	}
+
+	tree, err := spec.LoadTaskTree(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("load task tree: %v", err)
+	}
+	for _, task := range tree.LeafTasks() {
+		if task.Completed {
+			t.Fatalf("task %s checkbox mutated despite the evidence failure", task.ID)
+		}
+	}
+}
+
+func TestCompleteTaskEvidenceNoGitDegradesWithWarning(t *testing.T) {
+	root := t.TempDir()
+	writeEvidenceFixture(t, root)
+	overrideIdentityRunner(t, &scriptedIdentityRunner{fail: true})
+
+	runner := testutil.NewFakeRunner(testutil.Response{Stdout: "ok", ExitCode: 0})
+	result, err := CompleteTask(context.Background(), root, "todo-app-demo", "1.1", runner)
+	if err != nil {
+		t.Fatalf("CompleteTask returned error: %v", err)
+	}
+	if len(result.Warnings) != 1 || !strings.Contains(result.Warnings[0], "identity") {
+		t.Fatalf("expected an identity warning, got %v", result.Warnings)
+	}
+
+	ledger, err := evidence.Load(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("load evidence: %v", err)
+	}
+	if ledger.Tasks["1.1"].CodeIdentity != "" {
+		t.Fatalf("identity recorded despite git being unavailable: %q", ledger.Tasks["1.1"].CodeIdentity)
+	}
+	if ledger.Tasks["1.1"].Result != evidence.ResultPassed {
+		t.Fatal("completion did not stay successful without git")
+	}
+}

--- a/internal/workflow/execute_proof_test.go
+++ b/internal/workflow/execute_proof_test.go
@@ -1,0 +1,88 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/evidence"
+	"github.com/andrearaponi/walden/internal/spec"
+	"github.com/andrearaponi/walden/internal/testutil"
+)
+
+func expectOutputTask(expect string) ExecutableTask {
+	step := spec.VerificationStep{Argv: []string{"go", "test", "-run", "TestX", "./pkg/"}}
+	if expect != "" {
+		step.ExpectOutput = &expect
+	}
+	proof := spec.VerificationSpec{Steps: []spec.VerificationStep{step}}
+	return ExecutableTask{
+		ID:           "1.1",
+		Title:        "Step",
+		Verification: proof.Display(),
+		Proof:        proof,
+	}
+}
+
+func TestExecuteProofCapturesStepOutcomes(t *testing.T) {
+	runner := testutil.NewFakeRunner(testutil.Response{Stdout: "ok  \tpkg\t0.1s\n", ExitCode: 0})
+
+	results, display, err := executeProof(context.Background(), runner, expectOutputTask(""))
+	if err != nil {
+		t.Fatalf("executeProof returned error: %v", err)
+	}
+	if display == "" {
+		t.Fatal("proof display is empty")
+	}
+	if len(results) != 1 {
+		t.Fatalf("captured %d step outcomes, want 1", len(results))
+	}
+
+	step := results[0]
+	if strings.Join(step.Command, " ") != "go test -run TestX ./pkg/" {
+		t.Fatalf("recorded command = %v", step.Command)
+	}
+	if step.ExpectedExit != 0 || step.ActualExit != 0 {
+		t.Fatalf("recorded exits = %d/%d, want 0/0", step.ExpectedExit, step.ActualExit)
+	}
+	if step.OutputDigest != evidence.DigestOutput("ok  \tpkg\t0.1s\n") {
+		t.Fatalf("output digest mismatch: %s", step.OutputDigest)
+	}
+}
+
+func TestExecuteProofPassesWhenOutputContainsExpectation(t *testing.T) {
+	runner := testutil.NewFakeRunner(testutil.Response{Stdout: "ok  \tpkg\t0.1s\n", ExitCode: 0})
+
+	if _, _, err := executeProof(context.Background(), runner, expectOutputTask("ok  ")); err != nil {
+		t.Fatalf("expectation unexpectedly failed: %v", err)
+	}
+}
+
+func TestExecuteProofFailsVacuousRuns(t *testing.T) {
+	// `go test -run NoMatch` exits 0 while printing "no tests to run" — the
+	// vacuous pass expect_output exists to catch.
+	runner := testutil.NewFakeRunner(testutil.Response{Stdout: "ok  \tpkg\t0.1s [no tests to run]\n", ExitCode: 0})
+
+	_, _, err := executeProof(context.Background(), runner, expectOutputTask("--- PASS: TestX"))
+	if err == nil {
+		t.Fatal("vacuous proof passed despite the output expectation")
+	}
+	if !strings.Contains(err.Error(), "--- PASS: TestX") {
+		t.Fatalf("error %q does not name the expected content", err)
+	}
+}
+
+func TestExecuteProofStopsAtExitMismatchBeforeOutputCheck(t *testing.T) {
+	runner := testutil.NewFakeRunner(testutil.Response{Stderr: "build failed", ExitCode: 2})
+
+	results, _, err := executeProof(context.Background(), runner, expectOutputTask("ok"))
+	if err == nil {
+		t.Fatal("exit mismatch accepted")
+	}
+	if !strings.Contains(err.Error(), "exited with code 2") {
+		t.Fatalf("error %q does not report the exit mismatch", err)
+	}
+	if len(results) != 1 || results[0].ActualExit != 2 {
+		t.Fatalf("failing step outcome not captured: %+v", results)
+	}
+}

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -120,7 +120,7 @@ func evidenceWarnings(ctx context.Context, root string, feature spec.Feature) []
 
 	ledger, err := evidence.Load(root, feature.Name)
 	if err != nil {
-		return nil
+		return []string{fmt.Sprintf("evidence: ledger unreadable (%v) — remove %s and run `walden verify %s --all` to regenerate it", err, evidence.DocumentPath(root, feature.Name), feature.Name)}
 	}
 	identity, identityOK := evidence.Identity(ctx, identityRunner, root)
 	current := evidence.ChainFingerprints{

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/andrearaponi/walden/internal/evidence"
 	"github.com/andrearaponi/walden/internal/shell"
 	"github.com/andrearaponi/walden/internal/spec"
 )
@@ -38,6 +39,10 @@ type ExecutionReadiness struct {
 	// exhausted implementation plan: gates must fail commands, a finished
 	// plan must not.
 	GateBlocked bool
+	// EvidenceWarnings surface completed tasks whose evidence is not
+	// verified — the honest answer to "the plan is complete" after specs
+	// or code moved underneath it.
+	EvidenceWarnings []string
 }
 
 // TaskStartContext is the deterministic execution context returned when a task starts.
@@ -56,6 +61,7 @@ type TaskCompletionResult struct {
 	CompletedTasks []string
 	ProofCommand   string
 	NextAction     string
+	Warnings       []string
 }
 
 // BatchCompletionResult is the deterministic outcome of completing multiple runnable leaf tasks in order.
@@ -77,7 +83,62 @@ func LoadExecutionReadiness(root, featureName string) (ExecutionReadiness, error
 		return ExecutionReadiness{}, err
 	}
 
-	return ResolveExecutionReadiness(feature)
+	readiness, err := ResolveExecutionReadiness(feature)
+	if err != nil {
+		return ExecutionReadiness{}, err
+	}
+	if !readiness.GateBlocked {
+		readiness.EvidenceWarnings = evidenceWarnings(context.Background(), root, feature)
+	}
+	return readiness, nil
+}
+
+// evidenceWarnings derives the evidence states of completed tasks and
+// summarizes every non-verified one. Gate blockers already tell the chain
+// story, so this runs only on an unblocked chain.
+func evidenceWarnings(ctx context.Context, root string, feature spec.Feature) []string {
+	tree, err := spec.ParseTaskTree(feature.Tasks)
+	if err != nil {
+		return nil
+	}
+
+	leafs := []evidence.LeafTask{}
+	anyCompleted := false
+	for _, task := range tree.LeafTasks() {
+		if task.Completed {
+			anyCompleted = true
+		}
+		leafs = append(leafs, evidence.LeafTask{
+			ID:          task.ID,
+			Completed:   task.Completed,
+			Fingerprint: executableTaskFingerprint(toExecutableTask(task)),
+		})
+	}
+	if !anyCompleted {
+		return nil
+	}
+
+	ledger, err := evidence.Load(root, feature.Name)
+	if err != nil {
+		return nil
+	}
+	identity, identityOK := evidence.Identity(ctx, identityRunner, root)
+	current := evidence.ChainFingerprints{
+		Requirements: feature.Requirements.Fields["approved_fingerprint"],
+		Design:       feature.Design.Fields["approved_fingerprint"],
+	}
+
+	notVerified := []string{}
+	for _, derived := range evidence.Derive(ledger, current, identity, identityOK, leafs) {
+		if derived.State == evidence.StateVerified || derived.State == evidence.StatePending {
+			continue
+		}
+		notVerified = append(notVerified, fmt.Sprintf("%s (%s)", derived.TaskID, derived.State))
+	}
+	if len(notVerified) == 0 {
+		return nil
+	}
+	return []string{fmt.Sprintf("evidence: %d completed task(s) not verified — %s; run `walden verify %s`", len(notVerified), strings.Join(notVerified, ", "), feature.Name)}
 }
 
 // ResolveExecutionReadiness determines whether execution can start and which task is next.
@@ -241,6 +302,11 @@ func nextRunnableTask(tree spec.TaskTree) *ExecutableTask {
 	return nil
 }
 
+// identityRunner executes the read-only git invocations behind the code
+// identity. It is a seam so tests control identity outcomes without
+// consuming the proof runner's scripted responses.
+var identityRunner shell.Runner = shell.NewExecRunner()
+
 // CompleteTask runs the declared proof for a leaf task and marks it complete only if the proof succeeds.
 func CompleteTask(ctx context.Context, root, featureName, taskID string, runner shell.Runner) (TaskCompletionResult, error) {
 	if runner == nil {
@@ -252,30 +318,9 @@ func CompleteTask(ctx context.Context, root, featureName, taskID string, runner 
 		return TaskCompletionResult{}, err
 	}
 
-	proofCommands, proofCommand, err := resolveProofCommands(startContext.Task)
+	stepResults, proofCommand, err := executeProof(ctx, runner, startContext.Task)
 	if err != nil {
 		return TaskCompletionResult{}, err
-	}
-
-	for _, proofStep := range proofCommands {
-		response, err := runner.Run(ctx, proofStep.Name, proofStep.Args...)
-		if err != nil {
-			hint := ""
-			if strings.Contains(err.Error(), "executable file not found") {
-				hint = " (hint: shell operators require command: [\"sh\", \"-c\", \"...\"])"
-			}
-			return TaskCompletionResult{}, fmt.Errorf("verification failed for task %q: %w%s", startContext.Task.ID, err, hint)
-		}
-		if response.ExitCode != proofStep.ExpectExit {
-			detail := strings.TrimSpace(response.Stderr)
-			if detail == "" {
-				detail = strings.TrimSpace(response.Stdout)
-			}
-			if detail != "" {
-				return TaskCompletionResult{}, fmt.Errorf("verification failed for task %q: command %q exited with code %d (expected %d): %s", startContext.Task.ID, proofStep.Display, response.ExitCode, proofStep.ExpectExit, detail)
-			}
-			return TaskCompletionResult{}, fmt.Errorf("verification failed for task %q: command %q exited with code %d (expected %d)", startContext.Task.ID, proofStep.Display, response.ExitCode, proofStep.ExpectExit)
-		}
 	}
 
 	feature, err := spec.LoadFeature(root, featureName)
@@ -284,6 +329,33 @@ func CompleteTask(ctx context.Context, root, featureName, taskID string, runner 
 	}
 
 	completedAt := time.Now().UTC().Format("2006-01-02T15:04:05Z")
+
+	// Evidence is recorded before the checkbox moves: a completion the
+	// ledger cannot remember is a completion that did not happen.
+	identity, identityOK := evidence.Identity(ctx, identityRunner, root)
+	warnings := []string{}
+	if !identityOK {
+		warnings = append(warnings, "code identity unavailable (git not usable here); evidence recorded without it")
+	}
+
+	ledger, err := evidence.Load(root, feature.Name)
+	if err != nil {
+		return TaskCompletionResult{}, err
+	}
+	ledger.Feature = feature.Name
+	ledger.Tasks[startContext.Task.ID] = evidence.Record{
+		TaskFingerprint:         executableTaskFingerprint(startContext.Task),
+		RequirementsFingerprint: feature.Requirements.Fields["approved_fingerprint"],
+		DesignFingerprint:       feature.Design.Fields["approved_fingerprint"],
+		TasksFingerprint:        feature.Tasks.Fields["approved_fingerprint"],
+		CodeIdentity:            identity,
+		Steps:                   stepResults,
+		Result:                  evidence.ResultPassed,
+		VerifiedAt:              completedAt,
+	}
+	if err := evidence.Save(root, ledger); err != nil {
+		return TaskCompletionResult{}, fmt.Errorf("record evidence before completion: %w", err)
+	}
 	updatedTasks, completedTasks, err := spec.MarkTaskCompleteWithCascade(feature.Tasks, startContext.Task.ID, completedAt)
 	if err != nil {
 		return TaskCompletionResult{}, err
@@ -305,6 +377,7 @@ func CompleteTask(ctx context.Context, root, featureName, taskID string, runner 
 		CompletedTasks: completedTasks,
 		ProofCommand:   proofCommand,
 		NextAction:     readiness.NextAction,
+		Warnings:       warnings,
 	}, nil
 }
 
@@ -369,10 +442,11 @@ func CompleteAllTasks(ctx context.Context, root, featureName string, runner shel
 }
 
 type proofCommand struct {
-	Name       string
-	Args       []string
-	Display    string
-	ExpectExit int
+	Name         string
+	Args         []string
+	Display      string
+	ExpectExit   int
+	ExpectOutput string
 }
 
 func resolveProofCommands(task ExecutableTask) ([]proofCommand, string, error) {
@@ -386,11 +460,16 @@ func resolveProofCommands(task ExecutableTask) ([]proofCommand, string, error) {
 			if step.ExpectExit != nil {
 				expectExit = *step.ExpectExit
 			}
+			expectOutput := ""
+			if step.ExpectOutput != nil {
+				expectOutput = *step.ExpectOutput
+			}
 			commands = append(commands, proofCommand{
-				Name:       step.Argv[0],
-				Args:       append([]string(nil), step.Argv[1:]...),
-				Display:    formatCommandProofStep(step.Argv),
-				ExpectExit: expectExit,
+				Name:         step.Argv[0],
+				Args:         append([]string(nil), step.Argv[1:]...),
+				Display:      formatCommandProofStep(step.Argv),
+				ExpectExit:   expectExit,
+				ExpectOutput: expectOutput,
 			})
 		}
 		return commands, task.Verification, nil
@@ -401,6 +480,63 @@ func resolveProofCommands(task ExecutableTask) ([]proofCommand, string, error) {
 		return nil, "", err
 	}
 	return []proofCommand{{Name: name, Args: args, Display: display}}, display, nil
+}
+
+// executableTaskFingerprint bridges the execution view back to the spec
+// task-definition fingerprint.
+func executableTaskFingerprint(task ExecutableTask) string {
+	return spec.TaskDefinitionFingerprint(&spec.Task{
+		ID:           task.ID,
+		Title:        task.Title,
+		Requirements: task.Requirements,
+		DesignRefs:   task.DesignRefs,
+		Verification: task.Verification,
+	})
+}
+
+// executeProof runs every proof step in order, enforcing exit-code and
+// output expectations, and returns per-step outcomes for the evidence
+// record along with the human-readable proof command.
+func executeProof(ctx context.Context, runner shell.Runner, task ExecutableTask) ([]evidence.StepResult, string, error) {
+	proofCommands, display, err := resolveProofCommands(task)
+	if err != nil {
+		return nil, "", err
+	}
+
+	results := make([]evidence.StepResult, 0, len(proofCommands))
+	for _, proofStep := range proofCommands {
+		response, err := runner.Run(ctx, proofStep.Name, proofStep.Args...)
+		if err != nil {
+			hint := ""
+			if strings.Contains(err.Error(), "executable file not found") {
+				hint = " (hint: shell operators require command: [\"sh\", \"-c\", \"...\"])"
+			}
+			return results, display, fmt.Errorf("verification failed for task %q: %w%s", task.ID, err, hint)
+		}
+
+		combined := response.Stdout + response.Stderr
+		results = append(results, evidence.StepResult{
+			Command:      append([]string{proofStep.Name}, proofStep.Args...),
+			ExpectedExit: proofStep.ExpectExit,
+			ActualExit:   response.ExitCode,
+			OutputDigest: evidence.DigestOutput(combined),
+		})
+
+		if response.ExitCode != proofStep.ExpectExit {
+			detail := strings.TrimSpace(response.Stderr)
+			if detail == "" {
+				detail = strings.TrimSpace(response.Stdout)
+			}
+			if detail != "" {
+				return results, display, fmt.Errorf("verification failed for task %q: command %q exited with code %d (expected %d): %s", task.ID, proofStep.Display, response.ExitCode, proofStep.ExpectExit, detail)
+			}
+			return results, display, fmt.Errorf("verification failed for task %q: command %q exited with code %d (expected %d)", task.ID, proofStep.Display, response.ExitCode, proofStep.ExpectExit)
+		}
+		if proofStep.ExpectOutput != "" && !strings.Contains(combined, proofStep.ExpectOutput) {
+			return results, display, fmt.Errorf("verification failed for task %q: command %q output does not contain expected content %q", task.ID, proofStep.Display, proofStep.ExpectOutput)
+		}
+	}
+	return results, display, nil
 }
 
 func parseVerificationCommand(verification string) (string, []string, string, error) {

--- a/internal/workflow/readiness_evidence_test.go
+++ b/internal/workflow/readiness_evidence_test.go
@@ -1,0 +1,129 @@
+package workflow
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/evidence"
+	"github.com/andrearaponi/walden/internal/testutil"
+)
+
+func TestReadinessEvidenceSilentWhenVerified(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+
+	readiness, err := LoadExecutionReadiness(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("LoadExecutionReadiness: %v", err)
+	}
+	if len(readiness.EvidenceWarnings) != 0 {
+		t.Fatalf("verified plan raised warnings: %v", readiness.EvidenceWarnings)
+	}
+}
+
+func TestReadinessEvidenceWarnsOnStaleCode(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+
+	// The code moves under the completed plan.
+	overrideIdentityRunner(t, identityYielding("100644 blob bbb\tmain.go\n"))
+
+	readiness, err := LoadExecutionReadiness(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("LoadExecutionReadiness: %v", err)
+	}
+	if len(readiness.EvidenceWarnings) != 1 {
+		t.Fatalf("warnings = %v, want one evidence warning", readiness.EvidenceWarnings)
+	}
+	warning := readiness.EvidenceWarnings[0]
+	if !strings.Contains(warning, "stale-code") || !strings.Contains(warning, "walden verify") {
+		t.Fatalf("warning %q does not name stale-code and the remedy", warning)
+	}
+}
+
+func TestReadinessEvidenceWarnsOnStaleSpecAfterReapproval(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+
+	// The WDN-002 replay: requirements change and the chain is re-approved
+	// with fresh fingerprints, but no proof ever reruns.
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+status: approved
+approved_at: 2026-03-22T09:00:00Z
+last_modified: 2026-03-22T09:00:00Z
+---
+
+# Requirements Document
+
+## R2 A brand new requirement
+`)
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+status: approved
+approved_at: 2026-03-22T09:10:00Z
+last_modified: 2026-03-22T09:10:00Z
+source_requirements_approved_at: 2026-03-22T09:00:00Z
+---
+
+# Feature Design
+`)
+
+	readiness, err := LoadExecutionReadiness(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("LoadExecutionReadiness: %v", err)
+	}
+	if readiness.GateBlocked {
+		t.Fatalf("fixture chain unexpectedly blocked: %v", readiness.Blockers)
+	}
+	if len(readiness.EvidenceWarnings) != 1 || !strings.Contains(readiness.EvidenceWarnings[0], "stale-spec") {
+		t.Fatalf("warnings = %v, want a stale-spec warning", readiness.EvidenceWarnings)
+	}
+}
+
+func TestReadinessEvidenceFlagsUnrecordedLegacyCompletions(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+
+	// Complete without the ledger by checking the box the pre-ledger way:
+	// run one completion, then delete the evidence document.
+	completeBoth(t, root)
+	if err := removeEvidence(root, "todo-app-demo"); err != nil {
+		t.Fatalf("remove evidence: %v", err)
+	}
+
+	readiness, err := LoadExecutionReadiness(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("LoadExecutionReadiness: %v", err)
+	}
+	if len(readiness.EvidenceWarnings) != 1 || !strings.Contains(readiness.EvidenceWarnings[0], "unrecorded") {
+		t.Fatalf("warnings = %v, want an unrecorded warning", readiness.EvidenceWarnings)
+	}
+
+	// verify --all upgrades legacy completions into recorded evidence.
+	runner := testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+	)
+	if _, err := Verify(context.Background(), root, "todo-app-demo", true, false, runner); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	readiness, err = LoadExecutionReadiness(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("LoadExecutionReadiness after verify: %v", err)
+	}
+	if len(readiness.EvidenceWarnings) != 0 {
+		t.Fatalf("warnings persisted after verify --all: %v", readiness.EvidenceWarnings)
+	}
+}
+
+func removeEvidence(root, feature string) error {
+	return os.Remove(evidence.DocumentPath(root, feature))
+}

--- a/internal/workflow/readiness_evidence_test.go
+++ b/internal/workflow/readiness_evidence_test.go
@@ -127,3 +127,23 @@ func TestReadinessEvidenceFlagsUnrecordedLegacyCompletions(t *testing.T) {
 func removeEvidence(root, feature string) error {
 	return os.Remove(evidence.DocumentPath(root, feature))
 }
+
+func TestReadinessEvidenceWarnsOnUnreadableLedger(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+
+	path := evidence.DocumentPath(root, "todo-app-demo")
+	if err := os.WriteFile(path, []byte("{truncated"), 0o644); err != nil {
+		t.Fatalf("corrupt ledger: %v", err)
+	}
+
+	readiness, err := LoadExecutionReadiness(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("LoadExecutionReadiness: %v", err)
+	}
+	if len(readiness.EvidenceWarnings) != 1 || !strings.Contains(readiness.EvidenceWarnings[0], "unreadable") {
+		t.Fatalf("corrupt ledger did not surface a warning: %v", readiness.EvidenceWarnings)
+	}
+}

--- a/internal/workflow/verify.go
+++ b/internal/workflow/verify.go
@@ -60,6 +60,11 @@ func Verify(ctx context.Context, root, featureName string, all, check bool, runn
 	}
 	ledger.Feature = feature.Name
 
+	// Selection compares against the pre-run identity; the identity written
+	// into refreshed records is computed AFTER the proofs, because proofs
+	// that regenerate tracked artifacts (builds, go generate) change the
+	// tree they prove — the record must bind to the tree that exists once
+	// the proof has passed, exactly as CompleteTask does.
 	identity, _ := evidence.Identity(ctx, identityRunner, root)
 	current := evidence.ChainFingerprints{
 		Requirements: feature.Requirements.Fields["approved_fingerprint"],
@@ -67,6 +72,7 @@ func Verify(ctx context.Context, root, featureName string, all, check bool, runn
 	}
 
 	result := VerifyResult{Feature: feature.Name, Checked: check}
+	refreshed := map[string]evidence.Record{}
 	verifiedAt := time.Now().UTC().Format("2006-01-02T15:04:05Z")
 
 	for _, task := range tree.LeafTasks() {
@@ -93,7 +99,6 @@ func Verify(ctx context.Context, root, featureName string, all, check bool, runn
 			RequirementsFingerprint: current.Requirements,
 			DesignFingerprint:       current.Design,
 			TasksFingerprint:        feature.Tasks.Fields["approved_fingerprint"],
-			CodeIdentity:            identity,
 			Steps:                   stepResults,
 			Result:                  evidence.ResultPassed,
 			VerifiedAt:              verifiedAt,
@@ -109,12 +114,18 @@ func Verify(ctx context.Context, root, featureName string, all, check bool, runn
 		}
 
 		if !check {
-			ledger.Tasks[task.ID] = record
+			refreshed[task.ID] = record
 		}
 		result.Outcomes = append(result.Outcomes, outcome)
 	}
 
-	if !check && len(result.Outcomes) > 0 {
+	if !check && len(refreshed) > 0 {
+		// The post-proof identity: the tree the proofs actually left behind.
+		finalIdentity, _ := evidence.Identity(ctx, identityRunner, root)
+		for taskID, record := range refreshed {
+			record.CodeIdentity = finalIdentity
+			ledger.Tasks[taskID] = record
+		}
 		if err := evidence.Save(root, ledger); err != nil {
 			return VerifyResult{}, fmt.Errorf("persist refreshed evidence: %w", err)
 		}

--- a/internal/workflow/verify.go
+++ b/internal/workflow/verify.go
@@ -1,0 +1,171 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/andrearaponi/walden/internal/evidence"
+	"github.com/andrearaponi/walden/internal/shell"
+	"github.com/andrearaponi/walden/internal/spec"
+)
+
+// VerifyOutcome describes one task touched by a verify run.
+type VerifyOutcome struct {
+	TaskID  string
+	State   string
+	Passed  bool
+	Failure string
+}
+
+// VerifyResult is the outcome of re-proving a feature's completed tasks.
+type VerifyResult struct {
+	Feature  string
+	Outcomes []VerifyOutcome
+	Failed   []string
+	Checked  bool
+	Skipped  []string
+}
+
+// Verify re-executes the proofs of completed tasks against the current
+// working tree: non-verified ones by default, every one with all. Fresh
+// evidence replaces each task's entry unless check is set, which reports
+// without persisting anything. A failing proof never aborts the run — every
+// selected task is re-proven and failures are collected.
+func Verify(ctx context.Context, root, featureName string, all, check bool, runner shell.Runner) (VerifyResult, error) {
+	if runner == nil {
+		return VerifyResult{}, fmt.Errorf("proof runner is required")
+	}
+
+	readiness, err := LoadExecutionReadiness(root, featureName)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	if readiness.GateBlocked && len(readiness.Blockers) > 0 {
+		return VerifyResult{}, fmt.Errorf("%s", readiness.Blockers[0])
+	}
+
+	feature, err := spec.LoadFeature(root, featureName)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	tree, err := spec.ParseTaskTree(feature.Tasks)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+
+	ledger, err := evidence.Load(root, feature.Name)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	ledger.Feature = feature.Name
+
+	identity, _ := evidence.Identity(ctx, identityRunner, root)
+	current := evidence.ChainFingerprints{
+		Requirements: feature.Requirements.Fields["approved_fingerprint"],
+		Design:       feature.Design.Fields["approved_fingerprint"],
+	}
+
+	result := VerifyResult{Feature: feature.Name, Checked: check}
+	verifiedAt := time.Now().UTC().Format("2006-01-02T15:04:05Z")
+
+	for _, task := range tree.LeafTasks() {
+		if !task.Completed {
+			continue
+		}
+
+		executable := toExecutableTask(task)
+		fingerprint := executableTaskFingerprint(executable)
+
+		if !all {
+			derived := evidence.Derive(ledger, current, identity, identity != "", []evidence.LeafTask{
+				{ID: task.ID, Completed: true, Fingerprint: fingerprint},
+			})
+			if derived[0].State == evidence.StateVerified {
+				result.Skipped = append(result.Skipped, task.ID)
+				continue
+			}
+		}
+
+		stepResults, _, proofErr := executeProof(ctx, runner, executable)
+		record := evidence.Record{
+			TaskFingerprint:         fingerprint,
+			RequirementsFingerprint: current.Requirements,
+			DesignFingerprint:       current.Design,
+			TasksFingerprint:        feature.Tasks.Fields["approved_fingerprint"],
+			CodeIdentity:            identity,
+			Steps:                   stepResults,
+			Result:                  evidence.ResultPassed,
+			VerifiedAt:              verifiedAt,
+		}
+
+		outcome := VerifyOutcome{TaskID: task.ID, State: evidence.StateVerified, Passed: true}
+		if proofErr != nil {
+			record.Result = evidence.ResultFailed
+			outcome.State = evidence.StateFailed
+			outcome.Passed = false
+			outcome.Failure = proofErr.Error()
+			result.Failed = append(result.Failed, task.ID)
+		}
+
+		if !check {
+			ledger.Tasks[task.ID] = record
+		}
+		result.Outcomes = append(result.Outcomes, outcome)
+	}
+
+	if !check && len(result.Outcomes) > 0 {
+		if err := evidence.Save(root, ledger); err != nil {
+			return VerifyResult{}, fmt.Errorf("persist refreshed evidence: %w", err)
+		}
+	}
+	return result, nil
+}
+
+// toExecutableTask bridges a parsed task into the execution view.
+func toExecutableTask(task *spec.Task) ExecutableTask {
+	return ExecutableTask{
+		ID:           task.ID,
+		Title:        task.Title,
+		ParentID:     task.ParentID,
+		Completed:    task.Completed,
+		Level:        task.Level,
+		Requirements: append([]string(nil), task.Requirements...),
+		DesignRefs:   append([]string(nil), task.DesignRefs...),
+		Verification: task.Verification,
+		Proof:        task.Proof,
+	}
+}
+
+// EvidenceReport derives every leaf task's execution-evidence state for a
+// feature. It is a pure read: no gate, no writes, usable on any chain state.
+func EvidenceReport(ctx context.Context, root, featureName string) (string, []evidence.TaskEvidence, error) {
+	feature, err := spec.LoadFeature(root, featureName)
+	if err != nil {
+		return "", nil, err
+	}
+	tree, err := spec.ParseTaskTree(feature.Tasks)
+	if err != nil {
+		return "", nil, err
+	}
+
+	leafs := []evidence.LeafTask{}
+	for _, task := range tree.LeafTasks() {
+		leafs = append(leafs, evidence.LeafTask{
+			ID:          task.ID,
+			Completed:   task.Completed,
+			Fingerprint: executableTaskFingerprint(toExecutableTask(task)),
+		})
+	}
+
+	ledger, err := evidence.Load(root, feature.Name)
+	if err != nil {
+		return "", nil, err
+	}
+	identity, identityOK := evidence.Identity(ctx, identityRunner, root)
+	current := evidence.ChainFingerprints{
+		Requirements: feature.Requirements.Fields["approved_fingerprint"],
+		Design:       feature.Design.Fields["approved_fingerprint"],
+	}
+	return feature.Name, evidence.Derive(ledger, current, identity, identityOK, leafs), nil
+}

--- a/internal/workflow/verify.go
+++ b/internal/workflow/verify.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/andrearaponi/walden/internal/evidence"
@@ -25,6 +26,7 @@ type VerifyResult struct {
 	Failed   []string
 	Checked  bool
 	Skipped  []string
+	Pruned   []string
 }
 
 // Verify re-executes the proofs of completed tasks against the current
@@ -75,6 +77,17 @@ func Verify(ctx context.Context, root, featureName string, all, check bool, runn
 	refreshed := map[string]evidence.Record{}
 	verifiedAt := time.Now().UTC().Format("2006-01-02T15:04:05Z")
 
+	planIDs := map[string]bool{}
+	for _, task := range tree.LeafTasks() {
+		planIDs[task.ID] = true
+	}
+	for taskID := range ledger.Tasks {
+		if !planIDs[taskID] {
+			result.Pruned = append(result.Pruned, taskID)
+		}
+	}
+	sort.Strings(result.Pruned)
+
 	for _, task := range tree.LeafTasks() {
 		if !task.Completed {
 			continue
@@ -119,16 +132,25 @@ func Verify(ctx context.Context, root, featureName string, all, check bool, runn
 		result.Outcomes = append(result.Outcomes, outcome)
 	}
 
-	if !check && len(refreshed) > 0 {
+	if !check && (len(refreshed) > 0 || len(result.Pruned) > 0) {
 		// The post-proof identity: the tree the proofs actually left behind.
 		finalIdentity, _ := evidence.Identity(ctx, identityRunner, root)
 		for taskID, record := range refreshed {
 			record.CodeIdentity = finalIdentity
 			ledger.Tasks[taskID] = record
 		}
+		// The state map is a claim about the current plan: entries for task
+		// ids that left the plan are history, and history lives in git.
+		for _, taskID := range result.Pruned {
+			delete(ledger.Tasks, taskID)
+		}
 		if err := evidence.Save(root, ledger); err != nil {
 			return VerifyResult{}, fmt.Errorf("persist refreshed evidence: %w", err)
 		}
+	}
+	if check {
+		// Nothing is persisted in check mode; report what a real run would prune.
+		_ = check
 	}
 	return result, nil
 }

--- a/internal/workflow/verify_test.go
+++ b/internal/workflow/verify_test.go
@@ -2,6 +2,8 @@ package workflow
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"strings"
 	"testing"
@@ -227,5 +229,67 @@ func TestVerifyBlockedByStaleChain(t *testing.T) {
 	_, err := Verify(context.Background(), root, "todo-app-demo", false, false, testutil.NewFakeRunner())
 	if err == nil {
 		t.Fatal("Verify accepted a stale chain")
+	}
+}
+
+// sideEffectRunner passes every proof while mutating a tracked-visible file,
+// simulating build/generate proofs that regenerate artifacts.
+type sideEffectRunner struct {
+	root  string
+	inner shell.Runner
+}
+
+func (r *sideEffectRunner) Run(ctx context.Context, name string, args ...string) (shell.Response, error) {
+	_ = os.WriteFile(r.root+"/generated.txt", []byte(name+strings.Join(args, " ")), 0o644)
+	return shell.Response{Stdout: "ok", ExitCode: 0}, nil
+}
+
+// dynamicIdentityRunner derives porcelain output from the real filesystem so
+// the identity truly changes when a proof regenerates a file.
+type dynamicIdentityRunner struct{ root string }
+
+func (r *dynamicIdentityRunner) Run(_ context.Context, _ string, args ...string) (shell.Response, error) {
+	if len(args) >= 3 && args[2] == "ls-tree" {
+		return shell.Response{ExitCode: 0, Stdout: "100644 blob aaa\tmain.go\n"}, nil
+	}
+	if len(args) >= 3 && args[2] == "hash-object" {
+		content, err := os.ReadFile(r.root + "/" + args[len(args)-1])
+		if err != nil {
+			return shell.Response{ExitCode: 128, Stderr: err.Error()}, nil
+		}
+		return shell.Response{ExitCode: 0, Stdout: testDigest(content) + "\n"}, nil
+	}
+	// status: report generated.txt as untracked when it exists.
+	if _, err := os.Stat(r.root + "/generated.txt"); err == nil {
+		return shell.Response{ExitCode: 0, Stdout: "?? generated.txt\x00"}, nil
+	}
+	return shell.Response{ExitCode: 0}, nil
+}
+
+func testDigest(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+func TestVerifyRecordsPostProofIdentity(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, &dynamicIdentityRunner{root: root})
+	completeBoth(t, root)
+
+	// The proofs regenerate a tracked-visible artifact: the identity at the
+	// start of the run is not the identity of the tree the proofs leave.
+	if _, err := Verify(context.Background(), root, "todo-app-demo", true, false, &sideEffectRunner{root: root}); err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+
+	_, entries, err := EvidenceReport(context.Background(), root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("EvidenceReport: %v", err)
+	}
+	for _, entry := range entries {
+		if entry.State != evidence.StateVerified {
+			t.Fatalf("task %s = %s immediately after verify, want verified (identity recorded pre-proof?)", entry.TaskID, entry.State)
+		}
 	}
 }

--- a/internal/workflow/verify_test.go
+++ b/internal/workflow/verify_test.go
@@ -1,0 +1,231 @@
+package workflow
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/evidence"
+	"github.com/andrearaponi/walden/internal/shell"
+	"github.com/andrearaponi/walden/internal/testutil"
+)
+
+func writeVerifyFixture(t *testing.T, root string) {
+	t.Helper()
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "requirements.md", `---
+status: approved
+approved_at: 2026-03-21T14:00:00Z
+last_modified: 2026-03-21T14:00:00Z
+---
+
+# Requirements Document
+`)
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "design.md", `---
+status: approved
+approved_at: 2026-03-21T14:10:00Z
+last_modified: 2026-03-21T14:10:00Z
+source_requirements_approved_at: 2026-03-21T14:00:00Z
+---
+
+# Feature Design
+`)
+	writeFreshFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+status: approved
+approved_at: 2026-03-21T14:20:00Z
+last_modified: 2026-03-21T14:20:00Z
+source_design_approved_at: 2026-03-21T14:10:00Z
+---
+
+# Implementation Plan
+
+- [ ] 1. Build parser
+  - [ ] 1.1 Implement parser
+    - Requirements: `+"`R1`"+`
+    - Design: Task Store
+    - Verification:
+      - command: ["go", "test", "./internal/spec"]
+  - [ ] 1.2 Implement readiness
+    - Requirements: `+"`R1`"+`
+    - Design: Execution Service
+    - Verification:
+      - command: ["go", "test", "./internal/workflow"]
+`)
+}
+
+func identityYielding(listing string) shell.Runner {
+	return &scriptedIdentityRunner{
+		statusResponse: shell.Response{ExitCode: 0},
+		lsTreeResponse: shell.Response{ExitCode: 0, Stdout: listing},
+	}
+}
+
+// completeBoth completes both fixture tasks under the current identity runner.
+func completeBoth(t *testing.T, root string) {
+	t.Helper()
+	runner := testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+	)
+	if _, err := CompleteAllTasks(context.Background(), root, "todo-app-demo", runner); err != nil {
+		t.Fatalf("complete fixture tasks: %v", err)
+	}
+}
+
+func TestVerifyDefaultSkipsVerifiedTasks(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+
+	runner := testutil.NewFakeRunner()
+	result, err := Verify(context.Background(), root, "todo-app-demo", false, false, runner)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if len(runner.Calls()) != 0 {
+		t.Fatalf("verified tasks were re-executed: %v", runner.Calls())
+	}
+	if len(result.Skipped) != 2 || len(result.Outcomes) != 0 {
+		t.Fatalf("result = %+v, want both tasks skipped", result)
+	}
+}
+
+func TestVerifyRefreshesStaleCode(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+
+	// The code moves: identity changes, both tasks go stale-code.
+	overrideIdentityRunner(t, identityYielding("100644 blob bbb\tmain.go\n"))
+
+	runner := testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+	)
+	result, err := Verify(context.Background(), root, "todo-app-demo", false, false, runner)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if len(result.Outcomes) != 2 || len(result.Failed) != 0 {
+		t.Fatalf("result = %+v, want two passing re-executions", result)
+	}
+
+	ledger, err := evidence.Load(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("load evidence: %v", err)
+	}
+	for _, id := range []string{"1.1", "1.2"} {
+		if !strings.HasPrefix(ledger.Tasks[id].CodeIdentity, "sha256:") {
+			t.Fatalf("task %s identity not refreshed", id)
+		}
+	}
+
+	// A second default verify now has nothing to do.
+	idle := testutil.NewFakeRunner()
+	again, err := Verify(context.Background(), root, "todo-app-demo", false, false, idle)
+	if err != nil {
+		t.Fatalf("second Verify: %v", err)
+	}
+	if len(idle.Calls()) != 0 || len(again.Skipped) != 2 {
+		t.Fatalf("refresh did not restore verified: %+v", again)
+	}
+}
+
+func TestVerifyAllReexecutesVerifiedTasks(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+
+	runner := testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+	)
+	result, err := Verify(context.Background(), root, "todo-app-demo", true, false, runner)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if len(runner.Calls()) != 2 || len(result.Outcomes) != 2 {
+		t.Fatalf("--all did not re-execute everything: %+v", result)
+	}
+}
+
+func TestVerifyCheckPersistsNothing(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob bbb\tmain.go\n"))
+
+	before, err := os.ReadFile(evidence.DocumentPath(root, "todo-app-demo"))
+	if err != nil {
+		t.Fatalf("read ledger before: %v", err)
+	}
+
+	runner := testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+	)
+	result, err := Verify(context.Background(), root, "todo-app-demo", false, true, runner)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if !result.Checked || len(result.Outcomes) != 2 {
+		t.Fatalf("check mode outcome = %+v", result)
+	}
+
+	after, err := os.ReadFile(evidence.DocumentPath(root, "todo-app-demo"))
+	if err != nil {
+		t.Fatalf("read ledger after: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Fatal("check mode modified the evidence document")
+	}
+}
+
+func TestVerifyCollectsFailuresAcrossTasks(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob bbb\tmain.go\n"))
+
+	runner := testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stderr: "assertion blew up", ExitCode: 1},
+	)
+	result, err := Verify(context.Background(), root, "todo-app-demo", false, false, runner)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if len(result.Failed) != 1 || result.Failed[0] != "1.2" {
+		t.Fatalf("failed = %v, want [1.2]", result.Failed)
+	}
+
+	ledger, err := evidence.Load(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("load evidence: %v", err)
+	}
+	if ledger.Tasks["1.1"].Result != evidence.ResultPassed {
+		t.Fatal("passing task not refreshed as passed")
+	}
+	if ledger.Tasks["1.2"].Result != evidence.ResultFailed {
+		t.Fatal("failing task not recorded as failed")
+	}
+}
+
+func TestVerifyBlockedByStaleChain(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+
+	overrideFrontmatterField(t, root, "todo-app-demo", "requirements.md", "approved_fingerprint", "sha256:0000000000000000000000000000000000000000000000000000000000000000")
+
+	_, err := Verify(context.Background(), root, "todo-app-demo", false, false, testutil.NewFakeRunner())
+	if err == nil {
+		t.Fatal("Verify accepted a stale chain")
+	}
+}

--- a/internal/workflow/verify_test.go
+++ b/internal/workflow/verify_test.go
@@ -293,3 +293,49 @@ func TestVerifyRecordsPostProofIdentity(t *testing.T) {
 		}
 	}
 }
+
+func TestVerifyPrunesOrphanedEntries(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+	completeBoth(t, root)
+
+	ledger, err := evidence.Load(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("load ledger: %v", err)
+	}
+	orphan := ledger.Tasks["1.1"]
+	ledger.Tasks["9.9"] = orphan
+	if err := evidence.Save(root, ledger); err != nil {
+		t.Fatalf("seed orphan: %v", err)
+	}
+
+	// Check mode reports without touching the orphan.
+	checked, err := Verify(context.Background(), root, "todo-app-demo", false, true, testutil.NewFakeRunner())
+	if err != nil {
+		t.Fatalf("Verify --check: %v", err)
+	}
+	if len(checked.Pruned) != 1 || checked.Pruned[0] != "9.9" {
+		t.Fatalf("check mode pruned report = %v, want [9.9]", checked.Pruned)
+	}
+	after, _ := evidence.Load(root, "todo-app-demo")
+	if _, exists := after.Tasks["9.9"]; !exists {
+		t.Fatal("check mode removed the orphan")
+	}
+
+	// A real run prunes even when nothing needs re-proving.
+	result, err := Verify(context.Background(), root, "todo-app-demo", false, false, testutil.NewFakeRunner())
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if len(result.Pruned) != 1 || result.Pruned[0] != "9.9" {
+		t.Fatalf("pruned = %v, want [9.9]", result.Pruned)
+	}
+	final, _ := evidence.Load(root, "todo-app-demo")
+	if _, exists := final.Tasks["9.9"]; exists {
+		t.Fatal("orphan survived a persisting verify")
+	}
+	if len(final.Tasks) != 2 {
+		t.Fatalf("ledger holds %d entries, want the 2 plan tasks", len(final.Tasks))
+	}
+}

--- a/site/index.html
+++ b/site/index.html
@@ -85,8 +85,8 @@
         <span class="claim-hard">Walden enforces.</span>
       </p>
       <p class="claim-sub">
-        Blocking gates with exit codes — validation, proofs, freshness —
-        independent of any model&rsquo;s judgment.
+        Blocking gates with exit codes — validation, proofs, freshness,
+        execution evidence — independent of any model&rsquo;s judgment.
       </p>
     </section>
 
@@ -118,6 +118,7 @@
             <li>document freshness &amp; approval chains</li>
             <li>AC traceability — 100% coverage required</li>
             <li>a verification proof on every leaf task</li>
+            <li>execution evidence bound to the code — re-provable with <code>verify</code></li>
             <li>stale-document detection &amp; reconciliation</li>
           </ul>
           <p class="voice-foot">deterministic · the same answer every time</p>

--- a/skill/walden/SKILL.md
+++ b/skill/walden/SKILL.md
@@ -38,6 +38,8 @@ Walden is an open source spec-driven delivery kernel. It is not a complete enter
 - Use `walden review open <feature-name> --phase requirements|design|tasks` and `walden review approve <feature-name> --phase requirements|design|tasks` for deterministic review-state transitions.
 - Use `walden task status <feature-name> [--json]`, `walden task start <feature-name> [task-id] [--json]`, and `walden task complete <feature-name> <task-id> [--json]` for deterministic execution flow.
 - Use `walden task complete-all <feature-name> [--json]` to complete all runnable leaf tasks in order, stopping on first failure.
+- Use `walden verify <feature-name> [--all] [--check] [--json]` to re-execute completed tasks' proofs against the current code and refresh execution evidence; `--check` reports without persisting anything.
+- Use `walden evidence status <feature-name> [--json]` to inspect each task's derived evidence state: verified, stale-spec, stale-code, failed, unrecorded, or pending.
 - Use `walden reconcile <feature-name> [--json]` when approved upstream documents changed or the approval chain is stale.
 - Use `walden lesson log --feature <feature-name> --phase requirements|design|tasks|execute|release --trigger "<event>" --lesson "<pattern>" --guardrail "<rule>" [--json]` after meaningful corrections, failed validation, or execution surprises.
 - Use `walden version [--json]` to check the installed CLI version and schema version.
@@ -403,7 +405,8 @@ Task generation starts only from approved and non-stale design.
 - Reference acceptance criteria IDs (e.g., `R1.AC1`, `R1.AC2`) on every leaf task, not just parent requirement IDs.
 - Reference design sections on every leaf task.
 - Add a `Verification:` block on every leaf task using the structured `command` format (Kubernetes pattern). The CLI executes commands via `exec.Command` without a shell, so use JSON arrays for exact argument control.
-- Optionally add a `covers:` field on proof steps to declare which acceptance criteria the proof demonstrates. The CLI tracks proof reference coverage separately from task reference coverage and reports both in `walden validate --json`.
+- Optionally add a `covers:` field on proof steps to declare which acceptance criteria the proof demonstrates.
+- Prefer an `expect_output` assertion on test-running proof steps so a pattern that matches zero tests cannot pass vacuously. The CLI tracks proof reference coverage separately from task reference coverage and reports both in `walden validate --json`.
 - Approve with `walden review approve`, which records the upstream approval timestamp and fingerprint (`source_design_approved_at`, `source_design_fingerprint`).
 
 ### Verification Format
@@ -421,6 +424,14 @@ For negative assertions (command must fail), use `expect_exit`:
     - Verification:
       - command: ["grep", "-rq", "old_pattern", "."]
         expect_exit: 1
+```
+
+For output assertions — and to prevent vacuous passes where a test pattern matches zero tests — add `expect_output`:
+
+```markdown
+    - Verification:
+      - command: ["go", "test", "-run", "TestExample", "./pkg/example"]
+        expect_output: "--- PASS: TestExample"
 ```
 
 For shell operators (pipes, &&, globbing), use the Kubernetes shell pattern:
@@ -511,6 +522,8 @@ Execution is for approved specs only.
 - Write thorough tests for the task.
 - Run targeted tests for the changed area. Do not run the full suite unless the user asks.
 - Treat the task's `Verification:` line as mandatory proof. Prefer `walden task complete <feature-name> <task-id>` so proof execution and checkbox mutation remain deterministic.
+- Task completion records execution evidence in `.walden/evidence/<feature-name>.json`; commit it with the work — it is shared repository state, reviewed like the specs it proves.
+- If `walden task status` warns that completed tasks are no longer verified (stale-spec, stale-code, failed, unrecorded), run `walden verify <feature-name>` before building on top of them; never dismiss an evidence warning.
 - If a test fails or the proof is weaker than expected, stop and re-plan instead of hand-waving the result.
 - Before closing the execution step, report `Lesson Decision: none|logged`.
 - Stop after the requested task or batch and wait for review.
@@ -521,6 +534,7 @@ Execution is for approved specs only.
 - Update the earliest affected document.
 - Re-run the approval gate from that phase forward.
 - Prefer `walden reconcile <feature-name>` when upstream approval metadata or freshness is no longer valid.
+- After reconciliation and re-approval, run `walden verify <feature-name>`: completed tasks whose evidence went stale-spec must be re-proven against the updated contract, not assumed.
 - Log a lesson if the gap came from a missed pattern, missing guardrail, or design blind spot.
 - Do not silently rewrite approved requirements or design during implementation.
 

--- a/templates/embed_test.go
+++ b/templates/embed_test.go
@@ -12,6 +12,7 @@ func TestRepoFSExposesBootstrapTemplates(t *testing.T) {
 	// Paths are relative to the "repo" subtree, so the "repo/" prefix is gone.
 	want := []string{
 		"walden/constitution.md",
+		"walden/gitignore",
 		"walden/lessons.md",
 		"github/pull_request_template.md",
 		"github/workflows/validate-walden.yml",

--- a/templates/repo/walden/gitignore
+++ b/templates/repo/walden/gitignore
@@ -1,0 +1,4 @@
+# Transient Walden staging artifacts — never commit these.
+# Evidence documents (evidence/*.json) are deliberately NOT excluded:
+# they are shared repository state, reviewed like the specs they prove.
+.walden-doc-*


### PR DESCRIPTION
## Summary

Walden's certainty chain stops at the approved plan: a checked task proves only that a proof once passed. The external review reproduced the gap twice (WDN-001: delete the implementation, the plan stays "complete"; WDN-002: change the spec, reconcile, re-approve — checkboxes revive with no proof rerun) and concluded: *not yet a complete proof that the current implementation satisfies the current specification*. This PR retires that sentence.

Every task completion now records durable evidence in `.walden/evidence/<feature>.json`, binding the proof's steps (argv, exit codes, output digests) to the approved chain fingerprints and to a deterministic **code identity** of the working tree. States are **derived at read time, never stored**: `verified`, `stale-spec`, `stale-code`, `failed`, `unrecorded`, `pending`. `walden verify` re-proves the current code on demand (`--check` for CI, writing nothing); `walden evidence status` reports (always exit 0); `task status` warns when completed work is no longer verified. `expect_output` closes the vacuous-proof hole. `repo init` writes `.walden/.gitignore`. The checkbox stays the human projection — the ledger is the authoritative execution state, committed and reviewed like the specs it proves.

## Design pillars

- **State map, not a log** — one JSON document per feature keyed by task id (schema `v1alpha1`, refused when unknown); history comes free from `git log`; verify prunes entries for task ids that left the plan.
- **Derivation over mutation** — `reconcile` never touches evidence; stale-spec falls out of comparing recorded fingerprints (requirements, design, task-definition — sibling edits never stale a task) against the current chain.
- **The serpent constraint** — the identity is a uniform path→(mode, blob) map: `git ls-tree` seeded, dirty paths overlaid via batched `git hash-object`, symlinks hashed as their target string, modes canonicalized to git's trio, `.walden/` excluded at every layer. Committing the evidence never invalidates it; untracked→committed transitions are invisible; a chmod is a code change. Identity is recorded **post-proof** (build/generate proofs change the tree they prove). No git degrades to a warned, absent identity.
- **Fail-closed, report-not-gate** — evidence writes precede checkbox mutation; corruption warns with the recovery path; staleness is a warning everywhere and an exit code only where you ask for proof (`verify`).
- **Concurrency contained by construction** — whole-document atomic writes: parallel walden processes can never corrupt the ledger; at worst a record is lost to the last writer, surfaces as `unrecorded`, and one `verify` regenerates it.

## Battle-tested before merge

Two dogfooded real projects and three eval rounds; every finding fixed on this branch with a regression test:

- 6-scenario battery + Tier-1 (merge conflicts + recovery, corrupted/unknown-schema ledger, orphaned entries, mv/chmod/symlink edges) + pre-release round (concurrency race observed and contained, pathological filenames, legacy proofs).
- **On real repos** (a todo app + a 26-feature corporate portfolio + its Go sibling): caught a main package never committed (unanchored gitignore), a lockfile that breaks every fresh clone, a placeholder frontend committed over the proven build, one flaky proof (healed by default `verify`) — **zero false positives across four repositories**.
- Kernel bugs found by the evals and fixed here: pre-proof identity in verify, symlink representation split, silent unknown-schema acceptance, fail-open on corrupt ledgers, one-spawn-per-file hashing (3.1s → 438ms on 15k files/400 dirty).
- The battery is promoted to compiled e2e (`internal/e2e`, real git, driven through `app.Run`) running in CI: serpent transitions, WDN-001/002 replays, corruption recovery, orphan pruning, legacy proofs.

## Compatibility

- Envelope changes additive within `v0beta1`; spec-document fingerprints and schema untouched — no existing approved chain goes stale.
- Pre-ledger completions report `unrecorded`; one `walden verify --all` migrates a feature (verified on a 26-feature portfolio).
- `tasks.md` grammar additive only (`expect_output` optional); one walden version per repo recommended while the evidence schema is alpha.
- A code-only bugfix still needs no spec ceremony: evidence goes stale-code, one `verify` proves the ACs still hold — the no-ceremony lane, now watched instead of blind.

## Deliberately deferred

`release check` (aggregate gate), `waived`, multi-root identity for cross-repo proofs, rework-origin enrichment — the moat is the sharpness of the derivation model, not feature count.

## Process

Built through Walden's own gated workflow: 7 requirements / 30 EARS ACs, 100% task and proof reference coverage, 13 tasks closed through `walden task complete`, three mid-execution design amendments handled with reconcile + re-approval (identity representation, mode awareness, concurrency semantics), five lessons logged. Docs, site, and the shipped demo carry the new positioning.