### PR TITLE
feat: release check — one deterministic releasability verdict per repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ walden lesson log --feature user-auth --phase execute \
 | `task complete-all <feature> [--json]` | Complete all runnable tasks in order, stop on first failure |
 | `verify <feature> [--all] [--check] [--json]` | Re-prove completed tasks against the current code and refresh evidence |
 | `evidence status <feature> [--json]` | Report each task's derived execution-evidence state |
+| `release check [<feature>] [--strict] [--json]` | Certify the repository (or one feature) as releasable |
 | `reconcile <feature> [--json]` | Repair stale approval chains after upstream edits |
 | `lesson log [--json]` | Append a lesson to `.walden/lessons.md` |
 | `version [--json]` | Print build version and schema version |
@@ -369,6 +370,36 @@ walden verify <feature> --check  # report only — writes nothing (CI-friendly)
 
 `walden evidence status <feature>` reports the derived states without running anything (always exit 0). Evidence writes replace the whole document atomically: concurrent walden processes can never corrupt the ledger — at worst a record is lost to the last writer, surfaces as `unrecorded`, and `walden verify` regenerates it. `walden task status` warns when completed tasks are no longer verified — a spec change or code change is visible as staleness instead of hiding behind a checked box. Timestamps in evidence records are human context only: every verdict depends exclusively on content identities.
 
+## Release Certification
+
+Nobody releases a task — you release a repository. `walden release check` answers "is this releasable, right now?" with one deterministic exit code, composing the guarantees the kernel already enforces. It executes no proofs and writes nothing: `verify` produces evidence, `release check` judges it — which keeps certification at milliseconds and safe to run on untrusted checkouts.
+
+```bash
+walden release check             # certify every feature under .walden/specs/
+walden release check <feature>   # certify one feature
+walden release check --strict    # planned-but-unexecuted tasks block too
+walden release check --json      # machine-readable verdict for pipelines
+```
+
+| Criterion | Blocks when |
+| --- | --- |
+| `chain` | Any document is unapproved or stale |
+| `validation` | Full-spec validation fails |
+| `decisions` | An approved document carries an unresolved `[decision:]` marker |
+| `evidence` | A completed task is not `verified` |
+| `worktree` | Uncommitted changes outside `.walden/` |
+
+Planned-but-unexecuted tasks never block — the plan is a promise, not a debt (`--strict` opts into plans-complete). Uncommitted code has no bypass flag: what you certify is exactly what you tag. Dirty `.walden/` only warns, because a freshly refreshed ledger legitimately precedes its own commit. Every blocker names its remedy, so a failed certification is a work list, not just a verdict.
+
+The CI recipe composes production and judgment:
+
+```bash
+walden verify <feature>          # re-prove execution on the current tree
+walden release check --json      # certify; gate the pipeline on the exit code
+```
+
+Certification is not release: no tags, no changelogs, no publishing — that stays with the orchestrator. The gate's criteria are a public contract: once your pipeline gates on them, changes to their semantics are breaking changes.
+
 ## EARS
 
 Walden uses the Easy Approach to Requirements Syntax (EARS) for all acceptance criteria. EARS eliminates ambiguity, vagueness, and complexity by constraining requirements to six well-defined forms.
@@ -399,7 +430,7 @@ Each acceptance criterion gets a stable ID (e.g., `R1.AC1`) and uses exactly one
 | Task completion bound to the current code (evidence + code identity) | Yes | - |
 | Completed-task re-verification (`walden verify`) | Yes | - |
 | Vacuous-proof rejection (`expect_output`) | Yes | Opt-in per step |
-| Aggregate release gate | - | `release check` (planned) |
+| Aggregate release gate (`walden release check`) | Yes | - |
 
 ## Constitution
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 This is the public roadmap for Walden. It distinguishes committed open source work from exploratory and enterprise-only work.
 
-## Current Release: v0.8.x
+## Current Release: v0.9.x
 
 The open source core today includes:
 
@@ -13,6 +13,7 @@ The open source core today includes:
 - One-liner installer consuming checksum-verified release binaries
 - Self-update from GitHub releases (`walden update`) with fail-closed verification, rollback, and skill re-sync
 - Execution evidence ledger: task completions bound to spec fingerprints and a code identity, derived states, `walden verify` re-verification, `expect_output` proof assertions
+- Aggregate release gate (`walden release check`): one deterministic releasability verdict per repository — chain freshness, full-spec validation, decision-marker lint, evidence states, clean-worktree policy — judging only, executing nothing
 - Documentation pack (concepts, workflow, boundaries)
 - Example project with shell-safe verification, validated in CI as a compatibility fixture
 - Repository bootstrap and feature scaffolding templates (generated CI pinned to the generating version)
@@ -27,7 +28,7 @@ These improvements are planned for the open source core:
 - **Skill refinement** — tighter CLI delegation, fewer redundant instructions, better example conversations.
 - **Additional examples** — backend service demo, multi-feature workflow example.
 - **CI integration patterns** — documented patterns for using Walden validation in CI pipelines.
-- **Release check** — an aggregate gate composing `verify` across a feature (or repository) for release certification.
+- **Multi-root identity** — code identity spanning multiple repositories, unblocking cross-repo proofs and multi-repo certification.
 
 ## Medium-Term (Enterprise, Exploratory)
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -168,7 +168,7 @@ All `--json` commands return a versioned envelope:
 }
 ```
 
-## 6. Verify
+## 8. Verify
 
 Execution leaves evidence behind: every completed task's proof is recorded in `.walden/evidence/<feature>.json`, bound to the approved chain and to a code identity of the working tree. When the code or the specs move, `walden task status` warns that completed tasks are no longer verified.
 
@@ -180,3 +180,22 @@ walden verify <feature> --check    # CI mode: report only, write nothing
 ```
 
 A code-only bugfix needs no spec ceremony: the evidence goes `stale-code`, and one `verify` proves the acceptance criteria still hold — or names the task whose proof broke.
+
+## 9. Certify
+
+`walden release check` folds everything above into one deterministic verdict per feature — approved fresh chain, full-spec validation, no unresolved `[decision:]` markers in approved documents, execution evidence verified — plus one repository-level criterion: a clean worktree outside `.walden/`. Exit zero iff no blocker exists. It executes no proofs and writes nothing: verify produces evidence, release check judges it.
+
+```bash
+walden release check               # certify every feature
+walden release check <feature>     # certify one feature
+walden release check --strict      # planned-but-unexecuted tasks block too
+```
+
+The CI recipe composes the two:
+
+```bash
+walden verify <feature>            # re-prove execution on the current tree
+walden release check --json        # certify; gate the pipeline on the exit code
+```
+
+Planned work never blocks a release (`--strict` opts into plans-complete). Uncommitted code outside `.walden/` always blocks with no bypass flag — what you certify is what you tag — while dirty `.walden/` only warns, since a refreshed ledger legitimately precedes its own commit. Every blocker names its remedy.

--- a/internal/app/json_contract_test.go
+++ b/internal/app/json_contract_test.go
@@ -155,6 +155,11 @@ func TestJSONErrorContract(t *testing.T) {
 			args:        []string{"evidence", "status", "!!!", "--json"},
 			wantCommand: "evidence-status",
 		},
+		{
+			name:        "release check with invalid feature name",
+			args:        []string{"release", "check", "!!!", "--json"},
+			wantCommand: "release-check",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -1,0 +1,136 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/andrearaponi/walden/internal/output"
+	"github.com/andrearaponi/walden/internal/release"
+)
+
+func runRelease(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) > 0 && args[0] == "check" {
+		return runReleaseCheck(args[1:], stdout, stderr)
+	}
+
+	_, _ = fmt.Fprintf(stderr, "unknown command: release %s\n\n", strings.Join(args, " "))
+	printUsage(stderr)
+	return 1
+}
+
+func runReleaseCheck(args []string, stdout io.Writer, stderr io.Writer) int {
+	// --json is resolved first so even flag errors honor the envelope contract.
+	jsonMode := false
+	for _, arg := range args {
+		if arg == "--json" {
+			jsonMode = true
+		}
+	}
+
+	strict := false
+	positional := make([]string, 0, len(args))
+	for _, arg := range args {
+		switch arg {
+		case "--json":
+		case "--strict":
+			strict = true
+		default:
+			if strings.HasPrefix(arg, "--") {
+				// Certification has no bypasses by design (R3.AC2): every
+				// unrecognized flag is rejected, never ignored.
+				return emitResult("release-check", errorResult(fmt.Errorf("unknown flag %s: release check accepts only --strict and --json", arg)), jsonMode, stdout, stderr)
+			}
+			positional = append(positional, arg)
+		}
+	}
+
+	if len(positional) > 1 {
+		return emitResult("release-check", errorResult(errors.New("release check takes at most one feature name")), jsonMode, stdout, stderr)
+	}
+	featureName := ""
+	if len(positional) == 1 {
+		featureName = positional[0]
+	}
+
+	root, err := os.Getwd()
+	if err != nil {
+		return emitResult("release-check", errorResult(fmt.Errorf("resolve working directory: %w", err)), jsonMode, stdout, stderr)
+	}
+
+	report, err := release.ReleaseCheck(context.Background(), root, featureName, strict)
+	if err != nil {
+		return emitResult("release-check", errorResult(err), jsonMode, stdout, stderr)
+	}
+
+	result := releaseCheckResult(report)
+	if jsonMode {
+		return emitResult("release-check", result, jsonMode, stdout, stderr)
+	}
+	if result.ExitCode != 0 {
+		// A failed certification is a work list, not an invocation error:
+		// render the full report, mirroring validate's convention.
+		output.PrintText(stderr, result)
+		return result.ExitCode
+	}
+	output.PrintText(stdout, result)
+	return 0
+}
+
+func releaseCheckResult(report release.ReleaseReport) output.Result {
+	status := &output.ReleaseStatus{
+		Releasable: report.Releasable(),
+		Strict:     report.Strict,
+		Worktree: output.ReleaseWorktree{
+			Blockers:    append([]string(nil), report.WorktreeBlockers...),
+			WaldenDirty: append([]string(nil), report.WaldenDirty...),
+			GitSkipped:  report.GitSkipped,
+		},
+	}
+
+	result := output.Result{ExitCode: 0}
+	pendingTotal := 0
+	for _, feature := range report.Features {
+		view := output.ReleaseFeature{
+			Feature: feature.Feature,
+			Pending: append([]string(nil), feature.Pending...),
+		}
+		pendingTotal += len(feature.Pending)
+		for _, criterion := range feature.Criteria {
+			view.Criteria = append(view.Criteria, output.ReleaseCriterion{
+				Name:     criterion.Name,
+				Passed:   criterion.Passed,
+				Blockers: append([]string(nil), criterion.Blockers...),
+			})
+			for _, blocker := range criterion.Blockers {
+				result.Blockers = append(result.Blockers, fmt.Sprintf("%s: %s", feature.Feature, blocker))
+			}
+		}
+		status.Features = append(status.Features, view)
+	}
+	result.Blockers = append(result.Blockers, report.WorktreeBlockers...)
+	result.Release = status
+
+	for _, path := range report.WaldenDirty {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("uncommitted under .walden/ (not blocking): %s", path))
+	}
+	if report.GitSkipped {
+		result.Warnings = append(result.Warnings, "worktree criterion skipped: no usable git repository")
+	}
+
+	if report.Releasable() {
+		result.Summary = fmt.Sprintf("RELEASABLE — %d feature(s) certified", len(report.Features))
+		if pendingTotal > 0 {
+			result.Summary += fmt.Sprintf(", %d task(s) still planned", pendingTotal)
+		}
+		return result
+	}
+
+	result.Summary = fmt.Sprintf("NOT RELEASABLE — %d blocker(s)", report.BlockerCount())
+	result.NextAction = "Resolve the blockers above (each names its remedy) and rerun walden release check"
+	result.ExitCode = 1
+	return result
+}

--- a/internal/app/release_check_command_test.go
+++ b/internal/app/release_check_command_test.go
@@ -1,0 +1,326 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/output"
+	"github.com/andrearaponi/walden/internal/testutil"
+)
+
+const releasableRequirements = `---
+status: draft
+approved_at:
+last_modified: 2026-07-11T13:00:00Z
+approved_fingerprint:
+---
+
+# Requirements Document
+
+## Introduction
+
+Gate fixture.
+
+## Requirements
+
+### R1 Markers
+
+**User Story:** As a tester, I want markers, so that the gate has proofs to judge.
+
+#### Acceptance Criteria
+
+1. ` + "`R1.AC1`" + ` WHEN the first proof runs, the system SHALL succeed.
+2. ` + "`R1.AC2`" + ` WHEN the second proof runs, the system SHALL succeed.
+`
+
+const releasableDesign = `---
+status: draft
+approved_at:
+last_modified: 2026-07-11T13:00:00Z
+approved_fingerprint:
+source_requirements_approved_at:
+source_requirements_fingerprint:
+---
+
+# Feature Design
+
+## Overview
+
+Two trivially provable markers.
+
+## Architecture
+
+One shell proof per task.
+
+## Options Considered
+
+### Option A
+
+- Summary: shell proofs.
+- Why chosen: trivial.
+
+### Option B
+
+- Summary: none.
+- Why rejected: n/a.
+
+## Simplicity And Elegance Review
+
+- Simplest viable shape: two commands.
+- Coupling check: none.
+- Future-proofing: none.
+
+## Failure Modes And Tradeoffs
+
+- Failure mode: none.
+- Mitigation: none.
+- Tradeoff: none.
+
+## Testing Strategy
+
+Shell exit codes.
+
+## Verification Plan
+
+- Requirement proof: shell exits.
+- Test evidence: exit codes.
+
+## Requirement Coverage
+
+| Requirement | Covered By |
+| --- | --- |
+| ` + "`R1`" + ` | markers |
+`
+
+const releasableTasks = `---
+status: draft
+approved_at:
+last_modified: 2026-07-11T13:00:00Z
+approved_fingerprint:
+source_design_approved_at:
+source_design_fingerprint:
+---
+
+# Implementation Plan
+
+- [ ] 1. Markers
+  - [ ] 1.1 First marker
+    - Requirements: ` + "`R1.AC1`" + `
+    - Design: Overview
+    - Verification:
+      - command: ["sh", "-c", "true"]
+        covers: ["R1.AC1"]
+  - [ ] 1.2 Second marker
+    - Requirements: ` + "`R1.AC2`" + `
+    - Design: Overview
+    - Verification:
+      - command: ["sh", "-c", "true"]
+        covers: ["R1.AC2"]
+`
+
+// setupReleasableFeature writes a fully certifiable feature in a temp cwd and
+// approves its chain through the CLI. Task completion is left to each test.
+func setupReleasableFeature(t *testing.T, name string) string {
+	t.Helper()
+	root := chdirContract(t)
+	addReleasableFeature(t, root, name)
+	return root
+}
+
+func addReleasableFeature(t *testing.T, root, name string) {
+	t.Helper()
+	writeStatusFeatureFile(t, root, name, "requirements.md", releasableRequirements)
+	writeStatusFeatureFile(t, root, name, "design.md", releasableDesign)
+	writeStatusFeatureFile(t, root, name, "tasks.md", releasableTasks)
+
+	var stdout, stderr bytes.Buffer
+	for _, phase := range []string{"requirements", "design", "tasks"} {
+		if code := Run([]string{"review", "open", name, "--phase", phase}, &stdout, &stderr); code != 0 {
+			t.Fatalf("review open %s failed: %s", phase, stderr.String())
+		}
+		if code := Run([]string{"review", "approve", name, "--phase", phase}, &stdout, &stderr); code != 0 {
+			t.Fatalf("review approve %s failed: %s", phase, stderr.String())
+		}
+	}
+}
+
+func completeReleasableFeature(t *testing.T, name string) {
+	t.Helper()
+	overrideCommandRunner(t, testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+	))
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"task", "complete-all", name}, &stdout, &stderr); code != 0 {
+		t.Fatalf("task complete-all failed: %s", stderr.String())
+	}
+}
+
+func decodeReleaseEnvelope(t *testing.T, stdout *bytes.Buffer) output.Envelope {
+	t.Helper()
+	var envelope output.Envelope
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("stdout is not a JSON envelope: %v (%q)", err, stdout.String())
+	}
+	if envelope.Command != "release-check" {
+		t.Fatalf("command = %q, want release-check", envelope.Command)
+	}
+	return envelope
+}
+
+func TestRunReleaseCheckReleasableJSON(t *testing.T) {
+	setupReleasableFeature(t, "gate-demo")
+	completeReleasableFeature(t, "gate-demo")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"release", "check", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stdout %s, stderr %s)", code, stdout.String(), stderr.String())
+	}
+
+	envelope := decodeReleaseEnvelope(t, &stdout)
+	if !envelope.OK || !strings.Contains(envelope.Result.Summary, "RELEASABLE") {
+		t.Fatalf("green run not marked releasable: %+v", envelope.Result)
+	}
+	releaseBlock := envelope.Result.Release
+	if releaseBlock == nil || !releaseBlock.Releasable || releaseBlock.Strict {
+		t.Fatalf("release block wrong: %+v", releaseBlock)
+	}
+	if len(releaseBlock.Features) != 1 || len(releaseBlock.Features[0].Criteria) != 4 {
+		t.Fatalf("expected 1 feature with 4 criteria: %+v", releaseBlock.Features)
+	}
+	// chdirContract roots are not git repositories: the worktree criterion
+	// must report itself skipped rather than inventing a verdict.
+	if !releaseBlock.Worktree.GitSkipped {
+		t.Fatalf("worktree.git_skipped = false in a git-less root: %+v", releaseBlock.Worktree)
+	}
+}
+
+func TestRunReleaseCheckNotReleasableTextReport(t *testing.T) {
+	root := chdirContract(t)
+	// Approved chain, but the design misses required sections: full-spec
+	// validation blocks certification.
+	writeStatusFeatureFile(t, root, "gate-demo", "requirements.md", releasableRequirements)
+	writeStatusFeatureFile(t, root, "gate-demo", "design.md", `---
+status: draft
+approved_at:
+last_modified: 2026-07-11T13:00:00Z
+approved_fingerprint:
+source_requirements_approved_at:
+source_requirements_fingerprint:
+---
+
+# Feature Design
+
+## Overview
+
+Bare.
+
+## Requirement Coverage
+
+| Requirement | Covered By |
+| --- | --- |
+| `+"`R1`"+` | markers |
+`)
+	writeStatusFeatureFile(t, root, "gate-demo", "tasks.md", releasableTasks)
+	var buffer bytes.Buffer
+	for _, phase := range []string{"requirements", "design", "tasks"} {
+		if code := Run([]string{"review", "open", "gate-demo", "--phase", phase}, &buffer, &buffer); code != 0 {
+			t.Fatalf("review open %s failed: %s", phase, buffer.String())
+		}
+		if code := Run([]string{"review", "approve", "gate-demo", "--phase", phase}, &buffer, &buffer); code != 0 {
+			t.Fatalf("review approve %s failed: %s", phase, buffer.String())
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"release", "check"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("blocked repository exited zero: %s", stdout.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("failed certification wrote to stdout: %q", stdout.String())
+	}
+	report := stderr.String()
+	if !strings.Contains(report, "NOT RELEASABLE") || !strings.Contains(report, "Blockers:") || !strings.Contains(report, "gate-demo") {
+		t.Fatalf("text report incomplete: %q", report)
+	}
+}
+
+func TestRunReleaseCheckStrictPromotesPending(t *testing.T) {
+	setupReleasableFeature(t, "gate-demo")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"release", "check", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("pending-only plan blocked a non-strict run: %s", stdout.String())
+	}
+	envelope := decodeReleaseEnvelope(t, &stdout)
+	if pending := envelope.Result.Release.Features[0].Pending; len(pending) != 2 {
+		t.Fatalf("pending = %v, want both planned tasks", pending)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"release", "check", "--strict", "--json"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("--strict did not block pending work")
+	}
+	envelope = decodeReleaseEnvelope(t, &stdout)
+	if envelope.OK || !envelope.Result.Release.Strict {
+		t.Fatalf("strict envelope wrong: %+v", envelope.Result.Release)
+	}
+}
+
+func TestRunReleaseCheckRejectsBypassFlags(t *testing.T) {
+	setupReleasableFeature(t, "gate-demo")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"release", "check", "--allow-dirty", "--json"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("--allow-dirty accepted")
+	}
+	envelope := decodeReleaseEnvelope(t, &stdout)
+	if envelope.OK || !strings.Contains(envelope.Result.Summary, "--allow-dirty") {
+		t.Fatalf("bypass flag not named in the error: %+v", envelope.Result)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"release", "check", "--force"}, &stdout, &stderr); code == 0 {
+		t.Fatal("--force accepted")
+	}
+	if !strings.Contains(stderr.String(), "unknown flag --force") {
+		t.Fatalf("text-mode flag error missing: %q", stderr.String())
+	}
+}
+
+func TestRunReleaseCheckScopesToOneFeature(t *testing.T) {
+	root := setupReleasableFeature(t, "gate-demo")
+	addReleasableFeature(t, root, "second-feature")
+	completeReleasableFeature(t, "gate-demo")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"release", "check", "gate-demo", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("scoped run failed: %s (stderr %s)", stdout.String(), stderr.String())
+	}
+	envelope := decodeReleaseEnvelope(t, &stdout)
+	features := envelope.Result.Release.Features
+	if len(features) != 1 || features[0].Feature != "gate-demo" {
+		t.Fatalf("scoped run evaluated %+v, want only gate-demo", features)
+	}
+}
+
+func TestRunReleaseCheckUsageListed(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"--help"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("--help failed: %s", stderr.String())
+	}
+	usage := stdout.String()
+	if !strings.Contains(usage, "release check [<feature>] [--strict] [--json]") {
+		t.Fatalf("usage does not list release check: %q", usage)
+	}
+}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -44,6 +44,7 @@ var commandUsages = []commandUsage{
 	{"task complete-all <feature> [--json]", "Complete all runnable tasks in order"},
 	{"verify <feature> [--all] [--check] [--json]", "Re-prove completed tasks against the current code and refresh evidence"},
 	{"evidence status <feature> [--json]", "Report each completed task's derived execution-evidence state"},
+	{"release check [<feature>] [--strict] [--json]", "Certify the repository (or one feature) as releasable: chain, validation, decisions, evidence, worktree"},
 	{"validate <feature> [--all] [--json]", "Check EARS, traceability, and freshness"},
 	{"review open <feature> --phase <phase> [--json]", "Open the review gate (move to in-review)"},
 	{"review approve <feature> --phase <phase> [--json]", "Approve the review gate (move to approved)"},
@@ -88,6 +89,8 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 		return runVerify(args[1:], stdout, stderr)
 	case "evidence":
 		return runEvidence(args[1:], stdout, stderr)
+	case "release":
+		return runRelease(args[1:], stdout, stderr)
 	case "review":
 		return runReview(args[1:], stdout, stderr)
 	case "skill":

--- a/internal/e2e/release_check_e2e_test.go
+++ b/internal/e2e/release_check_e2e_test.go
@@ -1,0 +1,257 @@
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// releasableRepo bootstraps a real git repository holding one feature that
+// passes every certification criterion: approved fresh chain, full-spec-valid
+// documents, no decision markers, completed tasks verified on the committed
+// tree, clean worktree.
+func releasableRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	gitIn(t, dir, "init", "-q", "-b", "main")
+	gitIn(t, dir, "config", "user.email", "e2e@walden.dev")
+	gitIn(t, dir, "config", "user.name", "E2E")
+
+	mustCLI(t, dir, "repo", "init")
+	mustCLI(t, dir, "feature", "init", "gate-demo")
+
+	writeFile(t, dir, ".walden/specs/gate-demo/requirements.md", `---
+status: draft
+approved_at:
+last_modified: 2026-07-11T10:00:00Z
+approved_fingerprint:
+---
+
+# Requirements Document
+
+## Introduction
+
+Certification fixture.
+
+## Requirements
+
+### R1 Markers
+
+**User Story:** As a tester, I want provable markers, so that certification judges real evidence.
+
+#### Acceptance Criteria
+
+1. `+"`R1.AC1`"+` WHEN the first proof runs, the system SHALL find marker A in the source.
+2. `+"`R1.AC2`"+` WHEN the second proof runs, the system SHALL find marker B in the source.
+`)
+	writeFile(t, dir, ".walden/specs/gate-demo/design.md", `---
+status: draft
+approved_at:
+last_modified: 2026-07-11T10:00:00Z
+approved_fingerprint:
+source_requirements_approved_at:
+source_requirements_fingerprint:
+---
+
+# Feature Design
+
+## Overview
+
+A source file carries two grep-provable markers.
+
+## Architecture
+
+One shell proof per task.
+
+## Options Considered
+
+### Option A
+
+- Summary: grep proofs.
+- Why chosen: trivial and real.
+
+### Option B
+
+- Summary: none.
+- Why rejected: n/a.
+
+## Simplicity And Elegance Review
+
+- Simplest viable shape: two commands.
+- Coupling check: none.
+- Future-proofing: none.
+
+## Failure Modes And Tradeoffs
+
+- Failure mode: none.
+- Mitigation: none.
+- Tradeoff: none.
+
+## Testing Strategy
+
+Shell exit codes.
+
+## Verification Plan
+
+- Requirement proof: grep exits.
+- Test evidence: exit codes.
+
+## Requirement Coverage
+
+| Requirement | Covered By |
+| --- | --- |
+| `+"`R1`"+` | src.txt |
+`)
+	writeFile(t, dir, ".walden/specs/gate-demo/tasks.md", `---
+status: draft
+approved_at:
+last_modified: 2026-07-11T10:00:00Z
+approved_fingerprint:
+source_design_approved_at:
+source_design_fingerprint:
+---
+
+# Implementation Plan
+
+- [ ] 1. Markers
+  - [ ] 1.1 Place marker A
+    - Requirements: `+"`R1.AC1`"+`
+    - Design: Overview
+    - Verification:
+      - command: ["sh", "-c", "grep -q MARKER-A src.txt"]
+        covers: ["R1.AC1"]
+  - [ ] 1.2 Place marker B
+    - Requirements: `+"`R1.AC2`"+`
+    - Design: Overview
+    - Verification:
+      - command: ["sh", "-c", "grep -q MARKER-B src.txt"]
+        covers: ["R1.AC2"]
+`)
+
+	for _, phase := range []string{"requirements", "design", "tasks"} {
+		mustCLI(t, dir, "review", "open", "gate-demo", "--phase", phase)
+		mustCLI(t, dir, "review", "approve", "gate-demo", "--phase", phase)
+	}
+
+	writeFile(t, dir, "src.txt", "MARKER-A\nMARKER-B\n")
+	mustCLI(t, dir, "task", "complete-all", "gate-demo")
+
+	gitIn(t, dir, "add", "-A")
+	gitIn(t, dir, "commit", "-qm", "gate-demo: code, specs, evidence")
+	return dir
+}
+
+func TestE2EReleaseCheckCertifiesGreenRepository(t *testing.T) {
+	requireGit(t)
+	dir := releasableRepo(t)
+
+	out := mustCLI(t, dir, "release", "check")
+	if !strings.Contains(out, "RELEASABLE") || !strings.Contains(out, "worktree: clean") {
+		t.Fatalf("green repository not certified: %s", out)
+	}
+	// The full CI recipe: verify re-proves, release check certifies. On an
+	// unchanged tree verify rewrites identical evidence bytes, so the
+	// worktree stays clean and certification holds with no commit between.
+	mustCLI(t, dir, "verify", "gate-demo", "--all")
+	mustCLI(t, dir, "release", "check")
+}
+
+func TestE2EReleaseCheckCodeEditBlocks(t *testing.T) {
+	requireGit(t)
+	dir := releasableRepo(t)
+
+	writeFile(t, dir, "src.txt", "MARKER-A\nMARKER-B\ndrifted\n")
+
+	out, code := cli(t, dir, "release", "check")
+	if code == 0 {
+		t.Fatalf("edited code certified as releasable: %s", out)
+	}
+	if !strings.Contains(out, "stale-code") || !strings.Contains(out, "walden verify gate-demo") {
+		t.Fatalf("stale-code blocker missing its remedy: %s", out)
+	}
+	if !strings.Contains(out, "uncommitted: src.txt") {
+		t.Fatalf("dirty worktree not reported alongside: %s", out)
+	}
+}
+
+func TestE2EReleaseCheckSpecRevivalBlocks(t *testing.T) {
+	requireGit(t)
+	dir := releasableRepo(t)
+
+	// The spec moves after execution: evidence recorded under the old chain
+	// must read stale-spec even once the chain is re-approved and committed.
+	path := filepath.Join(dir, ".walden/specs/gate-demo/requirements.md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read requirements: %v", err)
+	}
+	writeFile(t, dir, ".walden/specs/gate-demo/requirements.md", string(content)+"\nRevived scope note.\n")
+	mustCLI(t, dir, "reconcile", "gate-demo")
+	for _, phase := range []string{"requirements", "design", "tasks"} {
+		mustCLI(t, dir, "review", "open", "gate-demo", "--phase", phase)
+		mustCLI(t, dir, "review", "approve", "gate-demo", "--phase", phase)
+	}
+	gitIn(t, dir, "add", "-A")
+	gitIn(t, dir, "commit", "-qm", "revive the spec")
+
+	out, code := cli(t, dir, "release", "check")
+	if code == 0 {
+		t.Fatalf("revived spec certified against old evidence: %s", out)
+	}
+	if !strings.Contains(out, "stale-spec") || !strings.Contains(out, "walden verify gate-demo") {
+		t.Fatalf("stale-spec blocker missing its remedy: %s", out)
+	}
+}
+
+func TestE2EReleaseCheckDecisionMarkerBlocks(t *testing.T) {
+	requireGit(t)
+	dir := releasableRepo(t)
+
+	path := filepath.Join(dir, ".walden/specs/gate-demo/design.md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read design: %v", err)
+	}
+	writeFile(t, dir, ".walden/specs/gate-demo/design.md", string(content)+"\n[decision: which backend stays?]\n")
+	mustCLI(t, dir, "reconcile", "gate-demo")
+	for _, phase := range []string{"design", "tasks"} {
+		mustCLI(t, dir, "review", "open", "gate-demo", "--phase", phase)
+		mustCLI(t, dir, "review", "approve", "gate-demo", "--phase", phase)
+	}
+	gitIn(t, dir, "add", "-A")
+	gitIn(t, dir, "commit", "-qm", "approve a design carrying an open checkpoint")
+
+	out, code := cli(t, dir, "release", "check")
+	if code == 0 {
+		t.Fatalf("open decision checkpoint certified: %s", out)
+	}
+	if !strings.Contains(out, "[decision:] marker in design.md") || !strings.Contains(out, "resolve") {
+		t.Fatalf("decision blocker missing document or remedy: %s", out)
+	}
+}
+
+func TestE2EReleaseCheckUncommittedFileBlocks(t *testing.T) {
+	requireGit(t)
+	dir := releasableRepo(t)
+
+	writeFile(t, dir, "notes.txt", "wip\n")
+
+	out, code := cli(t, dir, "release", "check")
+	if code == 0 {
+		t.Fatalf("dirty worktree certified: %s", out)
+	}
+	if !strings.Contains(out, "uncommitted: notes.txt — commit it") {
+		t.Fatalf("worktree blocker missing its remedy: %s", out)
+	}
+
+	// The same dirt under .walden/ warns without blocking.
+	if err := os.Remove(filepath.Join(dir, "notes.txt")); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	writeFile(t, dir, ".walden/scratch.txt", "local\n")
+	out = mustCLI(t, dir, "release", "check")
+	if !strings.Contains(out, ".walden/scratch.txt") || !strings.Contains(out, "not blocking") {
+		t.Fatalf(".walden dirt not surfaced as a warning: %s", out)
+	}
+}

--- a/internal/output/result.go
+++ b/internal/output/result.go
@@ -34,8 +34,38 @@ type Result struct {
 	Skills                []SkillStatus     `json:"skills,omitempty"`
 	Evidence              []EvidenceStatus  `json:"evidence,omitempty"`
 	Update                *UpdateStatus     `json:"update,omitempty"`
+	Release               *ReleaseStatus    `json:"release,omitempty"`
 	Content               string            `json:"content,omitempty"`
 	ExitCode              int               `json:"exit_code"`
+}
+
+// ReleaseStatus is the JSON output view of a release certification run.
+type ReleaseStatus struct {
+	Releasable bool             `json:"releasable"`
+	Strict     bool             `json:"strict"`
+	Features   []ReleaseFeature `json:"features"`
+	Worktree   ReleaseWorktree  `json:"worktree"`
+}
+
+// ReleaseFeature is one feature's per-criterion certification outcome.
+type ReleaseFeature struct {
+	Feature  string             `json:"feature"`
+	Criteria []ReleaseCriterion `json:"criteria"`
+	Pending  []string           `json:"pending,omitempty"`
+}
+
+// ReleaseCriterion is a single certification criterion's verdict.
+type ReleaseCriterion struct {
+	Name     string   `json:"name"`
+	Passed   bool     `json:"passed"`
+	Blockers []string `json:"blockers,omitempty"`
+}
+
+// ReleaseWorktree is the repository-level worktree criterion's outcome.
+type ReleaseWorktree struct {
+	Blockers    []string `json:"blockers,omitempty"`
+	WaldenDirty []string `json:"walden_dirty,omitempty"`
+	GitSkipped  bool     `json:"git_skipped"`
 }
 
 // EvidenceStatus is the JSON output view of one task's execution evidence.
@@ -243,6 +273,32 @@ func PrintText(w io.Writer, result Result) {
 	if result.Update != nil {
 		_, _ = fmt.Fprintf(w, "Update: current=%s target=%s available=%t applied=%t\n",
 			result.Update.CurrentVersion, result.Update.TargetVersion, result.Update.UpdateAvailable, result.Update.Applied)
+	}
+
+	if result.Release != nil {
+		_, _ = fmt.Fprintln(w, "Release:")
+		for _, feature := range result.Release.Features {
+			_, _ = fmt.Fprintf(w, "- %s:", feature.Feature)
+			for _, criterion := range feature.Criteria {
+				verdict := "pass"
+				if !criterion.Passed {
+					verdict = "FAIL"
+				}
+				_, _ = fmt.Fprintf(w, " %s=%s", criterion.Name, verdict)
+			}
+			if len(feature.Pending) > 0 {
+				_, _ = fmt.Fprintf(w, " pending: %s", strings.Join(feature.Pending, ", "))
+			}
+			_, _ = fmt.Fprintln(w)
+		}
+		switch {
+		case result.Release.Worktree.GitSkipped:
+			_, _ = fmt.Fprintln(w, "- worktree: skipped (no usable git)")
+		case len(result.Release.Worktree.Blockers) > 0:
+			_, _ = fmt.Fprintf(w, "- worktree: %d uncommitted path(s)\n", len(result.Release.Worktree.Blockers))
+		default:
+			_, _ = fmt.Fprintln(w, "- worktree: clean")
+		}
 	}
 
 	if len(result.Blockers) > 0 {

--- a/internal/release/check.go
+++ b/internal/release/check.go
@@ -1,0 +1,247 @@
+package release
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/andrearaponi/walden/internal/evidence"
+	"github.com/andrearaponi/walden/internal/shell"
+	"github.com/andrearaponi/walden/internal/spec"
+	"github.com/andrearaponi/walden/internal/validation"
+	"github.com/andrearaponi/walden/internal/workflow"
+)
+
+// gitRunner executes the gate's read-only git plumbing. It is a seam so
+// tests control worktree and identity outcomes.
+var gitRunner shell.Runner = shell.NewExecRunner()
+
+// decisionMarker is the skill protocol's open-checkpoint marker. The gate
+// treats it as a deterministic substring in approved documents — a textual
+// lint, never an interpretation of the protocol itself.
+const decisionMarker = "[decision:"
+
+// CriterionResult is one certification criterion's outcome for a feature.
+type CriterionResult struct {
+	Name     string
+	Passed   bool
+	Blockers []string
+}
+
+// FeatureCertification is one feature's full certification record.
+type FeatureCertification struct {
+	Feature  string
+	Criteria []CriterionResult
+	Pending  []string
+}
+
+// ReleaseReport is the aggregate verdict: releasable iff zero blockers.
+type ReleaseReport struct {
+	Features         []FeatureCertification
+	WorktreeBlockers []string
+	WaldenDirty      []string
+	GitSkipped       bool
+	Strict           bool
+}
+
+// BlockerCount sums every blocker across features and the worktree.
+func (r ReleaseReport) BlockerCount() int {
+	count := len(r.WorktreeBlockers)
+	for _, feature := range r.Features {
+		for _, criterion := range feature.Criteria {
+			count += len(criterion.Blockers)
+		}
+	}
+	return count
+}
+
+// Releasable reports the verdict.
+func (r ReleaseReport) Releasable() bool { return r.BlockerCount() == 0 }
+
+// ReleaseCheck certifies one feature (or, with an empty name, every feature
+// under .walden/specs/ in sorted order) against the release criteria. It
+// judges existing truths — chain freshness, validation, decision markers,
+// evidence — and executes no proofs and persists nothing: verify produces
+// evidence, release check judges it.
+func ReleaseCheck(ctx context.Context, root, featureName string, strict bool) (ReleaseReport, error) {
+	features, err := releaseTargets(root, featureName)
+	if err != nil {
+		return ReleaseReport{}, err
+	}
+
+	// One identity for the whole run: every feature's evidence is judged
+	// against the same tree.
+	identity, identityOK := evidence.Identity(ctx, gitRunner, root)
+
+	report := ReleaseReport{Strict: strict}
+	for _, name := range features {
+		report.Features = append(report.Features, certifyFeature(root, name, strict, identity, identityOK))
+	}
+
+	report.WorktreeBlockers, report.WaldenDirty, report.GitSkipped = worktreeCriterion(ctx, root)
+	return report, nil
+}
+
+// releaseTargets resolves the feature list for the run.
+func releaseTargets(root, featureName string) ([]string, error) {
+	if featureName != "" {
+		normalized, err := spec.NormalizeFeatureName(featureName)
+		if err != nil {
+			return nil, err
+		}
+		return []string{normalized}, nil
+	}
+
+	entries, err := os.ReadDir(filepath.Join(root, ".walden", "specs"))
+	if err != nil {
+		return nil, fmt.Errorf("read feature specs: %w", err)
+	}
+	features := []string{}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			features = append(features, entry.Name())
+		}
+	}
+	sort.Strings(features)
+	if len(features) == 0 {
+		return nil, fmt.Errorf("no features under .walden/specs to certify")
+	}
+	return features, nil
+}
+
+// certifyFeature evaluates every criterion; nothing short-circuits — a
+// certification is a complete work list, not a first failure.
+func certifyFeature(root, name string, strict bool, identity string, identityOK bool) FeatureCertification {
+	certification := FeatureCertification{Feature: name}
+
+	feature, loadErr := spec.LoadFeature(root, name)
+
+	// Criterion 1: the approval chain, approved and fresh.
+	chain := CriterionResult{Name: "chain"}
+	if loadErr != nil {
+		chain.Blockers = append(chain.Blockers, loadErr.Error())
+	} else if readiness, err := workflow.ResolveExecutionReadiness(feature); err != nil {
+		chain.Blockers = append(chain.Blockers, err.Error())
+	} else if readiness.GateBlocked {
+		chain.Blockers = append(chain.Blockers, readiness.Blockers...)
+	}
+	chain.Passed = len(chain.Blockers) == 0
+	certification.Criteria = append(certification.Criteria, chain)
+
+	// Criterion 2: full-spec validation.
+	valid := CriterionResult{Name: "validation"}
+	if result, err := validation.ValidateFeatureWithScope(root, name, validation.ScopeFullSpec); err != nil {
+		valid.Blockers = append(valid.Blockers, fmt.Sprintf("%v — fix and rerun walden validate %s --all", err, name))
+	} else if !result.Valid {
+		valid.Blockers = append(valid.Blockers, fmt.Sprintf("%s — fix and rerun walden validate %s --all", result.Message, name))
+	}
+	valid.Passed = len(valid.Blockers) == 0
+	certification.Criteria = append(certification.Criteria, valid)
+
+	// Criterion 3: no unresolved decision markers in approved documents.
+	// Drafts of in-flight features may legitimately carry open checkpoints.
+	decisions := CriterionResult{Name: "decisions"}
+	if loadErr == nil {
+		for _, doc := range []struct {
+			name     string
+			document spec.Document
+		}{
+			{"requirements.md", feature.Requirements},
+			{"design.md", feature.Design},
+			{"tasks.md", feature.Tasks},
+		} {
+			if doc.document.Exists && doc.document.Status == "approved" && strings.Contains(doc.document.Body, decisionMarker) {
+				decisions.Blockers = append(decisions.Blockers, fmt.Sprintf("unresolved %s] marker in %s — resolve it and re-approve", decisionMarker, doc.name))
+			}
+		}
+	}
+	decisions.Passed = len(decisions.Blockers) == 0
+	certification.Criteria = append(certification.Criteria, decisions)
+
+	// Criterion 4: executed work must be verified; planned work informs.
+	evidenceCriterion := CriterionResult{Name: "evidence"}
+	if loadErr == nil {
+		if tree, err := spec.ParseTaskTree(feature.Tasks); err == nil {
+			ledger, err := evidence.Load(root, name)
+			if err != nil {
+				evidenceCriterion.Blockers = append(evidenceCriterion.Blockers, fmt.Sprintf("%v — remove the file and run walden verify %s --all", err, name))
+			} else {
+				leafs := []evidence.LeafTask{}
+				for _, task := range tree.LeafTasks() {
+					leafs = append(leafs, evidence.LeafTask{
+						ID:          task.ID,
+						Completed:   task.Completed,
+						Fingerprint: spec.TaskDefinitionFingerprint(task),
+					})
+				}
+				current := evidence.ChainFingerprints{
+					Requirements: feature.Requirements.Fields["approved_fingerprint"],
+					Design:       feature.Design.Fields["approved_fingerprint"],
+				}
+				for _, derived := range evidence.Derive(ledger, current, identity, identityOK, leafs) {
+					switch derived.State {
+					case evidence.StateVerified:
+					case evidence.StatePending:
+						certification.Pending = append(certification.Pending, derived.TaskID)
+						if strict {
+							evidenceCriterion.Blockers = append(evidenceCriterion.Blockers, fmt.Sprintf("task %s not executed (--strict) — complete it or drop --strict", derived.TaskID))
+						}
+					default:
+						evidenceCriterion.Blockers = append(evidenceCriterion.Blockers, fmt.Sprintf("task %s is %s — run walden verify %s", derived.TaskID, derived.State, name))
+					}
+				}
+			}
+		} else {
+			evidenceCriterion.Blockers = append(evidenceCriterion.Blockers, err.Error())
+		}
+	}
+	evidenceCriterion.Passed = len(evidenceCriterion.Blockers) == 0
+	certification.Criteria = append(certification.Criteria, evidenceCriterion)
+
+	return certification
+}
+
+// worktreeCriterion partitions uncommitted paths once per run: code outside
+// .walden/ blocks certification (what you certify must be what you tag),
+// .walden/ itself only warns — a freshly refreshed ledger legitimately
+// precedes its own commit. Unusable git skips the criterion, reported.
+func worktreeCriterion(ctx context.Context, root string) (blockers, waldenDirty []string, skipped bool) {
+	status, err := gitRunner.Run(ctx, "git", "-C", root, "status", "--porcelain", "-z")
+	if err != nil || status.ExitCode != 0 {
+		return nil, nil, true
+	}
+
+	for _, path := range porcelainPathList(status.Stdout) {
+		if path == ".walden" || strings.HasPrefix(path, ".walden/") {
+			waldenDirty = append(waldenDirty, path)
+			continue
+		}
+		blockers = append(blockers, fmt.Sprintf("uncommitted: %s — commit it before certifying", path))
+	}
+	sort.Strings(blockers)
+	sort.Strings(waldenDirty)
+	return blockers, waldenDirty, false
+}
+
+// porcelainPathList extracts worktree paths from NUL-separated porcelain
+// output; rename and copy entries carry the source as a separate field,
+// consumed without being reported.
+func porcelainPathList(stdout string) []string {
+	fields := strings.Split(stdout, "\x00")
+	paths := []string{}
+	for index := 0; index < len(fields); index++ {
+		entry := fields[index]
+		if len(entry) < 4 {
+			continue
+		}
+		code, path := entry[:2], entry[3:]
+		if strings.HasPrefix(code, "R") || strings.HasPrefix(code, "C") {
+			index++
+		}
+		paths = append(paths, path)
+	}
+	return paths
+}

--- a/internal/release/check.go
+++ b/internal/release/check.go
@@ -153,7 +153,7 @@ func certifyFeature(root, name string, strict bool, identity string, identityOK 
 			{"design.md", feature.Design},
 			{"tasks.md", feature.Tasks},
 		} {
-			if doc.document.Exists && doc.document.Status == "approved" && strings.Contains(doc.document.Body, decisionMarker) {
+			if doc.document.Exists && doc.document.Status == "approved" && strings.Contains(stripHTMLComments(doc.document.Body), decisionMarker) {
 				decisions.Blockers = append(decisions.Blockers, fmt.Sprintf("unresolved %s] marker in %s — resolve it and re-approve", decisionMarker, doc.name))
 			}
 		}
@@ -202,6 +202,26 @@ func certifyFeature(root, name string, strict bool, identity string, identityOK 
 	certification.Criteria = append(certification.Criteria, evidenceCriterion)
 
 	return certification
+}
+
+// stripHTMLComments removes `<!-- ... -->` spans (unterminated ones to the
+// end) before the decision scan: assumed markers live in comments by skill
+// convention and legitimately mention the decision marker in prose.
+func stripHTMLComments(body string) string {
+	var kept strings.Builder
+	for {
+		start := strings.Index(body, "<!--")
+		if start < 0 {
+			kept.WriteString(body)
+			return kept.String()
+		}
+		kept.WriteString(body[:start])
+		end := strings.Index(body[start:], "-->")
+		if end < 0 {
+			return kept.String()
+		}
+		body = body[start+end+len("-->"):]
+	}
 }
 
 // worktreeCriterion partitions uncommitted paths once per run: code outside

--- a/internal/release/check_test.go
+++ b/internal/release/check_test.go
@@ -254,6 +254,49 @@ func TestReleaseCheckDecisionMarkerBlocksOnlyWhenApproved(t *testing.T) {
 	}
 }
 
+func TestReleaseCheckDecisionMarkerIgnoresHTMLComments(t *testing.T) {
+	requireGit(t)
+	root := t.TempDir()
+	gitIn(t, root, "init", "-q", "-b", "main")
+	gitIn(t, root, "config", "user.email", "g@g")
+	gitIn(t, root, "config", "user.name", "G")
+
+	// The production-shaped assumed note: prose inside an HTML comment that
+	// mentions the marker to deny its presence must never block.
+	commented := "\n\n<!-- assumed: no [decision: checkpoints — every fork was resolved during requirements -->"
+	addFeature(t, root, "commented", certifiableRequirements(), certifiableDesign(commented), certifiableTasks())
+
+	report, err := ReleaseCheck(context.Background(), root, "commented", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck: %v", err)
+	}
+	if decisions := criterion(t, report.Features[0], "decisions"); !decisions.Passed {
+		t.Fatalf("marker inside a comment blocked certification: %+v", decisions)
+	}
+
+	// An unterminated comment swallows the rest of the document.
+	unterminated := "\n\n<!-- assumed: still drafting\n\n[decision: which store?]"
+	addFeature(t, root, "unterminated", certifiableRequirements(), certifiableDesign(unterminated), certifiableTasks())
+	report, err = ReleaseCheck(context.Background(), root, "unterminated", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck unterminated: %v", err)
+	}
+	if decisions := criterion(t, report.Features[0], "decisions"); !decisions.Passed {
+		t.Fatalf("marker inside an unterminated comment blocked: %+v", decisions)
+	}
+
+	// A real marker beside a commented one still blocks.
+	mixed := "\n\n<!-- assumed: none open -->\n\n[decision: pick a queue]"
+	addFeature(t, root, "mixed", certifiableRequirements(), certifiableDesign(mixed), certifiableTasks())
+	report, err = ReleaseCheck(context.Background(), root, "mixed", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck mixed: %v", err)
+	}
+	if decisions := criterion(t, report.Features[0], "decisions"); decisions.Passed {
+		t.Fatal("marker outside the comment did not block")
+	}
+}
+
 func TestReleaseCheckEvidenceBlockerNamesStateAndRemedy(t *testing.T) {
 	root := gateRepo(t)
 

--- a/internal/release/check_test.go
+++ b/internal/release/check_test.go
@@ -1,0 +1,376 @@
+package release
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/testutil"
+	"github.com/andrearaponi/walden/internal/workflow"
+)
+
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+}
+
+func gitIn(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	command := exec.Command("git", args...)
+	command.Dir = dir
+	if out, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, out)
+	}
+}
+
+func write(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", name, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+const draftReqHeader = `---
+status: draft
+approved_at:
+last_modified: 2026-07-11T13:00:00Z
+approved_fingerprint:
+---
+
+`
+
+const draftDesignHeader = `---
+status: draft
+approved_at:
+last_modified: 2026-07-11T13:00:00Z
+approved_fingerprint:
+source_requirements_approved_at:
+source_requirements_fingerprint:
+---
+
+`
+
+const draftTasksHeader = `---
+status: draft
+approved_at:
+last_modified: 2026-07-11T13:00:00Z
+approved_fingerprint:
+source_design_approved_at:
+source_design_fingerprint:
+---
+
+`
+
+func certifiableRequirements() string {
+	return draftReqHeader + "# Requirements Document\n\n## Introduction\n\nGate fixture.\n\n## Requirements\n\n### R1 Markers\n\n**User Story:** As a tester, I want markers, so that the gate has proofs to judge.\n\n#### Acceptance Criteria\n\n1. `R1.AC1` WHEN the first proof runs, the system SHALL succeed.\n2. `R1.AC2` WHEN the second proof runs, the system SHALL succeed.\n"
+}
+
+func certifiableDesign(extra string) string {
+	return draftDesignHeader + "# Feature Design\n\n## Overview\n\nTwo trivially provable markers." + extra + "\n\n## Architecture\n\nOne shell proof per task.\n\n## Options Considered\n\n### Option A\n\n- Summary: shell proofs.\n- Why chosen: trivial.\n\n### Option B\n\n- Summary: none.\n- Why rejected: n/a.\n\n## Simplicity And Elegance Review\n\n- Simplest viable shape: two commands.\n- Coupling check: none.\n- Future-proofing: none.\n\n## Failure Modes And Tradeoffs\n\n- Failure mode: none.\n- Mitigation: none.\n- Tradeoff: none.\n\n## Testing Strategy\n\nShell exit codes.\n\n## Verification Plan\n\n- Requirement proof: shell exits.\n- Test evidence: exit codes.\n\n## Requirement Coverage\n\n| Requirement | Covered By |\n| --- | --- |\n| `R1` | markers |\n"
+}
+
+func certifiableTasks() string {
+	return draftTasksHeader + "# Implementation Plan\n\n- [ ] 1. Markers\n  - [ ] 1.1 First marker\n    - Requirements: `R1.AC1`\n    - Design: Overview\n    - Verification:\n      - command: [\"sh\", \"-c\", \"true\"]\n        covers: [\"R1.AC1\"]\n  - [ ] 1.2 Second marker\n    - Requirements: `R1.AC2`\n    - Design: Overview\n    - Verification:\n      - command: [\"sh\", \"-c\", \"true\"]\n        covers: [\"R1.AC2\"]\n"
+}
+
+// addFeature writes and approves a certifiable feature.
+func addFeature(t *testing.T, root, name, requirements, design, tasks string) {
+	t.Helper()
+	write(t, root, ".walden/specs/"+name+"/requirements.md", requirements)
+	write(t, root, ".walden/specs/"+name+"/design.md", design)
+	write(t, root, ".walden/specs/"+name+"/tasks.md", tasks)
+	for _, phase := range []string{"requirements", "design", "tasks"} {
+		parsed, err := workflow.ParsePhase(phase)
+		if err != nil {
+			t.Fatalf("parse phase: %v", err)
+		}
+		if _, err := workflow.OpenReview(root, name, parsed); err != nil {
+			t.Fatalf("open %s: %v", phase, err)
+		}
+		if _, err := workflow.ApproveReview(root, name, parsed); err != nil {
+			t.Fatalf("approve %s: %v", phase, err)
+		}
+	}
+}
+
+// gateRepo builds a real git repo with one completed, committed feature.
+func gateRepo(t *testing.T) string {
+	t.Helper()
+	requireGit(t)
+	root := t.TempDir()
+	gitIn(t, root, "init", "-q", "-b", "main")
+	gitIn(t, root, "config", "user.email", "gate@walden.dev")
+	gitIn(t, root, "config", "user.name", "Gate")
+
+	addFeature(t, root, "gate-demo", certifiableRequirements(), certifiableDesign(""), certifiableTasks())
+	write(t, root, "src.txt", "MARKER-A\nMARKER-B\n")
+
+	runner := testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+	)
+	if _, err := workflow.CompleteAllTasks(context.Background(), root, "gate-demo", runner); err != nil {
+		t.Fatalf("complete fixture: %v", err)
+	}
+
+	gitIn(t, root, "add", "-A")
+	gitIn(t, root, "commit", "-qm", "gate-demo: everything, evidence included")
+	return root
+}
+
+func criterion(t *testing.T, cert FeatureCertification, name string) CriterionResult {
+	t.Helper()
+	for _, c := range cert.Criteria {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("criterion %s missing from %v", name, cert.Criteria)
+	return CriterionResult{}
+}
+
+func TestReleaseCheckAllGreen(t *testing.T) {
+	root := gateRepo(t)
+
+	ledgerBefore, err := os.ReadFile(filepath.Join(root, ".walden/evidence/gate-demo.json"))
+	if err != nil {
+		t.Fatalf("read ledger: %v", err)
+	}
+
+	report, err := ReleaseCheck(context.Background(), root, "", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck: %v", err)
+	}
+	if !report.Releasable() {
+		t.Fatalf("green repository not releasable: %+v", report)
+	}
+	if len(report.Features) != 1 || len(report.Features[0].Criteria) != 4 {
+		t.Fatalf("expected 1 feature with 4 criteria: %+v", report.Features)
+	}
+	for _, c := range report.Features[0].Criteria {
+		if !c.Passed {
+			t.Fatalf("criterion %s failed on a green repo: %v", c.Name, c.Blockers)
+		}
+	}
+
+	ledgerAfter, _ := os.ReadFile(filepath.Join(root, ".walden/evidence/gate-demo.json"))
+	if string(ledgerBefore) != string(ledgerAfter) {
+		t.Fatal("release check mutated the ledger")
+	}
+
+	scoped, err := ReleaseCheck(context.Background(), root, "gate-demo", false)
+	if err != nil || len(scoped.Features) != 1 {
+		t.Fatalf("feature-scoped run: %v %+v", err, scoped.Features)
+	}
+}
+
+func TestReleaseCheckChainBlockerStillEvaluatesEverything(t *testing.T) {
+	root := gateRepo(t)
+
+	// Tamper with the approved requirements body: the chain goes stale.
+	path := filepath.Join(root, ".walden/specs/gate-demo/requirements.md")
+	content, _ := os.ReadFile(path)
+	if err := os.WriteFile(path, append(content, []byte("\ntampered\n")...), 0o644); err != nil {
+		t.Fatalf("tamper: %v", err)
+	}
+
+	report, err := ReleaseCheck(context.Background(), root, "gate-demo", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck: %v", err)
+	}
+	cert := report.Features[0]
+	if chain := criterion(t, cert, "chain"); chain.Passed || len(chain.Blockers) == 0 {
+		t.Fatalf("stale chain not blocked: %+v", chain)
+	}
+	if len(cert.Criteria) != 4 {
+		t.Fatalf("criteria short-circuited: %+v", cert.Criteria)
+	}
+	if report.Releasable() {
+		t.Fatal("stale chain certified as releasable")
+	}
+}
+
+func TestReleaseCheckValidationBlocker(t *testing.T) {
+	requireGit(t)
+	root := t.TempDir()
+	gitIn(t, root, "init", "-q", "-b", "main")
+	gitIn(t, root, "config", "user.email", "g@g")
+	gitIn(t, root, "config", "user.name", "G")
+
+	// A design missing required sections approves fine (approval does not
+	// validate) but fails full-spec validation.
+	brokenDesign := draftDesignHeader + "# Feature Design\n\n## Overview\n\nBare.\n\n## Requirement Coverage\n\n| Requirement | Covered By |\n| --- | --- |\n| `R1` | markers |\n"
+	addFeature(t, root, "gate-demo", certifiableRequirements(), brokenDesign, certifiableTasks())
+
+	report, err := ReleaseCheck(context.Background(), root, "gate-demo", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck: %v", err)
+	}
+	valid := criterion(t, report.Features[0], "validation")
+	if valid.Passed || !strings.Contains(strings.Join(valid.Blockers, " "), "walden validate") {
+		t.Fatalf("validation blocker missing or without remedy: %+v", valid)
+	}
+}
+
+func TestReleaseCheckDecisionMarkerBlocksOnlyWhenApproved(t *testing.T) {
+	requireGit(t)
+	root := t.TempDir()
+	gitIn(t, root, "init", "-q", "-b", "main")
+	gitIn(t, root, "config", "user.email", "g@g")
+	gitIn(t, root, "config", "user.name", "G")
+
+	// Approved design carrying an unresolved checkpoint.
+	addFeature(t, root, "marked", certifiableRequirements(), certifiableDesign("\n\n[decision: which store backs this?]"), certifiableTasks())
+
+	report, err := ReleaseCheck(context.Background(), root, "marked", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck: %v", err)
+	}
+	decisions := criterion(t, report.Features[0], "decisions")
+	if decisions.Passed || !strings.Contains(decisions.Blockers[0], "design.md") {
+		t.Fatalf("approved marker not blocked: %+v", decisions)
+	}
+
+	// A draft carrying a checkpoint is legitimate in-flight work.
+	write(t, root, ".walden/specs/inflight/requirements.md", certifiableRequirements())
+	write(t, root, ".walden/specs/inflight/design.md", certifiableDesign("\n\n[decision: still open]"))
+	write(t, root, ".walden/specs/inflight/tasks.md", certifiableTasks())
+
+	report, err = ReleaseCheck(context.Background(), root, "inflight", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck inflight: %v", err)
+	}
+	if decisions := criterion(t, report.Features[0], "decisions"); !decisions.Passed {
+		t.Fatalf("draft marker blocked certification: %+v", decisions)
+	}
+}
+
+func TestReleaseCheckEvidenceBlockerNamesStateAndRemedy(t *testing.T) {
+	root := gateRepo(t)
+
+	// The code moves after certification-worthy completion.
+	write(t, root, "src.txt", "MARKER-A\nMARKER-B\nchanged\n")
+
+	report, err := ReleaseCheck(context.Background(), root, "gate-demo", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck: %v", err)
+	}
+	ev := criterion(t, report.Features[0], "evidence")
+	joined := strings.Join(ev.Blockers, " ")
+	if ev.Passed || !strings.Contains(joined, "stale-code") || !strings.Contains(joined, "walden verify gate-demo") {
+		t.Fatalf("evidence blocker missing state or remedy: %+v", ev)
+	}
+}
+
+func TestReleaseCheckPendingInformationalAndStrict(t *testing.T) {
+	requireGit(t)
+	root := t.TempDir()
+	gitIn(t, root, "init", "-q", "-b", "main")
+	gitIn(t, root, "config", "user.email", "g@g")
+	gitIn(t, root, "config", "user.name", "G")
+
+	addFeature(t, root, "gate-demo", certifiableRequirements(), certifiableDesign(""), certifiableTasks())
+	runner := testutil.NewFakeRunner(testutil.Response{Stdout: "ok", ExitCode: 0})
+	if _, err := workflow.CompleteTask(context.Background(), root, "gate-demo", "1.1", runner); err != nil {
+		t.Fatalf("complete 1.1: %v", err)
+	}
+	gitIn(t, root, "add", "-A")
+	gitIn(t, root, "commit", "-qm", "half done")
+
+	report, err := ReleaseCheck(context.Background(), root, "gate-demo", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck: %v", err)
+	}
+	if !report.Releasable() {
+		t.Fatalf("pending work blocked a non-strict release: %+v", report)
+	}
+	if pending := report.Features[0].Pending; len(pending) != 1 || pending[0] != "1.2" {
+		t.Fatalf("pending = %v, want [1.2]", pending)
+	}
+
+	strict, err := ReleaseCheck(context.Background(), root, "gate-demo", true)
+	if err != nil {
+		t.Fatalf("ReleaseCheck --strict: %v", err)
+	}
+	ev := criterion(t, strict.Features[0], "evidence")
+	if strict.Releasable() || !strings.Contains(strings.Join(ev.Blockers, " "), "1.2") {
+		t.Fatalf("--strict did not block pending work: %+v", strict)
+	}
+}
+
+func TestReleaseCheckWalksFeaturesSorted(t *testing.T) {
+	root := gateRepo(t)
+	addFeature(t, root, "alpha-extra", certifiableRequirements(), certifiableDesign(""), certifiableTasks())
+	gitIn(t, root, "add", "-A")
+	gitIn(t, root, "commit", "-qm", "second feature specs")
+
+	report, err := ReleaseCheck(context.Background(), root, "", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck: %v", err)
+	}
+	if len(report.Features) != 2 || report.Features[0].Feature != "alpha-extra" || report.Features[1].Feature != "gate-demo" {
+		t.Fatalf("features not sorted: %+v", report.Features)
+	}
+}
+
+func TestReleaseCheckWorktreePartitionsPaths(t *testing.T) {
+	root := gateRepo(t)
+
+	write(t, root, "untracked-note.txt", "wip")
+	write(t, root, ".walden/scratch.txt", "local")
+	gitIn(t, root, "mv", "src.txt", "renamed.txt")
+
+	report, err := ReleaseCheck(context.Background(), root, "gate-demo", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck: %v", err)
+	}
+	joined := strings.Join(report.WorktreeBlockers, " ")
+	if !strings.Contains(joined, "untracked-note.txt") || !strings.Contains(joined, "renamed.txt") {
+		t.Fatalf("worktree blockers incomplete: %v", report.WorktreeBlockers)
+	}
+	if strings.Contains(joined, "src.txt") {
+		t.Fatalf("rename source reported as a live path: %v", report.WorktreeBlockers)
+	}
+	if len(report.WaldenDirty) != 1 || !strings.Contains(report.WaldenDirty[0], ".walden/scratch.txt") {
+		t.Fatalf(".walden dirt not partitioned as warning: %v", report.WaldenDirty)
+	}
+	if report.Releasable() {
+		t.Fatal("dirty worktree certified as releasable")
+	}
+}
+
+func TestReleaseCheckWorktreeSkipsWithoutGit(t *testing.T) {
+	root := t.TempDir()
+	addFeature(t, root, "gate-demo", certifiableRequirements(), certifiableDesign(""), certifiableTasks())
+	runner := testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+	)
+	if _, err := workflow.CompleteAllTasks(context.Background(), root, "gate-demo", runner); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	report, err := ReleaseCheck(context.Background(), root, "gate-demo", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck: %v", err)
+	}
+	if !report.GitSkipped {
+		t.Fatal("no-git repository did not skip the worktree criterion")
+	}
+	if len(report.WorktreeBlockers) != 0 {
+		t.Fatalf("skipped criterion produced blockers: %v", report.WorktreeBlockers)
+	}
+	// Absent identities compare equal: the feature stays certifiable.
+	if !report.Releasable() {
+		t.Fatalf("git-less repository not releasable: %+v", report.Features)
+	}
+}

--- a/site/index.html
+++ b/site/index.html
@@ -86,7 +86,7 @@
       </p>
       <p class="claim-sub">
         Blocking gates with exit codes — validation, proofs, freshness,
-        execution evidence — independent of any model&rsquo;s judgment.
+        execution evidence, release certification — independent of any model&rsquo;s judgment.
       </p>
     </section>
 
@@ -119,6 +119,7 @@
             <li>AC traceability — 100% coverage required</li>
             <li>a verification proof on every leaf task</li>
             <li>execution evidence bound to the code — re-provable with <code>verify</code></li>
+            <li>one releasability verdict per repository — <code>release check</code></li>
             <li>stale-document detection &amp; reconciliation</li>
           </ul>
           <p class="voice-foot">deterministic · the same answer every time</p>
@@ -286,10 +287,11 @@
 
         <article class="recipe">
           <h3 class="recipe-name">Your CI</h3>
-          <p>Gate every pull request that touches a spec. Validation runs headless
-             and the exit code decides — no model in the loop.</p>
-          <code class="recipe-cmd">walden validate &lt;feature&gt; --all --json</code>
-          <span class="recipe-out">exit ≠ 0 → merge blocked</span>
+          <p>Certify before you tag. <code>verify</code> re-proves the code,
+             <code>release check</code> judges everything — chains, validation,
+             evidence, worktree. One exit code decides.</p>
+          <code class="recipe-cmd">walden release check --json</code>
+          <span class="recipe-out">exit ≠ 0 → not releasable</span>
         </article>
 
         <article class="recipe">

--- a/skill/walden/SKILL.md
+++ b/skill/walden/SKILL.md
@@ -40,6 +40,7 @@ Walden is an open source spec-driven delivery kernel. It is not a complete enter
 - Use `walden task complete-all <feature-name> [--json]` to complete all runnable leaf tasks in order, stopping on first failure.
 - Use `walden verify <feature-name> [--all] [--check] [--json]` to re-execute completed tasks' proofs against the current code and refresh execution evidence; `--check` reports without persisting anything.
 - Use `walden evidence status <feature-name> [--json]` to inspect each task's derived evidence state: verified, stale-spec, stale-code, failed, unrecorded, or pending.
+- Use `walden release check [<feature-name>] [--strict] [--json]` to certify the repository (or one feature) as releasable in one deterministic verdict; it executes no proofs and writes nothing.
 - Use `walden reconcile <feature-name> [--json]` when approved upstream documents changed or the approval chain is stale.
 - Use `walden lesson log --feature <feature-name> --phase requirements|design|tasks|execute|release --trigger "<event>" --lesson "<pattern>" --guardrail "<rule>" [--json]` after meaningful corrections, failed validation, or execution surprises.
 - Use `walden version [--json]` to check the installed CLI version and schema version.
@@ -537,6 +538,15 @@ Execution is for approved specs only.
 - After reconciliation and re-approval, run `walden verify <feature-name>`: completed tasks whose evidence went stale-spec must be re-proven against the updated contract, not assumed.
 - Log a lesson if the gap came from a missed pattern, missing guardrail, or design blind spot.
 - Do not silently rewrite approved requirements or design during implementation.
+
+## Release Certification
+
+- When the user asks whether the work is releasable — or before any tag, release branch, or delivery hand-off — run `walden release check` and report its verdict; do not assemble the answer from separate status checks.
+- The gate certifies and never releases: approved fresh chains, full-spec validation, decision markers in approved documents, execution evidence, and a clean worktree outside `.walden/` fold into one exit code. Tags, changelogs, and publishing stay with you and the user, after certification passes.
+- Read a failed certification as a work list: every blocker names its remedy. Apply the remedies and rerun the gate; never edit state by hand to silence a blocker.
+- Planned-but-unexecuted tasks are informational and never block; pass `--strict` only when the user wants plans-complete certification.
+- The dirty-worktree blocker has no bypass by design: the remedy is committing the work. Do not look for a flag.
+- Compose production and judgment: `walden verify <feature-name>` re-proves execution, then `walden release check` judges the result. In CI, gate the pipeline on the exit code and use `--json` for structure.
 
 ## Self-Improvement Loop
 


### PR DESCRIPTION
## What

\`walden release check [<feature>] [--strict] [--json]\` — the aggregate certification gate for v0.9. Nobody releases a task; you release a repository. The gate composes the guarantees the kernel already enforces into one verdict with one exit code:

| Criterion | Blocks when |
| --- | --- |
| \`chain\` | any document unapproved or stale |
| \`validation\` | full-spec validation fails |
| \`decisions\` | an approved document carries an unresolved \`[decision:]\` marker (HTML comments stripped — assumed notes never count) |
| \`evidence\` | a completed task is not \`verified\` |
| \`worktree\` | uncommitted changes outside \`.walden/\` |

It judges and never executes: no proofs run, nothing is persisted — \`verify\` produces evidence, \`release check\` judges it. That keeps certification at milliseconds and safe on untrusted checkouts.

## Policy

- **Planned work never blocks** — the plan is a promise, not a debt; \`--strict\` opts into plans-complete certification.
- **Dirty worktree fails closed, no bypass flag** — what you certify is exactly what you tag. Dirty \`.walden/\` only warns: a refreshed ledger legitimately precedes its own commit.
- **Every blocker names its remedy** — a failed certification is a work list, not a verdict alone.
- **All criteria always evaluate** — no short-circuiting; the release manager gets the full list.
- The gate's criteria are a public contract from this release: semantic changes are breaking changes.

## Where it lives

\`internal/release\` — its own package above \`workflow\` and \`validation\` (validation already imports workflow; certification crosses every domain). App surface renders through the shared \`emitResult\`/envelope contract with an additive \`release\` block in \`v0beta1\`.

## Skill

The embedded skill gains a Release Certification section: run the gate on releasability questions and before any tag or hand-off, read blockers as a work list, never look for a bypass.

## Testing

- 12 unit matrices on the gate (per criterion, per evidence-state class, strict promotion, sorted walk, ledger bytes untouched, comment-stripped lint) + 6 app-command tests + error-contract row
- 5 e2e scenarios in \`internal/e2e\`: a fully releasable repository certifies; one mutation per blocker class flips it — code edit, spec revival, injected decision marker, uncommitted file — each named with its remedy
- Pre-release battery on three real repositories (todo-app, inlay-studio ×26 features, inlay-atlas): full blocked→remedy→RELEASABLE cycle validated, 26 features certified in 260 ms, JSON envelope consumed programmatically end to end. The battery also caught one lint false-positive class (marker mentioned in prose/assumed comments) — fixed here by stripping HTML comments before the scan.

## Docs

README (Release Certification section, command table, enforcement matrix), docs/workflow.md (§9 Certify + CI recipe \`verify\` → \`release check\`), site positioning (claim, enforcement column, CI recipe), roadmap (release check → current, multi-root identity → near-term).