### PR TITLE
feat: proof execution policy, document evolution contract, release verdict facts

### DIFF
--- a/internal/app/fingerprint_fixtures_test.go
+++ b/internal/app/fingerprint_fixtures_test.go
@@ -34,7 +34,7 @@ func stampSpecFingerprint(t *testing.T, root, featureName, name string) {
 		return
 	}
 
-	document.ApprovedFingerprint = spec.Fingerprint(document.Body)
+	document.ApprovedFingerprint = spec.Fingerprint(document.Path, document.Body)
 	document.Fields["approved_fingerprint"] = document.ApprovedFingerprint
 
 	switch name {
@@ -42,7 +42,7 @@ func stampSpecFingerprint(t *testing.T, root, featureName, name string) {
 		if feature.Requirements.Status == "approved" {
 			fingerprint := feature.Requirements.ApprovedFingerprint
 			if fingerprint == "" {
-				fingerprint = spec.Fingerprint(feature.Requirements.Body)
+				fingerprint = spec.Fingerprint(feature.Requirements.Path, feature.Requirements.Body)
 			}
 			document.SourceRequirementsFingerprint = fingerprint
 			document.Fields["source_requirements_fingerprint"] = fingerprint
@@ -51,7 +51,7 @@ func stampSpecFingerprint(t *testing.T, root, featureName, name string) {
 		if feature.Design.Status == "approved" {
 			fingerprint := feature.Design.ApprovedFingerprint
 			if fingerprint == "" {
-				fingerprint = spec.Fingerprint(feature.Design.Body)
+				fingerprint = spec.Fingerprint(feature.Design.Path, feature.Design.Body)
 			}
 			document.SourceDesignFingerprint = fingerprint
 			document.Fields["source_design_fingerprint"] = fingerprint

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -99,6 +99,9 @@ func releaseCheckResult(report release.ReleaseReport) output.Result {
 	}
 	result.Blockers = append(result.Blockers, report.WorktreeBlockers...)
 	result.Release = status
+	// Facts, not verdicts: both hold whether or not the check is releasable.
+	result.Completion = report.Completion()
+	result.CertifiedCommit = report.CertifiedCommit
 
 	if !report.Strict {
 		// Under strict these paths are already blockers; the not-blocking
@@ -112,6 +115,13 @@ func releaseCheckResult(report release.ReleaseReport) output.Result {
 		result.Summary = fmt.Sprintf("RELEASABLE — %d feature(s) certified", len(report.Features))
 		if pendingTotal > 0 {
 			result.Summary += fmt.Sprintf(", %d task(s) still planned", pendingTotal)
+		}
+		if report.CertifiedCommit != "" {
+			short := report.CertifiedCommit
+			if len(short) > 12 {
+				short = short[:12]
+			}
+			result.Summary += ", commit " + short
 		}
 		return result
 	}

--- a/internal/app/release_additions_test.go
+++ b/internal/app/release_additions_test.go
@@ -1,0 +1,60 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/release"
+)
+
+func TestReleaseEnvelopeCarriesCompletionAndCommit(t *testing.T) {
+	report := release.ReleaseReport{
+		Features: []release.FeatureCertification{
+			{Feature: "demo", Pending: []string{"1.3"}},
+		},
+		CertifiedCommit: "0123456789abcdef0123456789abcdef01234567",
+	}
+
+	result := releaseCheckResult(report)
+
+	if result.Completion != release.CompletionWithPending {
+		t.Fatalf("completion = %q, want %q", result.Completion, release.CompletionWithPending)
+	}
+	if result.CertifiedCommit != report.CertifiedCommit {
+		t.Fatalf("certified_commit = %q, want %q", result.CertifiedCommit, report.CertifiedCommit)
+	}
+	if !strings.Contains(result.Summary, "1 task(s) still planned") {
+		t.Fatalf("summary does not count planned tasks: %q", result.Summary)
+	}
+
+	executed := release.ReleaseReport{Features: []release.FeatureCertification{{Feature: "demo"}}}
+	if got := releaseCheckResult(executed).Completion; got != release.CompletionComplete {
+		t.Fatalf("completion = %q, want %q", got, release.CompletionComplete)
+	}
+}
+
+func TestReleasableSummaryNamesCommit(t *testing.T) {
+	report := release.ReleaseReport{
+		Features:        []release.FeatureCertification{{Feature: "demo"}},
+		CertifiedCommit: "0123456789abcdef0123456789abcdef01234567",
+	}
+
+	result := releaseCheckResult(report)
+	if !strings.Contains(result.Summary, "commit 0123456789ab") {
+		t.Fatalf("releasable summary does not name the short commit: %q", result.Summary)
+	}
+
+	// Blocked verdicts keep their summary untouched; the facts stay in JSON.
+	blocked := release.ReleaseReport{
+		Features:         []release.FeatureCertification{{Feature: "demo"}},
+		WorktreeBlockers: []string{"uncommitted: src.txt — commit it before certifying"},
+		CertifiedCommit:  "0123456789abcdef0123456789abcdef01234567",
+	}
+	blockedResult := releaseCheckResult(blocked)
+	if strings.Contains(blockedResult.Summary, "commit 0123") {
+		t.Fatalf("blocked summary must not carry the commit clause: %q", blockedResult.Summary)
+	}
+	if blockedResult.CertifiedCommit == "" {
+		t.Fatal("blocked result must still expose the commit fact in JSON")
+	}
+}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -91,8 +91,9 @@ func runVersion(args []string, stdout io.Writer, stderr io.Writer) int {
 	jsonMode := parsed.Bool("--json")
 
 	result := output.Result{
-		Summary:  fmt.Sprintf("walden %s (schema %s)", effectiveVersion(), "v0beta1"),
-		ExitCode: 0,
+		Summary:               fmt.Sprintf("walden %s (schema %s, documents %s)", effectiveVersion(), "v0beta1", spec.DocumentSchemaVersion),
+		DocumentSchemaVersion: spec.DocumentSchemaVersion,
+		ExitCode:              0,
 	}
 
 	if jsonMode {

--- a/internal/app/status_test.go
+++ b/internal/app/status_test.go
@@ -159,7 +159,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 # Implementation Plan
 `)
 	// The design approval was recorded against different requirements content.
-	overrideSpecFingerprintField(t, root, "todo-app-demo", "design.md", "source_requirements_fingerprint", spec.Fingerprint("some earlier requirements content"))
+	overrideSpecFingerprintField(t, root, "todo-app-demo", "design.md", "source_requirements_fingerprint", spec.Fingerprint("requirements.md", "some earlier requirements content"))
 
 	previousWD, err := os.Getwd()
 	if err != nil {

--- a/internal/app/verify.go
+++ b/internal/app/verify.go
@@ -61,6 +61,7 @@ func verifyOutputResult(verifyResult workflow.VerifyResult) output.Result {
 	if len(verifyResult.Pruned) > 0 && !verifyResult.Checked {
 		result.Warnings = append(result.Warnings, fmt.Sprintf("pruned %d orphaned evidence entr%s no longer in the plan: %s", len(verifyResult.Pruned), map[bool]string{true: "y", false: "ies"}[len(verifyResult.Pruned) == 1], strings.Join(verifyResult.Pruned, ", ")))
 	}
+	result.Warnings = append(result.Warnings, verifyResult.Warnings...)
 	switch {
 	case len(verifyResult.Failed) > 0:
 		result.Summary = fmt.Sprintf("verification failed for %s: %s%s", verifyResult.Feature, strings.Join(verifyResult.Failed, ", "), suffix)

--- a/internal/app/verify_warnings_test.go
+++ b/internal/app/verify_warnings_test.go
@@ -1,0 +1,25 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/workflow"
+)
+
+func TestVerifyEnvelopeCarriesWarnings(t *testing.T) {
+	result := verifyOutputResult(workflow.VerifyResult{
+		Feature:  "demo",
+		Warnings: []string{"proof side effects modified the repository: generated.txt"},
+	})
+
+	found := false
+	for _, warning := range result.Warnings {
+		if strings.Contains(warning, "proof side effects modified the repository") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected the purity warning in the envelope result, got %v", result.Warnings)
+	}
+}

--- a/internal/app/version_schema_test.go
+++ b/internal/app/version_schema_test.go
@@ -1,0 +1,35 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/spec"
+)
+
+func TestVersionReportsDocumentSchema(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	if exitCode := Run([]string{"version", "--json"}, &stdout, &stderr); exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr: %s)", exitCode, stderr.String())
+	}
+
+	var envelope struct {
+		Result struct {
+			Summary               string `json:"summary"`
+			DocumentSchemaVersion string `json:"document_schema_version"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("parse version envelope: %v", err)
+	}
+	if envelope.Result.DocumentSchemaVersion != spec.DocumentSchemaVersion {
+		t.Fatalf("document_schema_version = %q, want %q", envelope.Result.DocumentSchemaVersion, spec.DocumentSchemaVersion)
+	}
+	if !strings.Contains(envelope.Result.Summary, spec.DocumentSchemaVersion) {
+		t.Fatalf("summary does not mention the document schema: %q", envelope.Result.Summary)
+	}
+}

--- a/internal/evidence/identity.go
+++ b/internal/evidence/identity.go
@@ -17,39 +17,78 @@ import (
 // never invalidate the evidence it carries.
 const waldenDir = ".walden"
 
-// Identity derives a deterministic identity of the working tree as one
-// uniform path→blob map: the .walden-filtered HEAD listing seeds committed
-// blob ids, and every dirty or untracked path overrides its entry with the
-// blob id of its current content (git hash-object). Uniform blob ids on both
-// layers mean committing an unchanged file never moves the identity.
-// Identical content yields identical identities regardless of branch names,
-// timestamps, or .walden contents. The second return is false when git is
-// unavailable — callers record the absence and continue.
-func Identity(ctx context.Context, runner shell.Runner, root string) (string, bool) {
+// Manifest is the working tree's uniform path→"mode:blob" map — the raw
+// material of the code identity, exported so re-verification can attribute a
+// working-tree change to the proof that ran between two captures and name
+// the paths involved.
+type Manifest map[string]string
+
+// CaptureManifest derives the deterministic manifest of the working tree:
+// the .walden-filtered HEAD listing seeds committed blob ids, and every
+// dirty or untracked path overrides its entry with the blob id of its
+// current content (git hash-object). Uniform blob ids on both layers mean
+// committing an unchanged file never moves the manifest. The second return
+// is false when git is unavailable — callers record the absence and continue.
+func CaptureManifest(ctx context.Context, runner shell.Runner, root string) (Manifest, bool) {
 	status, err := runner.Run(ctx, "git", "-C", root, "status", "--porcelain", "--untracked-files=all", "-z", "--", ".", ":(exclude)"+waldenDir)
 	if err != nil || status.ExitCode != 0 {
-		return "", false
+		return nil, false
 	}
 
 	// Unborn HEAD (no commits yet) degrades to the overlay alone; the
 	// repository itself is proven present by the successful status call.
-	blobs := map[string]string{}
+	blobs := Manifest{}
 	if lsTree, err := runner.Run(ctx, "git", "-C", root, "ls-tree", "-r", "HEAD"); err == nil && lsTree.ExitCode == 0 {
 		seedListing(blobs, lsTree.Stdout)
 	}
 
 	if !applyOverlay(ctx, runner, root, status.Stdout, blobs) {
-		return "", false
+		return nil, false
 	}
+	return blobs, true
+}
 
-	entries := make([]string, 0, len(blobs))
-	for path, blob := range blobs {
+// Digest folds the manifest into the identity string. Identical content
+// yields identical digests regardless of branch names, timestamps, or
+// .walden contents.
+func (m Manifest) Digest() string {
+	entries := make([]string, 0, len(m))
+	for path, blob := range m {
 		entries = append(entries, path+":"+blob)
 	}
 	sort.Strings(entries)
 
 	sum := sha256.Sum256([]byte(strings.Join(entries, "\n")))
-	return "sha256:" + hex.EncodeToString(sum[:]), true
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// DiffPaths returns the sorted union of paths whose entries differ between
+// two manifests: added, removed, or content-changed.
+func DiffPaths(before, after Manifest) []string {
+	changed := []string{}
+	for path, blob := range before {
+		if other, exists := after[path]; !exists || other != blob {
+			changed = append(changed, path)
+		}
+	}
+	for path := range after {
+		if _, exists := before[path]; !exists {
+			changed = append(changed, path)
+		}
+	}
+	sort.Strings(changed)
+	return changed
+}
+
+// Identity derives the deterministic identity of the working tree — the
+// digest of its manifest. The second return is false when git is
+// unavailable.
+func Identity(ctx context.Context, runner shell.Runner, root string) (string, bool) {
+	manifest, ok := CaptureManifest(ctx, runner, root)
+	if !ok {
+		return "", false
+	}
+	return manifest.Digest(), true
 }
 
 // seedListing fills the map from a `git ls-tree -r HEAD` listing (format:

--- a/internal/evidence/manifest_test.go
+++ b/internal/evidence/manifest_test.go
@@ -1,0 +1,74 @@
+package evidence
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/shell"
+)
+
+func TestCaptureManifestDigestMatchesIdentity(t *testing.T) {
+	root := t.TempDir()
+	fixture := func() *fakeGit {
+		return &fakeGit{responses: map[string]shell.Response{
+			"status": {ExitCode: 0},
+			"ls-tree": {ExitCode: 0, Stdout: lsTreeListing(
+				"100644 blob aaa\tmain.go",
+				"100755 blob bbb\tscripts/run.sh",
+			)},
+		}}
+	}
+
+	identity, ok := Identity(context.Background(), fixture(), root)
+	if !ok {
+		t.Fatal("identity not computed")
+	}
+	manifest, ok := CaptureManifest(context.Background(), fixture(), root)
+	if !ok {
+		t.Fatal("manifest not captured")
+	}
+
+	if digest := manifest.Digest(); digest != identity {
+		t.Fatalf("manifest digest diverged from identity: %s vs %s", digest, identity)
+	}
+	if len(manifest) != 2 {
+		t.Fatalf("expected 2 manifest entries, got %d", len(manifest))
+	}
+	if blob := manifest["main.go"]; blob != "100644:aaa" {
+		t.Fatalf("unexpected manifest entry for main.go: %q", blob)
+	}
+}
+
+func TestCaptureManifestUnavailableGit(t *testing.T) {
+	root := t.TempDir()
+	failing := &fakeGit{responses: map[string]shell.Response{
+		"status": {ExitCode: 128},
+	}}
+
+	if manifest, ok := CaptureManifest(context.Background(), failing, root); ok {
+		t.Fatalf("expected capture to report unavailable git, got %v", manifest)
+	}
+}
+
+func TestDiffPaths(t *testing.T) {
+	before := Manifest{
+		"main.go":   "100644:aaa",
+		"go.mod":    "100644:mmm",
+		"README.md": "100644:rrr",
+	}
+	after := Manifest{
+		"main.go":   "100644:aaa",
+		"go.mod":    "100644:changed",
+		"build/out": "100755:nnn",
+	}
+
+	diff := DiffPaths(before, after)
+	if got, want := strings.Join(diff, ","), "README.md,build/out,go.mod"; got != want {
+		t.Fatalf("unexpected diff paths: %q, want %q", got, want)
+	}
+
+	if diff := DiffPaths(before, before); len(diff) != 0 {
+		t.Fatalf("expected empty diff for identical manifests, got %v", diff)
+	}
+}

--- a/internal/output/result.go
+++ b/internal/output/result.go
@@ -22,6 +22,8 @@ type Result struct {
 	GitAlreadyInitialized bool                `json:"git_already_initialized,omitempty"`
 	CurrentPhase          string              `json:"current_phase,omitempty"`
 	DocumentSchemaVersion string              `json:"document_schema_version,omitempty"`
+	Completion            string              `json:"completion,omitempty"`
+	CertifiedCommit       string              `json:"certified_commit,omitempty"`
 	BranchName            string              `json:"branch_name,omitempty"`
 	Document              string              `json:"document,omitempty"`
 	Documents             []DocumentStatus    `json:"documents,omitempty"`

--- a/internal/output/result.go
+++ b/internal/output/result.go
@@ -21,6 +21,7 @@ type Result struct {
 	GitInitialized        bool                `json:"git_initialized,omitempty"`
 	GitAlreadyInitialized bool                `json:"git_already_initialized,omitempty"`
 	CurrentPhase          string              `json:"current_phase,omitempty"`
+	DocumentSchemaVersion string              `json:"document_schema_version,omitempty"`
 	BranchName            string              `json:"branch_name,omitempty"`
 	Document              string              `json:"document,omitempty"`
 	Documents             []DocumentStatus    `json:"documents,omitempty"`

--- a/internal/release/check.go
+++ b/internal/release/check.go
@@ -45,6 +45,10 @@ type ReleaseReport struct {
 	WaldenDirty      []string
 	GitSkipped       bool
 	Strict           bool
+	// CertifiedCommit is the HEAD revision the certification ran against —
+	// the commit an auditor checks out. Empty when git is unusable (already
+	// a repository-level blocker) or HEAD is unborn.
+	CertifiedCommit string
 }
 
 // BlockerCount sums every blocker across features and the worktree.
@@ -60,6 +64,26 @@ func (r ReleaseReport) BlockerCount() int {
 
 // Releasable reports the verdict.
 func (r ReleaseReport) Releasable() bool { return r.BlockerCount() == 0 }
+
+// Completion classes: the verdict's answer to "was anything still planned
+// when this certification ran?". `with-waivers` is reserved for the v0.10.0
+// strict-by-default flip.
+const (
+	CompletionComplete    = "complete"
+	CompletionWithPending = "with-pending"
+)
+
+// Completion derives the completion class from the certified features'
+// pending lists — a reading of report state, never stored input, so it can
+// never disagree with the data it summarizes.
+func (r ReleaseReport) Completion() string {
+	for _, feature := range r.Features {
+		if len(feature.Pending) > 0 {
+			return CompletionWithPending
+		}
+	}
+	return CompletionComplete
+}
 
 // ReleaseCheck certifies one feature (or, with an empty name, every feature
 // under .walden/specs/ in sorted order) against the release criteria. It
@@ -77,6 +101,13 @@ func ReleaseCheck(ctx context.Context, root, featureName string, strict bool) (R
 	identity, identityOK := evidence.Identity(ctx, gitRunner, root)
 
 	report := ReleaseReport{Strict: strict}
+	// The revision being certified: identity proves what tree, the commit
+	// names where in history. Failure leaves it empty — unusable git is
+	// already a blocker below, and an unborn HEAD cannot pass the worktree
+	// criterion.
+	if head, err := gitRunner.Run(ctx, "git", "-C", root, "rev-parse", "HEAD"); err == nil && head.ExitCode == 0 {
+		report.CertifiedCommit = strings.TrimSpace(head.Stdout)
+	}
 	for _, name := range features {
 		report.Features = append(report.Features, certifyFeature(root, name, strict, identity, identityOK))
 	}

--- a/internal/release/readonly_test.go
+++ b/internal/release/readonly_test.go
@@ -1,0 +1,53 @@
+package release
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// The gate judges and never writes: after a full certification the worktree
+// is byte-identical — no proof ran, no state moved.
+func TestReleaseCheckStaysReadOnly(t *testing.T) {
+	root := gateRepo(t)
+
+	ledgerPath := filepath.Join(root, ".walden", "evidence", "gate-demo.json")
+	ledgerBefore, err := os.ReadFile(ledgerPath)
+	if err != nil {
+		t.Fatalf("read ledger before: %v", err)
+	}
+
+	statusOf := func() string {
+		command := exec.Command("git", "status", "--porcelain")
+		command.Dir = root
+		out, err := command.Output()
+		if err != nil {
+			t.Fatalf("git status: %v", err)
+		}
+		return string(out)
+	}
+	if before := statusOf(); before != "" {
+		t.Fatalf("fixture not clean before the check: %q", before)
+	}
+
+	report, err := ReleaseCheck(context.Background(), root, "", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck: %v", err)
+	}
+	if !report.Releasable() {
+		t.Fatalf("green fixture not releasable: %+v", report)
+	}
+
+	if after := statusOf(); after != "" {
+		t.Fatalf("release check dirtied the worktree: %q", after)
+	}
+	ledgerAfter, err := os.ReadFile(ledgerPath)
+	if err != nil {
+		t.Fatalf("read ledger after: %v", err)
+	}
+	if string(ledgerBefore) != string(ledgerAfter) {
+		t.Fatal("release check modified the evidence ledger")
+	}
+}

--- a/internal/release/report_additions_test.go
+++ b/internal/release/report_additions_test.go
@@ -1,0 +1,79 @@
+package release
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/testutil"
+	"github.com/andrearaponi/walden/internal/workflow"
+)
+
+func TestReleaseReportCompletion(t *testing.T) {
+	complete := ReleaseReport{Features: []FeatureCertification{{Feature: "a"}, {Feature: "b"}}}
+	if got := complete.Completion(); got != CompletionComplete {
+		t.Fatalf("no pending tasks classified as %q, want %q", got, CompletionComplete)
+	}
+
+	withPending := ReleaseReport{Features: []FeatureCertification{
+		{Feature: "a"},
+		{Feature: "b", Pending: []string{"1.2"}},
+	}}
+	if got := withPending.Completion(); got != CompletionWithPending {
+		t.Fatalf("pending tasks classified as %q, want %q", got, CompletionWithPending)
+	}
+
+	// Integration: the green gate repo has every task executed.
+	root := gateRepo(t)
+	report, err := ReleaseCheck(context.Background(), root, "gate-demo", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck: %v", err)
+	}
+	if !report.Releasable() || report.Completion() != CompletionComplete {
+		t.Fatalf("green repo completion = %q (releasable=%t), want complete", report.Completion(), report.Releasable())
+	}
+}
+
+func TestReleaseCheckCertifiedCommit(t *testing.T) {
+	root := gateRepo(t)
+
+	head := exec.Command("git", "rev-parse", "HEAD")
+	head.Dir = root
+	out, err := head.Output()
+	if err != nil {
+		t.Fatalf("rev-parse fixture HEAD: %v", err)
+	}
+	expected := strings.TrimSpace(string(out))
+
+	report, err := ReleaseCheck(context.Background(), root, "gate-demo", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck: %v", err)
+	}
+	if report.CertifiedCommit != expected {
+		t.Fatalf("certified commit = %q, want %q", report.CertifiedCommit, expected)
+	}
+}
+
+func TestReleaseCheckCertifiedCommitEmptyWithoutGit(t *testing.T) {
+	root := t.TempDir()
+	addFeature(t, root, "gate-demo", certifiableRequirements(), certifiableDesign(""), certifiableTasks())
+	runner := testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+	)
+	if _, err := workflow.CompleteAllTasks(context.Background(), root, "gate-demo", runner); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	report, err := ReleaseCheck(context.Background(), root, "gate-demo", false)
+	if err != nil {
+		t.Fatalf("ReleaseCheck: %v", err)
+	}
+	if report.CertifiedCommit != "" {
+		t.Fatalf("expected empty certified commit without git, got %q", report.CertifiedCommit)
+	}
+	if report.Releasable() {
+		t.Fatal("a repository without git must stay blocked (existing fail-closed contract)")
+	}
+}

--- a/internal/repo/feature.go
+++ b/internal/repo/feature.go
@@ -128,7 +128,10 @@ func renderSpecTemplate(templateFS fs.FS, name, timestamp string) ([]byte, error
 	}
 
 	var rendered bytes.Buffer
-	if err := tmpl.Execute(&rendered, struct{ Timestamp string }{Timestamp: timestamp}); err != nil {
+	if err := tmpl.Execute(&rendered, struct {
+		Timestamp     string
+		SchemaVersion string
+	}{Timestamp: timestamp, SchemaVersion: spec.DocumentSchemaVersion}); err != nil {
 		return nil, fmt.Errorf("render spec template %q: %w", name, err)
 	}
 

--- a/internal/repo/feature_schema_test.go
+++ b/internal/repo/feature_schema_test.go
@@ -1,0 +1,32 @@
+package repo
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/spec"
+)
+
+func TestScaffoldedDocumentsCarrySchemaVersion(t *testing.T) {
+	root := t.TempDir()
+	mustMkdir(t, filepath.Join(root, ".git"))
+	if _, err := Init(root, "v0.9.1"); err != nil {
+		t.Fatalf("repo init: %v", err)
+	}
+	if _, err := InitFeature(root, "demo"); err != nil {
+		t.Fatalf("feature init: %v", err)
+	}
+
+	for _, name := range []string{"requirements.md", "design.md", "tasks.md"} {
+		content, err := os.ReadFile(filepath.Join(root, ".walden", "specs", "demo", name))
+		if err != nil {
+			t.Fatalf("read scaffolded %s: %v", name, err)
+		}
+		want := "walden_schema_version: " + spec.DocumentSchemaVersion + "\n"
+		if !strings.Contains(string(content), want) {
+			t.Fatalf("%s scaffold lacks the schema version field:\n%s", name, content)
+		}
+	}
+}

--- a/internal/shell/exec_runner.go
+++ b/internal/shell/exec_runner.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"os/exec"
+	"time"
 )
 
 type execRunner struct{}
@@ -14,8 +15,15 @@ func NewExecRunner() Runner {
 	return execRunner{}
 }
 
+// waitDelay bounds how long Run waits for the output pipes after the process
+// exits or the context is canceled: a proof that leaves an orphan holding
+// stdout must surface as an explicit error, never as a hang.
+var waitDelay = 5 * time.Second
+
 func (execRunner) Run(ctx context.Context, name string, args ...string) (Response, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
+	configureProcessContainment(cmd)
+	cmd.WaitDelay = waitDelay
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/shell/exec_runner_other.go
+++ b/internal/shell/exec_runner_other.go
@@ -1,0 +1,10 @@
+//go:build !unix
+
+package shell
+
+import "os/exec"
+
+// configureProcessContainment is a no-op outside unix: context cancellation
+// falls back to killing the direct process only. Released binaries target
+// linux and darwin, both unix.
+func configureProcessContainment(cmd *exec.Cmd) {}

--- a/internal/shell/exec_runner_unix.go
+++ b/internal/shell/exec_runner_unix.go
@@ -1,0 +1,27 @@
+//go:build unix
+
+package shell
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// configureProcessContainment places the command in its own process group and
+// makes context cancellation kill the whole group: proof steps spawn children
+// (sh -c pipelines, test binaries), and killing only the direct child would
+// leak them past a timeout.
+func configureProcessContainment(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if err == syscall.ESRCH {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+}

--- a/internal/shell/exec_runner_unix_test.go
+++ b/internal/shell/exec_runner_unix_test.go
@@ -1,0 +1,51 @@
+//go:build unix
+
+package shell
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// The group kill must reap the whole tree well before the WaitDelay backstop:
+// a long backstop here proves termination is doing the work.
+func TestRunnerKillsProcessGroupOnDeadline(t *testing.T) {
+	previous := waitDelay
+	waitDelay = 10 * time.Second
+	defer func() { waitDelay = previous }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	started := time.Now()
+	response, _ := NewExecRunner().Run(ctx, "sh", "-c", "sleep 60 & wait")
+	elapsed := time.Since(started)
+
+	if elapsed > 3*time.Second {
+		t.Fatalf("expected prompt return after group kill, took %s", elapsed)
+	}
+	if response.ExitCode == 0 {
+		t.Fatalf("expected non-zero exit for killed proof, got %d", response.ExitCode)
+	}
+}
+
+// A proof that exits successfully but leaves an orphan holding the output
+// pipes must return within the WaitDelay bound as an explicit error — before
+// this containment it hung until the orphan exited.
+func TestRunnerReturnsDespiteOrphanPipe(t *testing.T) {
+	previous := waitDelay
+	waitDelay = 1 * time.Second
+	defer func() { waitDelay = previous }()
+
+	started := time.Now()
+	_, err := NewExecRunner().Run(context.Background(), "sh", "-c", "(sleep 60 &); exit 0")
+	elapsed := time.Since(started)
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("expected return within the wait-delay bound, took %s", elapsed)
+	}
+	if err == nil {
+		t.Fatal("expected an explicit error for an orphan holding the pipes")
+	}
+}

--- a/internal/spec/extensions_test.go
+++ b/internal/spec/extensions_test.go
@@ -1,0 +1,140 @@
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func extensionDocument(path string) Document {
+	return Document{
+		Path:   path,
+		Status: "draft",
+		Fields: map[string]string{
+			"status":               "draft",
+			"approved_at":          "",
+			"last_modified":        "2026-07-16T10:00:00Z",
+			"approved_fingerprint": "",
+			"x-review-url":         "https://example.test/pr/42",
+			"x-approver":           "team-platform",
+		},
+		Exists: true,
+		Body:   "# Requirements Document\n\nBody.\n",
+	}
+}
+
+func TestSaveDocumentPreservesExtensions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "requirements.md")
+
+	if err := SaveDocument(extensionDocument(path)); err != nil {
+		t.Fatalf("SaveDocument: %v", err)
+	}
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved document: %v", err)
+	}
+
+	// Extensions come after the core keys, lexicographically ordered.
+	content := string(first)
+	frontmatter := content[:strings.Index(content, "\n---\n")]
+	approverIndex := strings.Index(frontmatter, "x-approver: team-platform")
+	reviewIndex := strings.Index(frontmatter, "x-review-url: https://example.test/pr/42")
+	coreIndex := strings.Index(frontmatter, "approved_fingerprint:")
+	if approverIndex < 0 || reviewIndex < 0 {
+		t.Fatalf("extensions missing from serialized frontmatter:\n%s", frontmatter)
+	}
+	if !(coreIndex < approverIndex && approverIndex < reviewIndex) {
+		t.Fatalf("extension ordering wrong (core=%d, approver=%d, review=%d):\n%s", coreIndex, approverIndex, reviewIndex, frontmatter)
+	}
+
+	// Round trip: values verbatim after reload.
+	loaded, err := loadDocument(path)
+	if err != nil {
+		t.Fatalf("loadDocument: %v", err)
+	}
+	if loaded.Fields["x-review-url"] != "https://example.test/pr/42" || loaded.Fields["x-approver"] != "team-platform" {
+		t.Fatalf("extension values not preserved verbatim: %v", loaded.Fields)
+	}
+
+	// Determinism: saving the reloaded document produces identical bytes.
+	if err := SaveDocument(loaded); err != nil {
+		t.Fatalf("second SaveDocument: %v", err)
+	}
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read re-saved document: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatalf("serialization is not byte-deterministic:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+}
+
+func TestLoaderRejectsUnknownField(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "requirements.md")
+	content := "---\nstatus: draft\napproved_at: \nlast_modified: 2026-07-16T10:00:00Z\napproved_fingerprint: \naproved_at: 2026-07-16T10:00:00Z\n---\n\n# Requirements Document\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write document: %v", err)
+	}
+
+	_, err := loadDocument(path)
+	if err == nil {
+		t.Fatal("expected the loader to reject the unknown field")
+	}
+	for _, fragment := range []string{`"aproved_at"`, `"x-aproved_at"`, "or remove it", path} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Fatalf("rejection missing %q: %v", fragment, err)
+		}
+	}
+}
+
+func TestVersionErrorPrecedesUnknownField(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "requirements.md")
+	content := "---\nwalden_schema_version: v9alpha9\nstatus: draft\napproved_at: \nlast_modified: 2026-07-16T10:00:00Z\napproved_fingerprint: \nstray_field: junk\n---\n\n# Requirements Document\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write document: %v", err)
+	}
+
+	_, err := loadDocument(path)
+	if err == nil {
+		t.Fatal("expected a refusal")
+	}
+	if !strings.Contains(err.Error(), "walden_schema_version") {
+		t.Fatalf("expected the schema-version error first, got %v", err)
+	}
+	if strings.Contains(err.Error(), "unknown frontmatter field") {
+		t.Fatalf("unknown-field error must not precede the version error: %v", err)
+	}
+}
+
+func TestApprovalFingerprintIgnoresFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	plainPath := filepath.Join(dir, "plain", "requirements.md")
+	extendedPath := filepath.Join(dir, "extended", "requirements.md")
+
+	plain := extensionDocument(plainPath)
+	delete(plain.Fields, "x-review-url")
+	delete(plain.Fields, "x-approver")
+	extended := extensionDocument(extendedPath)
+
+	for _, document := range []Document{plain, extended} {
+		if err := SaveDocument(document); err != nil {
+			t.Fatalf("SaveDocument: %v", err)
+		}
+	}
+	loadedPlain, err := loadDocument(plainPath)
+	if err != nil {
+		t.Fatalf("load plain: %v", err)
+	}
+	loadedExtended, err := loadDocument(extendedPath)
+	if err != nil {
+		t.Fatalf("load extended: %v", err)
+	}
+
+	if Fingerprint(loadedPlain.Path, loadedPlain.Body) != Fingerprint(loadedExtended.Path, loadedExtended.Body) {
+		t.Fatal("frontmatter extensions leaked into the body fingerprint")
+	}
+}

--- a/internal/spec/feature.go
+++ b/internal/spec/feature.go
@@ -105,6 +105,12 @@ func loadDocument(path string) (Document, error) {
 	if err != nil {
 		return Document{}, err
 	}
+	if err := checkDocumentSchemaVersion(path, values.Fields); err != nil {
+		return Document{}, err
+	}
+	if err := checkUnknownFrontmatterFields(path, values.Fields); err != nil {
+		return Document{}, err
+	}
 
 	return Document{
 		Path:                          path,

--- a/internal/spec/fingerprint.go
+++ b/internal/spec/fingerprint.go
@@ -3,6 +3,7 @@ package spec
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -16,13 +17,14 @@ var (
 
 // Fingerprint computes the canonical content fingerprint of a document body.
 // Normalization is deliberately minimal and versioned by design: CRLF and CR
-// become LF, checked task markers (`- [x]` / `- [X]` as a line's first token)
-// are fingerprinted as unchecked — checkbox state is execution progress owned
-// by `task complete`, not approved content — then leading and trailing
-// whitespace is trimmed. Changing this normalization re-fingerprints
-// identical content and is a breaking change.
-func Fingerprint(body string) string {
-	sum := sha256.Sum256([]byte(normalizeBody(body)))
+// become LF; in tasks.md — and only there — checked task markers (`- [x]` /
+// `- [X]` as a line's first token) are fingerprinted as unchecked, because
+// checkbox state there is execution progress owned by `task complete`, not
+// approved content; in every other document a checkbox is content. Then
+// leading and trailing whitespace is trimmed. Changing this normalization
+// re-fingerprints identical content and is a breaking change.
+func Fingerprint(documentPath, body string) string {
+	sum := sha256.Sum256([]byte(normalizeBody(documentPath, body)))
 	return fingerprintPrefix + hex.EncodeToString(sum[:])
 }
 
@@ -33,16 +35,18 @@ func ValidFingerprint(value string) bool {
 
 // BodyMatchesFingerprint reports whether the body's fingerprint equals the
 // recorded value. Malformed recorded values never match (fail-closed).
-func BodyMatchesFingerprint(body, fingerprint string) bool {
+func BodyMatchesFingerprint(documentPath, body, fingerprint string) bool {
 	if !ValidFingerprint(fingerprint) {
 		return false
 	}
-	return Fingerprint(body) == fingerprint
+	return Fingerprint(documentPath, body) == fingerprint
 }
 
-func normalizeBody(body string) string {
+func normalizeBody(documentPath, body string) string {
 	normalized := strings.ReplaceAll(body, "\r\n", "\n")
 	normalized = strings.ReplaceAll(normalized, "\r", "\n")
-	normalized = checkedTaskPattern.ReplaceAllString(normalized, "${1}- [ ]")
+	if filepath.Base(documentPath) == "tasks.md" {
+		normalized = checkedTaskPattern.ReplaceAllString(normalized, "${1}- [ ]")
+	}
 	return strings.TrimSpace(normalized)
 }

--- a/internal/spec/fingerprint_roundtrip_test.go
+++ b/internal/spec/fingerprint_roundtrip_test.go
@@ -11,7 +11,7 @@ func TestFingerprintFieldsRoundTrip(t *testing.T) {
 	path := filepath.Join(dir, "design.md")
 
 	body := "# Feature Design\n\nContent under review.\n"
-	fingerprint := Fingerprint(body)
+	fingerprint := Fingerprint(path, body)
 
 	document := Document{
 		Path:   path,
@@ -43,7 +43,7 @@ func TestFingerprintFieldsRoundTrip(t *testing.T) {
 	if loaded.SourceRequirementsFingerprint != fingerprint {
 		t.Fatalf("SourceRequirementsFingerprint = %q, want %q", loaded.SourceRequirementsFingerprint, fingerprint)
 	}
-	if got := Fingerprint(loaded.Body); got != fingerprint {
+	if got := Fingerprint(path, loaded.Body); got != fingerprint {
 		t.Fatalf("body fingerprint changed across save/load round-trip: %q != %q", got, fingerprint)
 	}
 }
@@ -53,7 +53,7 @@ func TestFingerprintUnchangedByFrontmatterOnlyEdit(t *testing.T) {
 	path := filepath.Join(dir, "requirements.md")
 
 	body := "# Requirements Document\n\n1. `R1.AC1` WHEN x, the system SHALL y.\n"
-	fingerprint := Fingerprint(body)
+	fingerprint := Fingerprint(path, body)
 
 	document := Document{
 		Path:   path,
@@ -82,7 +82,7 @@ func TestFingerprintUnchangedByFrontmatterOnlyEdit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadDocument: %v", err)
 	}
-	if got := Fingerprint(loaded.Body); got != fingerprint {
+	if got := Fingerprint(path, loaded.Body); got != fingerprint {
 		t.Fatalf("frontmatter-only edit changed the body fingerprint: %q != %q", got, fingerprint)
 	}
 }
@@ -94,16 +94,16 @@ func TestFingerprintResetClearsFields(t *testing.T) {
 		Status:                  "approved",
 		ApprovedAt:              "2026-07-02T08:00:00Z",
 		LastModified:            "2026-07-02T08:00:00Z",
-		ApprovedFingerprint:     Fingerprint(body),
+		ApprovedFingerprint:     Fingerprint("tasks.md", body),
 		SourceDesignApprovedAt:  "2026-07-02T07:50:00Z",
-		SourceDesignFingerprint: Fingerprint("design body"),
+		SourceDesignFingerprint: Fingerprint("design.md", "design body"),
 		Fields: map[string]string{
 			"status":                    "approved",
 			"approved_at":               "2026-07-02T08:00:00Z",
 			"last_modified":             "2026-07-02T08:00:00Z",
-			"approved_fingerprint":      Fingerprint(body),
+			"approved_fingerprint":      Fingerprint("tasks.md", body),
 			"source_design_approved_at": "2026-07-02T07:50:00Z",
-			"source_design_fingerprint": Fingerprint("design body"),
+			"source_design_fingerprint": Fingerprint("design.md", "design body"),
 		},
 		Exists: true,
 		Body:   body,

--- a/internal/spec/fingerprint_scope_test.go
+++ b/internal/spec/fingerprint_scope_test.go
@@ -1,0 +1,38 @@
+package spec
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestFingerprintScopesCheckboxNormalization(t *testing.T) {
+	checked := "# Document\n\n- [x] 1. Item\n"
+	unchecked := "# Document\n\n- [ ] 1. Item\n"
+
+	// tasks.md: checkbox state is execution progress — identical fingerprints.
+	if Fingerprint("specs/f/tasks.md", checked) != Fingerprint("specs/f/tasks.md", unchecked) {
+		t.Fatal("tasks.md checkbox state moved the fingerprint")
+	}
+
+	// requirements.md and design.md: a checkbox is content — state distinguishes.
+	if Fingerprint("specs/f/requirements.md", checked) == Fingerprint("specs/f/requirements.md", unchecked) {
+		t.Fatal("requirements.md checkbox state did not move the fingerprint")
+	}
+	if Fingerprint("specs/f/design.md", checked) == Fingerprint("specs/f/design.md", unchecked) {
+		t.Fatal("design.md checkbox state did not move the fingerprint")
+	}
+
+	// Marker-free bodies keep the pre-scoping digest in every document type:
+	// the normalization pipeline reduces to line endings plus trim, so the
+	// digest equals the direct hash of the trimmed body.
+	body := "# Requirements Document\n\nNo markers here.\n"
+	sum := sha256.Sum256([]byte(strings.TrimSpace(body)))
+	expected := "sha256:" + hex.EncodeToString(sum[:])
+	for _, documentPath := range []string{"requirements.md", "design.md", "tasks.md"} {
+		if got := Fingerprint(documentPath, body); got != expected {
+			t.Fatalf("marker-free fingerprint moved for %s: %s != %s", documentPath, got, expected)
+		}
+	}
+}

--- a/internal/spec/fingerprint_test.go
+++ b/internal/spec/fingerprint_test.go
@@ -34,7 +34,7 @@ func TestFingerprintGoldenVectors(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := Fingerprint(test.body); got != test.want {
+			if got := Fingerprint("requirements.md", test.body); got != test.want {
 				t.Fatalf("Fingerprint(%q) = %q, want %q", test.body, got, test.want)
 			}
 		})
@@ -42,7 +42,7 @@ func TestFingerprintGoldenVectors(t *testing.T) {
 }
 
 func TestFingerprintLineEndingNormalization(t *testing.T) {
-	reference := Fingerprint("# Title\n\nBody line one\nBody line two\n")
+	reference := Fingerprint("requirements.md", "# Title\n\nBody line one\nBody line two\n")
 
 	tests := []struct {
 		name string
@@ -56,7 +56,7 @@ func TestFingerprintLineEndingNormalization(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := Fingerprint(test.body); got != reference {
+			if got := Fingerprint("requirements.md", test.body); got != reference {
 				t.Fatalf("Fingerprint(%q) = %q, want reference %q", test.body, got, reference)
 			}
 		})
@@ -68,11 +68,11 @@ func TestFingerprintCheckboxStateInsensitivity(t *testing.T) {
 	partiallyChecked := "# Implementation Plan\n\n- [ ] 1. Objective\n  - [x] 1.1 Step one\n  - [ ] 1.2 Step two\n"
 	fullyChecked := "# Implementation Plan\n\n- [x] 1. Objective\n  - [x] 1.1 Step one\n  - [X] 1.2 Step two\n"
 
-	reference := Fingerprint(unchecked)
-	if got := Fingerprint(partiallyChecked); got != reference {
+	reference := Fingerprint("tasks.md", unchecked)
+	if got := Fingerprint("tasks.md", partiallyChecked); got != reference {
 		t.Fatalf("partially checked plan fingerprint diverged: %q != %q", got, reference)
 	}
-	if got := Fingerprint(fullyChecked); got != reference {
+	if got := Fingerprint("tasks.md", fullyChecked); got != reference {
 		t.Fatalf("fully checked plan fingerprint diverged: %q != %q", got, reference)
 	}
 }
@@ -80,35 +80,35 @@ func TestFingerprintCheckboxStateInsensitivity(t *testing.T) {
 func TestFingerprintCheckboxNormalizationScope(t *testing.T) {
 	// Only a line's leading task marker is normalized: inline bracket text
 	// and non-list lines remain distinguishing content.
-	if Fingerprint("verify the [x] flag") == Fingerprint("verify the [ ] flag") {
+	if Fingerprint("tasks.md", "verify the [x] flag") == Fingerprint("tasks.md", "verify the [ ] flag") {
 		t.Fatal("inline bracket text must remain distinguishing content")
 	}
-	if Fingerprint("- [x] done") != Fingerprint("- [ ] done") {
+	if Fingerprint("tasks.md", "- [x] done") != Fingerprint("tasks.md", "- [ ] done") {
 		t.Fatal("leading task marker must be normalized")
 	}
-	if Fingerprint("note - [x] not a marker") == Fingerprint("note - [ ] not a marker") {
+	if Fingerprint("tasks.md", "note - [x] not a marker") == Fingerprint("tasks.md", "note - [ ] not a marker") {
 		t.Fatal("mid-line dashes must not be treated as task markers")
 	}
 }
 
 func TestFingerprintIsDeterministic(t *testing.T) {
 	body := "# Requirements\n\n1. `R1.AC1` WHEN x, the system SHALL y.\n"
-	first := Fingerprint(body)
+	first := Fingerprint("requirements.md", body)
 	for i := 0; i < 100; i++ {
-		if got := Fingerprint(body); got != first {
+		if got := Fingerprint("requirements.md", body); got != first {
 			t.Fatalf("Fingerprint is not deterministic: %q != %q", got, first)
 		}
 	}
 }
 
 func TestFingerprintDistinguishesContent(t *testing.T) {
-	if Fingerprint("alpha") == Fingerprint("beta") {
+	if Fingerprint("requirements.md", "alpha") == Fingerprint("requirements.md", "beta") {
 		t.Fatal("different bodies produced the same fingerprint")
 	}
 }
 
 func TestFingerprintValidation(t *testing.T) {
-	valid := Fingerprint("any content")
+	valid := Fingerprint("requirements.md", "any content")
 
 	tests := []struct {
 		name  string
@@ -136,7 +136,7 @@ func TestFingerprintValidation(t *testing.T) {
 
 func TestFingerprintBodyMatch(t *testing.T) {
 	body := "# Design\n\nContent under approval.\n"
-	recorded := Fingerprint(body)
+	recorded := Fingerprint("design.md", body)
 
 	tests := []struct {
 		name        string
@@ -153,8 +153,8 @@ func TestFingerprintBodyMatch(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := BodyMatchesFingerprint(test.body, test.fingerprint); got != test.want {
-				t.Fatalf("BodyMatchesFingerprint(%q, %q) = %t, want %t", test.body, test.fingerprint, got, test.want)
+			if got := BodyMatchesFingerprint("design.md", test.body, test.fingerprint); got != test.want {
+				t.Fatalf("BodyMatchesFingerprint(design.md, %q, %q) = %t, want %t", test.body, test.fingerprint, got, test.want)
 			}
 		})
 	}

--- a/internal/spec/freshness.go
+++ b/internal/spec/freshness.go
@@ -78,7 +78,7 @@ func documentIntegrity(document Document) DocumentFreshness {
 		return DocumentFreshness{Causes: []string{CauseFingerprintMissing}}
 	case !ValidFingerprint(document.ApprovedFingerprint):
 		return DocumentFreshness{Causes: []string{CauseFingerprintMalformed}}
-	case !BodyMatchesFingerprint(document.Body, document.ApprovedFingerprint):
+	case !BodyMatchesFingerprint(document.Path, document.Body, document.ApprovedFingerprint):
 		return DocumentFreshness{Causes: []string{CauseContentMismatch}}
 	default:
 		return DocumentFreshness{Intact: true, Fresh: true}

--- a/internal/spec/freshness_test.go
+++ b/internal/spec/freshness_test.go
@@ -17,7 +17,7 @@ func approvedDocument(name, body string) Document {
 		Status:              "approved",
 		ApprovedAt:          "2026-07-02T08:00:00Z",
 		LastModified:        "2026-07-02T08:00:00Z",
-		ApprovedFingerprint: Fingerprint(body),
+		ApprovedFingerprint: Fingerprint(name, body),
 		Fields:              map[string]string{},
 		Exists:              true,
 		Body:                body,
@@ -116,7 +116,7 @@ func TestEvaluateFreshnessTamperedBody(t *testing.T) {
 
 func TestEvaluateFreshnessChainMismatch(t *testing.T) {
 	feature := approvedChain()
-	feature.Design.SourceRequirementsFingerprint = Fingerprint("some other requirements content")
+	feature.Design.SourceRequirementsFingerprint = Fingerprint("requirements.md", "some other requirements content")
 
 	report := EvaluateFreshness(feature)
 	if !report.Design.Intact {

--- a/internal/spec/reconcile_test.go
+++ b/internal/spec/reconcile_test.go
@@ -8,18 +8,18 @@ func TestResetDocumentToDraftClearsFingerprintFields(t *testing.T) {
 		Status:                        "approved",
 		ApprovedAt:                    "2026-03-21T14:10:00Z",
 		LastModified:                  "2026-03-21T14:10:00Z",
-		ApprovedFingerprint:           Fingerprint("# Feature Design\n"),
+		ApprovedFingerprint:           Fingerprint("design.md", "# Feature Design\n"),
 		SourceRequirementsApprovedAt:  "2026-03-21T14:00:00Z",
-		SourceRequirementsFingerprint: Fingerprint("# Requirements Document\n"),
+		SourceRequirementsFingerprint: Fingerprint("requirements.md", "# Requirements Document\n"),
 		Exists:                        true,
 		Body:                          "# Feature Design\n",
 		Fields: map[string]string{
 			"status":                          "approved",
 			"approved_at":                     "2026-03-21T14:10:00Z",
 			"last_modified":                   "2026-03-21T14:10:00Z",
-			"approved_fingerprint":            Fingerprint("# Feature Design\n"),
+			"approved_fingerprint":            Fingerprint("design.md", "# Feature Design\n"),
 			"source_requirements_approved_at": "2026-03-21T14:00:00Z",
-			"source_requirements_fingerprint": Fingerprint("# Requirements Document\n"),
+			"source_requirements_fingerprint": Fingerprint("requirements.md", "# Requirements Document\n"),
 		},
 	}
 

--- a/internal/spec/schema_version.go
+++ b/internal/spec/schema_version.go
@@ -1,0 +1,52 @@
+package spec
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// DocumentSchemaVersion is the document schema this CLI reads and writes.
+// Every save stamps it, so repositories converge to versioned documents
+// through normal use. Documents without the field are accepted as legacy;
+// documents declaring a different version are refused with the remedy.
+const DocumentSchemaVersion = "v1alpha1"
+
+// checkDocumentSchemaVersion refuses documents this CLI cannot honor. The
+// version check runs before any field-level validation: a document written
+// by a newer CLI is reported as a version mismatch, not as unknown fields.
+func checkDocumentSchemaVersion(path string, fields map[string]string) error {
+	declared := fields["walden_schema_version"]
+	if declared != "" && declared != DocumentSchemaVersion {
+		return fmt.Errorf("%s declares walden_schema_version %q; this CLI supports %q — upgrade the walden CLI or migrate the document", path, declared, DocumentSchemaVersion)
+	}
+	return nil
+}
+
+// checkUnknownFrontmatterFields replaces silent deletion with a loud,
+// remediable error: the field the writer would drop is exactly the field the
+// loader refuses. Namespaced `x-` extensions and the schema version are
+// always legal; the writer's own allowlist defines what "core" means.
+func checkUnknownFrontmatterFields(path string, fields map[string]string) error {
+	coreKeys, err := orderedFrontmatterKeys(path)
+	if err != nil {
+		return err
+	}
+	core := map[string]bool{"walden_schema_version": true}
+	for _, key := range coreKeys {
+		core[key] = true
+	}
+
+	unknown := []string{}
+	for key := range fields {
+		if core[key] || strings.HasPrefix(key, "x-") {
+			continue
+		}
+		unknown = append(unknown, key)
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	return fmt.Errorf("%s contains unknown frontmatter field %q — rename it to %q to preserve it, or remove it", path, unknown[0], "x-"+unknown[0])
+}

--- a/internal/spec/schema_version_test.go
+++ b/internal/spec/schema_version_test.go
@@ -1,0 +1,73 @@
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoaderRefusesUnsupportedSchemaVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "requirements.md")
+	content := "---\nwalden_schema_version: v9alpha9\nstatus: draft\napproved_at: \nlast_modified: 2026-07-16T10:00:00Z\napproved_fingerprint: \n---\n\n# Requirements Document\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write document: %v", err)
+	}
+
+	_, err := loadDocument(path)
+	if err == nil {
+		t.Fatal("expected the loader to refuse an unsupported schema version")
+	}
+	for _, fragment := range []string{`"v9alpha9"`, `"v1alpha1"`, "upgrade the walden CLI or migrate the document", path} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Fatalf("refusal missing %q: %v", fragment, err)
+		}
+	}
+}
+
+func TestLoaderAcceptsCurrentSchemaVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "requirements.md")
+	content := "---\nwalden_schema_version: " + DocumentSchemaVersion + "\nstatus: draft\napproved_at: \nlast_modified: 2026-07-16T10:00:00Z\napproved_fingerprint: \n---\n\n# Requirements Document\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write document: %v", err)
+	}
+
+	if _, err := loadDocument(path); err != nil {
+		t.Fatalf("current schema version refused: %v", err)
+	}
+}
+
+func TestLegacyDocumentsLoadAndStampOnSave(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "requirements.md")
+	legacy := "---\nstatus: draft\napproved_at: \nlast_modified: 2026-07-16T10:00:00Z\napproved_fingerprint: \n---\n\n# Requirements Document\n"
+	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("write legacy document: %v", err)
+	}
+
+	document, err := loadDocument(path)
+	if err != nil {
+		t.Fatalf("legacy document refused: %v", err)
+	}
+
+	if err := SaveDocument(document); err != nil {
+		t.Fatalf("SaveDocument: %v", err)
+	}
+	saved, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved document: %v", err)
+	}
+	if !strings.HasPrefix(string(saved), "---\nwalden_schema_version: "+DocumentSchemaVersion+"\n") {
+		t.Fatalf("save did not stamp the schema version first:\n%s", saved)
+	}
+
+	reloaded, err := loadDocument(path)
+	if err != nil {
+		t.Fatalf("reload stamped document: %v", err)
+	}
+	if reloaded.Fields["walden_schema_version"] != DocumentSchemaVersion {
+		t.Fatalf("stamped version not visible after reload: %q", reloaded.Fields["walden_schema_version"])
+	}
+}

--- a/internal/spec/tasks.go
+++ b/internal/spec/tasks.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 var (
@@ -15,6 +16,7 @@ var (
 	expectExitPattern   = regexp.MustCompile(`^( +)expect_exit: ([0-9]+)\s*$`)
 	expectOutputPattern = regexp.MustCompile(`^( +)expect_output: (.+?)\s*$`)
 	coversPattern       = regexp.MustCompile(`^( +)covers: (\[.+\])\s*$`)
+	timeoutPattern      = regexp.MustCompile(`^( +)timeout: (.+?)\s*$`)
 	backtickRefPattern  = regexp.MustCompile("`([^`]+)`")
 )
 
@@ -31,6 +33,9 @@ type VerificationStep struct {
 	ExpectExit   *int
 	ExpectOutput *string
 	Covers       []string
+	// Timeout holds the declared per-step timeout as written (a positive Go
+	// duration string); nil means the executor's default applies.
+	Timeout *string
 }
 
 // Empty reports whether the verification spec contains any executable proof.
@@ -50,7 +55,14 @@ func (spec VerificationSpec) Display() string {
 	rendered := make([]string, 0, len(spec.Steps))
 	for _, step := range spec.Steps {
 		payload, _ := json.Marshal(step.Argv)
-		rendered = append(rendered, fmt.Sprintf("command %s", string(payload)))
+		entry := fmt.Sprintf("command %s", string(payload))
+		// The declared raw string, verbatim: the task fingerprint hashes this
+		// rendering, and steps without a timeout must render byte-identically
+		// to every pre-timeout release so existing evidence never moves.
+		if step.Timeout != nil {
+			entry += " timeout=" + *step.Timeout
+		}
+		rendered = append(rendered, entry)
 	}
 	return strings.Join(rendered, "; ")
 }
@@ -207,6 +219,32 @@ func ParseTaskTree(document Document) (TaskTree, error) {
 					return TaskTree{}, err
 				}
 				steps[len(steps)-1].Covers = covers
+				continue
+			}
+			if match := timeoutPattern.FindStringSubmatch(line); match != nil {
+				if len(match[1]) != attrIndent {
+					return TaskTree{}, fmt.Errorf(
+						"line %d: invalid proof attribute indentation for task %q: expected %d spaces",
+						index+1, pendingVerificationTask.ID, attrIndent,
+					)
+				}
+				steps := pendingVerificationTask.Proof.Steps
+				if len(steps) == 0 {
+					return TaskTree{}, fmt.Errorf("line %d: timeout declared before any command step for task %q", index+1, pendingVerificationTask.ID)
+				}
+				value := strings.TrimSpace(match[2])
+				if len(value) >= 2 && strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
+					value = value[1 : len(value)-1]
+				}
+				duration, err := time.ParseDuration(value)
+				if err != nil {
+					return TaskTree{}, fmt.Errorf("line %d: invalid timeout value for task %q: %v", index+1, pendingVerificationTask.ID, err)
+				}
+				if duration <= 0 {
+					return TaskTree{}, fmt.Errorf("line %d: invalid timeout value for task %q: must be positive", index+1, pendingVerificationTask.ID)
+				}
+				steps[len(steps)-1].Timeout = &value
+				pendingVerificationTask.Verification = pendingVerificationTask.Proof.Display()
 				continue
 			}
 			if strings.TrimSpace(line) == "" {

--- a/internal/spec/tasks_timeout_test.go
+++ b/internal/spec/tasks_timeout_test.go
@@ -1,0 +1,209 @@
+package spec
+
+import (
+	"strings"
+	"testing"
+)
+
+func timeoutFixture(attrLines string) Document {
+	return Document{
+		Path:   "tasks.md",
+		Exists: true,
+		Body: `# Implementation Plan
+
+- [ ] 1. Harden proof execution
+  - [ ] 1.1 Bound the proof step
+    - Requirements: ` + "`R1`" + `
+    - Design: Proof executor
+    - Verification:
+      - command: ["go", "test", "./internal/spec"]
+` + attrLines,
+	}
+}
+
+func TestParseTimeoutAttribute(t *testing.T) {
+	cases := []struct {
+		name        string
+		attrLines   string
+		wantTimeout string
+		wantErr     string
+	}{
+		{
+			name:        "valid seconds",
+			attrLines:   "        timeout: 30s\n",
+			wantTimeout: "30s",
+		},
+		{
+			name:        "valid composite duration",
+			attrLines:   "        timeout: 1h30m\n",
+			wantTimeout: "1h30m",
+		},
+		{
+			name:        "quoted value is unquoted",
+			attrLines:   "        timeout: \"45s\"\n",
+			wantTimeout: "45s",
+		},
+		{
+			name:      "invalid duration string",
+			attrLines: "        timeout: banana\n",
+			wantErr:   `invalid timeout value for task "1.1"`,
+		},
+		{
+			name:      "zero duration",
+			attrLines: "        timeout: 0s\n",
+			wantErr:   "must be positive",
+		},
+		{
+			name:      "negative duration",
+			attrLines: "        timeout: -5m\n",
+			wantErr:   "must be positive",
+		},
+		{
+			name:      "wrong indentation",
+			attrLines: "      timeout: 30s\n",
+			wantErr:   "invalid proof attribute indentation",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tree, err := ParseTaskTree(timeoutFixture(testCase.attrLines))
+			if testCase.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", testCase.wantErr)
+				}
+				if !strings.Contains(err.Error(), testCase.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", testCase.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected parse to succeed, got %v", err)
+			}
+			task, ok := tree.FindTask("1.1")
+			if !ok {
+				t.Fatal("expected task 1.1 to exist")
+			}
+			if len(task.Proof.Steps) != 1 {
+				t.Fatalf("expected 1 proof step, got %d", len(task.Proof.Steps))
+			}
+			timeout := task.Proof.Steps[0].Timeout
+			if timeout == nil {
+				t.Fatal("expected timeout to be set")
+			}
+			if *timeout != testCase.wantTimeout {
+				t.Fatalf("expected timeout %q, got %q", testCase.wantTimeout, *timeout)
+			}
+		})
+	}
+}
+
+func TestParseTimeoutAttributeBeforeAnyStep(t *testing.T) {
+	document := Document{
+		Path:   "tasks.md",
+		Exists: true,
+		Body: `# Implementation Plan
+
+- [ ] 1. Harden proof execution
+  - [ ] 1.1 Bound the proof step
+    - Requirements: ` + "`R1`" + `
+    - Design: Proof executor
+    - Verification:
+        timeout: 30s
+`,
+	}
+	_, err := ParseTaskTree(document)
+	if err == nil || !strings.Contains(err.Error(), "timeout declared before any command step") {
+		t.Fatalf("expected timeout-before-step error, got %v", err)
+	}
+}
+
+func TestParseTimeoutAttributeAttachesToLastStep(t *testing.T) {
+	document := Document{
+		Path:   "tasks.md",
+		Exists: true,
+		Body: `# Implementation Plan
+
+- [ ] 1. Harden proof execution
+  - [ ] 1.1 Bound the proof step
+    - Requirements: ` + "`R1`" + `
+    - Design: Proof executor
+    - Verification:
+      - command: ["go", "build", "./..."]
+      - command: ["go", "test", "./internal/spec"]
+        timeout: 2m
+`,
+	}
+	tree, err := ParseTaskTree(document)
+	if err != nil {
+		t.Fatalf("expected parse to succeed, got %v", err)
+	}
+	task, ok := tree.FindTask("1.1")
+	if !ok {
+		t.Fatal("expected task 1.1 to exist")
+	}
+	if len(task.Proof.Steps) != 2 {
+		t.Fatalf("expected 2 proof steps, got %d", len(task.Proof.Steps))
+	}
+	if task.Proof.Steps[0].Timeout != nil {
+		t.Fatalf("expected first step without timeout, got %q", *task.Proof.Steps[0].Timeout)
+	}
+	second := task.Proof.Steps[1].Timeout
+	if second == nil || *second != "2m" {
+		t.Fatalf("expected second step timeout 2m, got %v", second)
+	}
+}
+
+func TestDisplayTimeoutSuffix(t *testing.T) {
+	declared := "2m"
+	spec := VerificationSpec{Steps: []VerificationStep{
+		{Argv: []string{"go", "build", "./..."}},
+		{Argv: []string{"go", "test", "./internal/spec"}, Timeout: &declared},
+	}}
+	display := spec.Display()
+	if want := `command ["go","build","./..."]; command ["go","test","./internal/spec"] timeout=2m`; display != want {
+		t.Fatalf("unexpected display:\n got %q\nwant %q", display, want)
+	}
+}
+
+func TestDisplayWithoutTimeoutIsByteIdentical(t *testing.T) {
+	tree, err := ParseTaskTree(timeoutFixture(""))
+	if err != nil {
+		t.Fatalf("expected parse to succeed, got %v", err)
+	}
+	task, ok := tree.FindTask("1.1")
+	if !ok {
+		t.Fatal("expected task 1.1 to exist")
+	}
+	if want := `command ["go","test","./internal/spec"]`; task.Verification != want {
+		t.Fatalf("undeclared timeout changed the rendering:\n got %q\nwant %q", task.Verification, want)
+	}
+}
+
+func TestTaskFingerprintMovesWithTimeout(t *testing.T) {
+	fingerprintFor := func(attrLines string) string {
+		tree, err := ParseTaskTree(timeoutFixture(attrLines))
+		if err != nil {
+			t.Fatalf("expected parse to succeed, got %v", err)
+		}
+		task, ok := tree.FindTask("1.1")
+		if !ok {
+			t.Fatal("expected task 1.1 to exist")
+		}
+		return TaskDefinitionFingerprint(task)
+	}
+
+	none := fingerprintFor("")
+	thirty := fingerprintFor("        timeout: 30s\n")
+	fortyFive := fingerprintFor("        timeout: 45s\n")
+
+	if none == thirty {
+		t.Fatal("declaring a timeout must move the task fingerprint")
+	}
+	if thirty == fortyFive {
+		t.Fatal("changing a declared timeout must move the task fingerprint")
+	}
+	if again := fingerprintFor(""); none != again {
+		t.Fatal("fingerprint without timeout must stay deterministic")
+	}
+}

--- a/internal/spec/write.go
+++ b/internal/spec/write.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -24,7 +25,27 @@ func SaveDocument(document Document) error {
 
 	var builder strings.Builder
 	builder.WriteString("---\n")
+	// Every save stamps the current schema version first: stamping-on-save
+	// is the migration mechanism for legacy documents.
+	builder.WriteString("walden_schema_version: ")
+	builder.WriteString(DocumentSchemaVersion)
+	builder.WriteString("\n")
 	for _, key := range orderedKeys {
+		builder.WriteString(key)
+		builder.WriteString(": ")
+		builder.WriteString(document.Fields[key])
+		builder.WriteString("\n")
+	}
+	// Namespaced extensions survive every mutation, verbatim and in
+	// lexicographic order — deterministic bytes for identical content.
+	extensionKeys := make([]string, 0)
+	for key := range document.Fields {
+		if strings.HasPrefix(key, "x-") {
+			extensionKeys = append(extensionKeys, key)
+		}
+	}
+	sort.Strings(extensionKeys)
+	for _, key := range extensionKeys {
 		builder.WriteString(key)
 		builder.WriteString(": ")
 		builder.WriteString(document.Fields[key])

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -1382,7 +1382,7 @@ func stampFixtureFingerprint(t *testing.T, root, featureName, name string) {
 		return
 	}
 
-	document.ApprovedFingerprint = spec.Fingerprint(document.Body)
+	document.ApprovedFingerprint = spec.Fingerprint(document.Path, document.Body)
 	document.Fields["approved_fingerprint"] = document.ApprovedFingerprint
 
 	switch name {
@@ -1390,7 +1390,7 @@ func stampFixtureFingerprint(t *testing.T, root, featureName, name string) {
 		if feature.Requirements.Status == "approved" {
 			fingerprint := feature.Requirements.ApprovedFingerprint
 			if fingerprint == "" {
-				fingerprint = spec.Fingerprint(feature.Requirements.Body)
+				fingerprint = spec.Fingerprint(feature.Requirements.Path, feature.Requirements.Body)
 			}
 			document.SourceRequirementsFingerprint = fingerprint
 			document.Fields["source_requirements_fingerprint"] = fingerprint
@@ -1399,7 +1399,7 @@ func stampFixtureFingerprint(t *testing.T, root, featureName, name string) {
 		if feature.Design.Status == "approved" {
 			fingerprint := feature.Design.ApprovedFingerprint
 			if fingerprint == "" {
-				fingerprint = spec.Fingerprint(feature.Design.Body)
+				fingerprint = spec.Fingerprint(feature.Design.Path, feature.Design.Body)
 			}
 			document.SourceDesignFingerprint = fingerprint
 			document.Fields["source_design_fingerprint"] = fingerprint

--- a/internal/workflow/complete_mutation_test.go
+++ b/internal/workflow/complete_mutation_test.go
@@ -1,0 +1,60 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/evidence"
+)
+
+// Completion is the implementation step: a proof that mutates the tree
+// (generators, builds) must complete normally — purity binds verify only.
+func TestCompleteTaskMutatingProofSucceeds(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, &dynamicIdentityRunner{root: root})
+
+	result, err := CompleteTask(context.Background(), root, "todo-app-demo", "1.1", &sideEffectRunner{root: root})
+	if err != nil {
+		t.Fatalf("mutating completion proof was rejected: %v", err)
+	}
+	if len(result.CompletedTasks) == 0 || result.CompletedTasks[0] != "1.1" {
+		t.Fatalf("task 1.1 not completed: %+v", result.CompletedTasks)
+	}
+}
+
+func TestCompleteEvidenceBindsPostProofTree(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	identityRunnerForRoot := &dynamicIdentityRunner{root: root}
+	overrideIdentityRunner(t, identityRunnerForRoot)
+
+	preIdentity, ok := evidence.Identity(context.Background(), identityRunnerForRoot, root)
+	if !ok {
+		t.Fatal("pre-completion identity not computed")
+	}
+
+	if _, err := CompleteTask(context.Background(), root, "todo-app-demo", "1.1", &sideEffectRunner{root: root}); err != nil {
+		t.Fatalf("CompleteTask: %v", err)
+	}
+
+	postIdentity, ok := evidence.Identity(context.Background(), identityRunnerForRoot, root)
+	if !ok {
+		t.Fatal("post-completion identity not computed")
+	}
+
+	ledger, err := evidence.Load(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("load ledger: %v", err)
+	}
+	record, exists := ledger.Tasks["1.1"]
+	if !exists {
+		t.Fatal("no evidence recorded for task 1.1")
+	}
+	if record.CodeIdentity == preIdentity {
+		t.Fatal("evidence bound the pre-proof tree; it must bind the tree the proof left behind")
+	}
+	if record.CodeIdentity != postIdentity {
+		t.Fatalf("evidence identity %s does not match the post-proof tree %s", record.CodeIdentity, postIdentity)
+	}
+}

--- a/internal/workflow/execute_timeout_test.go
+++ b/internal/workflow/execute_timeout_test.go
@@ -1,0 +1,100 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/andrearaponi/walden/internal/shell"
+	"github.com/andrearaponi/walden/internal/spec"
+)
+
+type runnerFunc func(ctx context.Context, name string, args ...string) (shell.Response, error)
+
+func (f runnerFunc) Run(ctx context.Context, name string, args ...string) (shell.Response, error) {
+	return f(ctx, name, args...)
+}
+
+func timeoutTask(declared string) ExecutableTask {
+	step := spec.VerificationStep{Argv: []string{"go", "test", "./pkg/"}}
+	if declared != "" {
+		step.Timeout = &declared
+	}
+	proof := spec.VerificationSpec{Steps: []spec.VerificationStep{step}}
+	return ExecutableTask{
+		ID:           "1.1",
+		Title:        "Step",
+		Verification: proof.Display(),
+		Proof:        proof,
+	}
+}
+
+func TestExecuteProofDefaultTimeout(t *testing.T) {
+	var remaining time.Duration
+	runner := runnerFunc(func(ctx context.Context, name string, args ...string) (shell.Response, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("expected the proof step context to carry a deadline")
+		}
+		remaining = time.Until(deadline)
+		return shell.Response{ExitCode: 0}, nil
+	})
+
+	if _, _, err := executeProof(context.Background(), runner, timeoutTask("")); err != nil {
+		t.Fatalf("executeProof returned error: %v", err)
+	}
+	if remaining <= 9*time.Minute || remaining > 10*time.Minute {
+		t.Fatalf("expected a ~10m default deadline, got %s remaining", remaining)
+	}
+}
+
+func TestExecuteProofDeclaredTimeoutHonored(t *testing.T) {
+	var remaining time.Duration
+	runner := runnerFunc(func(ctx context.Context, name string, args ...string) (shell.Response, error) {
+		deadline, _ := ctx.Deadline()
+		remaining = time.Until(deadline)
+		return shell.Response{ExitCode: 0}, nil
+	})
+
+	if _, _, err := executeProof(context.Background(), runner, timeoutTask("30s")); err != nil {
+		t.Fatalf("executeProof returned error: %v", err)
+	}
+	if remaining <= 0 || remaining > 30*time.Second {
+		t.Fatalf("expected a ≤30s declared deadline, got %s remaining", remaining)
+	}
+}
+
+func TestExecuteProofTimeoutFailure(t *testing.T) {
+	runner := runnerFunc(func(ctx context.Context, name string, args ...string) (shell.Response, error) {
+		<-ctx.Done()
+		return shell.Response{ExitCode: -1}, nil
+	})
+
+	_, _, err := executeProof(context.Background(), runner, timeoutTask("50ms"))
+	if err == nil {
+		t.Fatal("expected a timeout failure")
+	}
+	if !strings.Contains(err.Error(), "exceeded timeout 50ms") {
+		t.Fatalf("expected failure naming the exceeded timeout, got %v", err)
+	}
+	if !strings.Contains(err.Error(), `task "1.1"`) {
+		t.Fatalf("expected failure naming the task, got %v", err)
+	}
+}
+
+func TestExecuteProofInvalidTimeoutRefused(t *testing.T) {
+	calls := 0
+	runner := runnerFunc(func(ctx context.Context, name string, args ...string) (shell.Response, error) {
+		calls++
+		return shell.Response{ExitCode: 0}, nil
+	})
+
+	_, _, err := executeProof(context.Background(), runner, timeoutTask("banana"))
+	if err == nil || !strings.Contains(err.Error(), "invalid timeout value") {
+		t.Fatalf("expected invalid-timeout refusal, got %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected no proof execution after refusal, ran %d step(s)", calls)
+	}
+}

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -447,7 +447,17 @@ type proofCommand struct {
 	Display      string
 	ExpectExit   int
 	ExpectOutput string
+	Timeout      time.Duration
+	TimeoutLabel string
 }
+
+// defaultProofStepTimeout bounds every proof step without a declared timeout:
+// a hung proof must fail its command, never block it indefinitely. The label
+// is what failure messages name for the default budget.
+const (
+	defaultProofStepTimeout      = 10 * time.Minute
+	defaultProofStepTimeoutLabel = "10m"
+)
 
 func resolveProofCommands(task ExecutableTask) ([]proofCommand, string, error) {
 	if len(task.Proof.Steps) > 0 {
@@ -464,12 +474,27 @@ func resolveProofCommands(task ExecutableTask) ([]proofCommand, string, error) {
 			if step.ExpectOutput != nil {
 				expectOutput = *step.ExpectOutput
 			}
+			timeout := defaultProofStepTimeout
+			timeoutLabel := defaultProofStepTimeoutLabel
+			if step.Timeout != nil {
+				parsed, err := time.ParseDuration(*step.Timeout)
+				if err != nil {
+					return nil, "", fmt.Errorf("invalid timeout value %q for task %q: %v", *step.Timeout, task.ID, err)
+				}
+				if parsed <= 0 {
+					return nil, "", fmt.Errorf("invalid timeout value %q for task %q: must be positive", *step.Timeout, task.ID)
+				}
+				timeout = parsed
+				timeoutLabel = *step.Timeout
+			}
 			commands = append(commands, proofCommand{
 				Name:         step.Argv[0],
 				Args:         append([]string(nil), step.Argv[1:]...),
 				Display:      formatCommandProofStep(step.Argv),
 				ExpectExit:   expectExit,
 				ExpectOutput: expectOutput,
+				Timeout:      timeout,
+				TimeoutLabel: timeoutLabel,
 			})
 		}
 		return commands, task.Verification, nil
@@ -479,7 +504,13 @@ func resolveProofCommands(task ExecutableTask) ([]proofCommand, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	return []proofCommand{{Name: name, Args: args, Display: display}}, display, nil
+	return []proofCommand{{
+		Name:         name,
+		Args:         args,
+		Display:      display,
+		Timeout:      defaultProofStepTimeout,
+		TimeoutLabel: defaultProofStepTimeoutLabel,
+	}}, display, nil
 }
 
 // executableTaskFingerprint bridges the execution view back to the spec
@@ -505,7 +536,19 @@ func executeProof(ctx context.Context, runner shell.Runner, task ExecutableTask)
 
 	results := make([]evidence.StepResult, 0, len(proofCommands))
 	for _, proofStep := range proofCommands {
-		response, err := runner.Run(ctx, proofStep.Name, proofStep.Args...)
+		stepCtx, cancel := context.WithTimeout(ctx, proofStep.Timeout)
+		response, err := runner.Run(stepCtx, proofStep.Name, proofStep.Args...)
+		timedOut := stepCtx.Err() == context.DeadlineExceeded
+		cancel()
+		if timedOut {
+			results = append(results, evidence.StepResult{
+				Command:      append([]string{proofStep.Name}, proofStep.Args...),
+				ExpectedExit: proofStep.ExpectExit,
+				ActualExit:   response.ExitCode,
+				OutputDigest: evidence.DigestOutput(response.Stdout + response.Stderr),
+			})
+			return results, display, fmt.Errorf("verification failed for task %q: command %q exceeded timeout %s", task.ID, proofStep.Display, proofStep.TimeoutLabel)
+		}
 		if err != nil {
 			hint := ""
 			if strings.Contains(err.Error(), "executable file not found") {

--- a/internal/workflow/execution_test.go
+++ b/internal/workflow/execution_test.go
@@ -176,7 +176,7 @@ source_design_approved_at: 2026-03-21T14:10:00Z
 `)
 
 	// The tasks approval was recorded against different design content.
-	overrideFrontmatterField(t, root, "todo-app-demo", "tasks.md", "source_design_fingerprint", spec.Fingerprint("some earlier design content"))
+	overrideFrontmatterField(t, root, "todo-app-demo", "tasks.md", "source_design_fingerprint", spec.Fingerprint("design.md", "some earlier design content"))
 
 	readiness, err := LoadExecutionReadiness(root, "todo-app-demo")
 	if err != nil {

--- a/internal/workflow/extension_cycle_test.go
+++ b/internal/workflow/extension_cycle_test.go
@@ -1,0 +1,74 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/spec"
+	"github.com/andrearaponi/walden/internal/testutil"
+)
+
+// The document-evolution contract, end to end: an x- extension declared on
+// tasks.md survives the real approval gate, a task completion that rewrites
+// the document, and a persisting verify — byte-identical value, schema
+// version stamped, chain still fresh.
+func TestExtensionFieldsSurviveFullCycle(t *testing.T) {
+	root := t.TempDir()
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+
+	writeApproveFeatureDoc(t, root, "todo-app-demo", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T14:00:00Z"))
+	writeApproveFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("requirements.md", approveReqBody)))
+	writeApproveFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
+status: in-review
+approved_at:
+last_modified: 2026-03-21T14:20:00Z
+source_design_approved_at:
+x-tracking: JIRA-123
+---
+
+# Implementation Plan
+
+- [ ] 1. Build parser
+  - [ ] 1.1 Implement parser
+    - Requirements: `+"`R1`"+`
+    - Design: Task Store
+    - Verification:
+      - command: ["go", "test", "./internal/spec"]
+`)
+
+	// The real approval gate rewrites the document: the extension survives it.
+	if _, err := ApproveReview(root, "todo-app-demo", PhaseTasks); err != nil {
+		t.Fatalf("ApproveReview: %v", err)
+	}
+
+	// Task completion mutates the checkbox and rewrites the document again.
+	runner := testutil.NewFakeRunner(testutil.Response{Stdout: "ok", ExitCode: 0})
+	if _, err := CompleteTask(context.Background(), root, "todo-app-demo", "1.1", runner); err != nil {
+		t.Fatalf("CompleteTask: %v", err)
+	}
+
+	// A persisting verify refreshes evidence without touching the documents.
+	verifyRunner := testutil.NewFakeRunner(testutil.Response{Stdout: "ok", ExitCode: 0})
+	if _, err := Verify(context.Background(), root, "todo-app-demo", true, false, verifyRunner); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+
+	feature, err := spec.LoadFeature(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("LoadFeature: %v", err)
+	}
+	tasks := feature.Tasks
+	if tasks.Fields["x-tracking"] != "JIRA-123" {
+		t.Fatalf("extension lost across the cycle: %v", tasks.Fields)
+	}
+	if tasks.Fields["walden_schema_version"] != spec.DocumentSchemaVersion {
+		t.Fatalf("mutations did not stamp the schema version, got %q", tasks.Fields["walden_schema_version"])
+	}
+	if !strings.Contains(tasks.Body, "- [x] 1.1") {
+		t.Fatal("completion did not mutate the plan")
+	}
+	if state := ResolveFeatureState(feature); !state.Tasks.Fresh {
+		t.Fatal("the cycle left the approved tasks.md stale")
+	}
+}

--- a/internal/workflow/fixtures_test.go
+++ b/internal/workflow/fixtures_test.go
@@ -21,7 +21,7 @@ last_modified: %s
 approved_fingerprint: %s
 ---
 
-%s`, approvedAt, approvedAt, spec.Fingerprint(body), body)
+%s`, approvedAt, approvedAt, spec.Fingerprint("requirements.md", body), body)
 }
 
 func approvedDesignContent(body, approvedAt, sourceApprovedAt, sourceFingerprint string) string {
@@ -34,7 +34,7 @@ source_requirements_approved_at: %s
 source_requirements_fingerprint: %s
 ---
 
-%s`, approvedAt, approvedAt, spec.Fingerprint(body), sourceApprovedAt, sourceFingerprint, body)
+%s`, approvedAt, approvedAt, spec.Fingerprint("design.md", body), sourceApprovedAt, sourceFingerprint, body)
 }
 
 func approvedTasksContent(body, approvedAt, sourceApprovedAt, sourceFingerprint string) string {
@@ -47,7 +47,7 @@ source_design_approved_at: %s
 source_design_fingerprint: %s
 ---
 
-%s`, approvedAt, approvedAt, spec.Fingerprint(body), sourceApprovedAt, sourceFingerprint, body)
+%s`, approvedAt, approvedAt, spec.Fingerprint("tasks.md", body), sourceApprovedAt, sourceFingerprint, body)
 }
 
 // writeFreshFeatureDoc writes a fixture document and, when it is approved,
@@ -69,7 +69,7 @@ func writeFreshFeatureDoc(t *testing.T, root, featureName, name, content string)
 		return
 	}
 
-	document.ApprovedFingerprint = spec.Fingerprint(document.Body)
+	document.ApprovedFingerprint = spec.Fingerprint(document.Path, document.Body)
 	document.Fields["approved_fingerprint"] = document.ApprovedFingerprint
 
 	switch name {
@@ -77,7 +77,7 @@ func writeFreshFeatureDoc(t *testing.T, root, featureName, name, content string)
 		if feature.Requirements.Status == "approved" {
 			fingerprint := feature.Requirements.ApprovedFingerprint
 			if fingerprint == "" {
-				fingerprint = spec.Fingerprint(feature.Requirements.Body)
+				fingerprint = spec.Fingerprint(feature.Requirements.Path, feature.Requirements.Body)
 			}
 			document.SourceRequirementsFingerprint = fingerprint
 			document.Fields["source_requirements_fingerprint"] = fingerprint
@@ -86,7 +86,7 @@ func writeFreshFeatureDoc(t *testing.T, root, featureName, name, content string)
 		if feature.Design.Status == "approved" {
 			fingerprint := feature.Design.ApprovedFingerprint
 			if fingerprint == "" {
-				fingerprint = spec.Fingerprint(feature.Design.Body)
+				fingerprint = spec.Fingerprint(feature.Design.Path, feature.Design.Body)
 			}
 			document.SourceDesignFingerprint = fingerprint
 			document.Fields["source_design_fingerprint"] = fingerprint

--- a/internal/workflow/freshness_scope_test.go
+++ b/internal/workflow/freshness_scope_test.go
@@ -1,0 +1,37 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/andrearaponi/walden/internal/spec"
+	"github.com/andrearaponi/walden/internal/testutil"
+)
+
+// Checkbox mutation by task completion is the one legitimate writer of an
+// approved tasks.md: under the scoped normalization it must stay exempt, or
+// the workflow would stale itself on every completed task.
+func TestScopedNormalizationKeepsCompletedTasksFresh(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+
+	runner := testutil.NewFakeRunner(testutil.Response{Stdout: "ok", ExitCode: 0})
+	if _, err := CompleteTask(context.Background(), root, "todo-app-demo", "1.1", runner); err != nil {
+		t.Fatalf("CompleteTask: %v", err)
+	}
+
+	feature, err := spec.LoadFeature(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("LoadFeature: %v", err)
+	}
+	if !strings.Contains(feature.Tasks.Body, "- [x] 1.1") {
+		t.Fatal("completion did not mutate the checkbox — the exemption is not exercised")
+	}
+
+	state := ResolveFeatureState(feature)
+	if !state.Tasks.Fresh {
+		t.Fatal("checkbox mutation by task completion staled the approved tasks.md")
+	}
+}

--- a/internal/workflow/reconcile_test.go
+++ b/internal/workflow/reconcile_test.go
@@ -13,9 +13,9 @@ func TestReconcileFeatureResetsTamperedRequirementsAndDownstream(t *testing.T) {
 	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md",
 		approvedRequirementsContent(approveReqBody, "2026-03-21T14:00:00Z")+"\nInjected after approval.\n")
 	writeFeatureDoc(t, root, "todo-app-demo", "design.md",
-		approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint(approveReqBody)))
+		approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("requirements.md", approveReqBody)))
 	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md",
-		approvedTasksContent(approveTasksBody, "2026-03-21T14:20:00Z", "2026-03-21T14:10:00Z", spec.Fingerprint(approveDesignBody)))
+		approvedTasksContent(approveTasksBody, "2026-03-21T14:20:00Z", "2026-03-21T14:10:00Z", spec.Fingerprint("design.md", approveDesignBody)))
 
 	result, err := reconcileFeatureAt(root, "todo-app-demo", "2026-03-21T18:55:00Z")
 	if err != nil {
@@ -63,9 +63,9 @@ func TestReconcileFeatureResetsDesignAndTasksOnSourceFingerprintMismatch(t *test
 		approvedRequirementsContent(approveReqBody, "2026-03-21T14:30:00Z"))
 	// Design was approved against different requirements content.
 	writeFeatureDoc(t, root, "todo-app-demo", "design.md",
-		approvedDesignContent(approveDesignBody, "2026-03-21T14:40:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("some earlier requirements content")))
+		approvedDesignContent(approveDesignBody, "2026-03-21T14:40:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("requirements.md", "some earlier requirements content")))
 	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md",
-		approvedTasksContent(approveTasksBody, "2026-03-21T14:50:00Z", "2026-03-21T14:40:00Z", spec.Fingerprint(approveDesignBody)))
+		approvedTasksContent(approveTasksBody, "2026-03-21T14:50:00Z", "2026-03-21T14:40:00Z", spec.Fingerprint("design.md", approveDesignBody)))
 
 	result, err := reconcileFeatureAt(root, "todo-app-demo", "2026-03-21T18:55:00Z")
 	if err != nil {
@@ -103,10 +103,10 @@ func TestReconcileFeatureResetsTasksOnSourceFingerprintMismatch(t *testing.T) {
 	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md",
 		approvedRequirementsContent(approveReqBody, "2026-03-21T14:00:00Z"))
 	writeFeatureDoc(t, root, "todo-app-demo", "design.md",
-		approvedDesignContent(approveDesignBody, "2026-03-21T14:30:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint(approveReqBody)))
+		approvedDesignContent(approveDesignBody, "2026-03-21T14:30:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("requirements.md", approveReqBody)))
 	// Tasks were approved against different design content.
 	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md",
-		approvedTasksContent(approveTasksBody, "2026-03-21T14:50:00Z", "2026-03-21T14:10:00Z", spec.Fingerprint("some earlier design content")))
+		approvedTasksContent(approveTasksBody, "2026-03-21T14:50:00Z", "2026-03-21T14:10:00Z", spec.Fingerprint("design.md", "some earlier design content")))
 
 	result, err := reconcileFeatureAt(root, "todo-app-demo", "2026-03-21T18:55:00Z")
 	if err != nil {
@@ -196,9 +196,9 @@ func TestReconcileFeatureLeavesFreshChainUntouched(t *testing.T) {
 	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md",
 		approvedRequirementsContent(approveReqBody, "2026-03-21T14:00:00Z"))
 	writeFeatureDoc(t, root, "todo-app-demo", "design.md",
-		approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint(approveReqBody)))
+		approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("requirements.md", approveReqBody)))
 	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md",
-		approvedTasksContent(approveTasksBody, "2026-03-21T14:20:00Z", "2026-03-21T14:10:00Z", spec.Fingerprint(approveDesignBody)))
+		approvedTasksContent(approveTasksBody, "2026-03-21T14:20:00Z", "2026-03-21T14:10:00Z", spec.Fingerprint("design.md", approveDesignBody)))
 
 	result, err := reconcileFeatureAt(root, "todo-app-demo", "2026-03-21T18:55:00Z")
 	if err != nil {

--- a/internal/workflow/review.go
+++ b/internal/workflow/review.go
@@ -91,7 +91,7 @@ func ApproveReview(root, featureName string, phase Phase) (ApprovalResult, error
 	document.Status = "approved"
 	document.ApprovedAt = approvedAt
 	document.LastModified = approvedAt
-	document.ApprovedFingerprint = spec.Fingerprint(document.Body)
+	document.ApprovedFingerprint = spec.Fingerprint(document.Path, document.Body)
 	document.Fields["status"] = document.Status
 	document.Fields["approved_at"] = document.ApprovedAt
 	document.Fields["last_modified"] = document.LastModified

--- a/internal/workflow/review_approve_test.go
+++ b/internal/workflow/review_approve_test.go
@@ -44,7 +44,7 @@ last_modified: 2026-03-21T14:00:00Z
 	if !spec.ValidFingerprint(feature.Requirements.ApprovedFingerprint) {
 		t.Fatalf("expected a valid approval fingerprint, got %q", feature.Requirements.ApprovedFingerprint)
 	}
-	if !spec.BodyMatchesFingerprint(feature.Requirements.Body, feature.Requirements.ApprovedFingerprint) {
+	if !spec.BodyMatchesFingerprint(feature.Requirements.Path, feature.Requirements.Body, feature.Requirements.ApprovedFingerprint) {
 		t.Fatal("recorded approval fingerprint does not match the approved body")
 	}
 	if result.Document != ".walden/specs/todo-app-demo/requirements.md" {
@@ -84,10 +84,10 @@ source_requirements_approved_at:
 	if feature.Design.SourceRequirementsApprovedAt != "2026-03-21T14:00:00Z" {
 		t.Fatalf("unexpected source requirements approval timestamp %q", feature.Design.SourceRequirementsApprovedAt)
 	}
-	if feature.Design.SourceRequirementsFingerprint != spec.Fingerprint(approveReqBody) {
+	if feature.Design.SourceRequirementsFingerprint != spec.Fingerprint("requirements.md", approveReqBody) {
 		t.Fatalf("source requirements fingerprint %q does not match upstream approval fingerprint", feature.Design.SourceRequirementsFingerprint)
 	}
-	if !spec.BodyMatchesFingerprint(feature.Design.Body, feature.Design.ApprovedFingerprint) {
+	if !spec.BodyMatchesFingerprint(feature.Design.Path, feature.Design.Body, feature.Design.ApprovedFingerprint) {
 		t.Fatal("recorded design approval fingerprint does not match the approved body")
 	}
 	if !timestampLike(feature.Design.ApprovedAt) {
@@ -101,7 +101,7 @@ source_requirements_approved_at:
 func TestApproveReviewTasksCopiesUpstreamApprovalTimestampAndFingerprint(t *testing.T) {
 	root := t.TempDir()
 	writeApproveFeatureDoc(t, root, "todo-app-demo", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T14:00:00Z"))
-	writeApproveFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint(approveReqBody)))
+	writeApproveFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("requirements.md", approveReqBody)))
 	writeApproveFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: in-review
 approved_at:
@@ -128,7 +128,7 @@ source_design_approved_at:
 	if feature.Tasks.SourceDesignApprovedAt != "2026-03-21T14:10:00Z" {
 		t.Fatalf("unexpected source design approval timestamp %q", feature.Tasks.SourceDesignApprovedAt)
 	}
-	if feature.Tasks.SourceDesignFingerprint != spec.Fingerprint(approveDesignBody) {
+	if feature.Tasks.SourceDesignFingerprint != spec.Fingerprint("design.md", approveDesignBody) {
 		t.Fatalf("source design fingerprint %q does not match upstream approval fingerprint", feature.Tasks.SourceDesignFingerprint)
 	}
 	if result.NextAction != "Start execution from the next unchecked task" {
@@ -169,7 +169,7 @@ func TestApproveReviewBlocksWhenDesignIsStaleForTasksApproval(t *testing.T) {
 	root := t.TempDir()
 	writeApproveFeatureDoc(t, root, "todo-app-demo", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T15:00:00Z"))
 	// Design was approved against different requirements content: chain mismatch.
-	writeApproveFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("some earlier requirements content")))
+	writeApproveFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("requirements.md", "some earlier requirements content")))
 	writeApproveFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: in-review
 approved_at:
@@ -206,7 +206,7 @@ approved_fingerprint: %s
 # Requirements Document
 
 Injected after approval.
-`, spec.Fingerprint(approveReqBody))
+`, spec.Fingerprint("requirements.md", approveReqBody))
 	writeApproveFeatureDoc(t, root, "todo-app-demo", "requirements.md", tampered)
 	writeApproveFeatureDoc(t, root, "todo-app-demo", "design.md", `---
 status: in-review

--- a/internal/workflow/review_test.go
+++ b/internal/workflow/review_test.go
@@ -76,7 +76,7 @@ func TestOpenReviewBlocksStaleUpstreamArtifact(t *testing.T) {
 	root := t.TempDir()
 	writeReviewFeatureDoc(t, root, "todo-app-demo", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T15:00:00Z"))
 	// Approved against different requirements content: chain mismatch.
-	writeReviewFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("some earlier requirements content")))
+	writeReviewFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("requirements.md", "some earlier requirements content")))
 	writeReviewFeatureDoc(t, root, "todo-app-demo", "tasks.md", `---
 status: draft
 approved_at:

--- a/internal/workflow/state_test.go
+++ b/internal/workflow/state_test.go
@@ -43,8 +43,8 @@ func TestLoadFeatureStateMarksDesignAndTasksStaleAfterRequirementsChange(t *test
 	// Requirements were re-approved with different content: the design's
 	// recorded source fingerprint no longer matches.
 	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T15:00:00Z"))
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:30:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("some earlier requirements content")))
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", approvedTasksContent(approveTasksBody, "2026-03-21T14:40:00Z", "2026-03-21T14:30:00Z", spec.Fingerprint(approveDesignBody)))
+	writeFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:30:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("requirements.md", "some earlier requirements content")))
+	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", approvedTasksContent(approveTasksBody, "2026-03-21T14:40:00Z", "2026-03-21T14:30:00Z", spec.Fingerprint("design.md", approveDesignBody)))
 
 	state, err := LoadFeatureState(root, "todo-app-demo")
 	if err != nil {
@@ -74,7 +74,7 @@ func TestLoadFeatureStateMarksTamperedRequirementsStale(t *testing.T) {
 	root := t.TempDir()
 	tampered := approvedRequirementsContent(approveReqBody, "2026-03-21T15:00:00Z") + "\nInjected after approval.\n"
 	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", tampered)
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T15:10:00Z", "2026-03-21T15:00:00Z", spec.Fingerprint(approveReqBody)))
+	writeFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T15:10:00Z", "2026-03-21T15:00:00Z", spec.Fingerprint("requirements.md", approveReqBody)))
 
 	state, err := LoadFeatureState(root, "todo-app-demo")
 	if err != nil {
@@ -125,8 +125,8 @@ source_requirements_approved_at:
 func TestLoadFeatureStateReturnsExecutionNextActionWhenAllSpecsAreApproved(t *testing.T) {
 	root := t.TempDir()
 	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T14:00:00Z"))
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint(approveReqBody)))
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", approvedTasksContent(approveTasksBody, "2026-03-21T14:20:00Z", "2026-03-21T14:10:00Z", spec.Fingerprint(approveDesignBody)))
+	writeFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("requirements.md", approveReqBody)))
+	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", approvedTasksContent(approveTasksBody, "2026-03-21T14:20:00Z", "2026-03-21T14:10:00Z", spec.Fingerprint("design.md", approveDesignBody)))
 
 	state, err := LoadFeatureState(root, "todo-app-demo")
 	if err != nil {
@@ -177,7 +177,7 @@ func TestFingerprintComparisonDecidesFreshnessDespiteTimestampDivergence(t *test
 	// The chain must stay fresh — fingerprint comparison alone decides.
 	root := t.TempDir()
 	writeFeatureDoc(t, root, "ts-test", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T18:00:00Z"))
-	writeFeatureDoc(t, root, "ts-test", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint(approveReqBody)))
+	writeFeatureDoc(t, root, "ts-test", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("requirements.md", approveReqBody)))
 
 	state, err := LoadFeatureState(root, "ts-test")
 	if err != nil {
@@ -203,8 +203,8 @@ func TestLoadFeatureStateReportsCompletedImplementationPlan(t *testing.T) {
     - Verification: ` + "`go test ./internal/spec`" + `
 `
 	writeFeatureDoc(t, root, "todo-app-demo", "requirements.md", approvedRequirementsContent(approveReqBody, "2026-03-21T14:00:00Z"))
-	writeFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint(approveReqBody)))
-	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", approvedTasksContent(completedPlanBody, "2026-03-21T14:20:00Z", "2026-03-21T14:10:00Z", spec.Fingerprint(approveDesignBody)))
+	writeFeatureDoc(t, root, "todo-app-demo", "design.md", approvedDesignContent(approveDesignBody, "2026-03-21T14:10:00Z", "2026-03-21T14:00:00Z", spec.Fingerprint("requirements.md", approveReqBody)))
+	writeFeatureDoc(t, root, "todo-app-demo", "tasks.md", approvedTasksContent(completedPlanBody, "2026-03-21T14:20:00Z", "2026-03-21T14:10:00Z", spec.Fingerprint("design.md", approveDesignBody)))
 
 	state, err := LoadFeatureState(root, "todo-app-demo")
 	if err != nil {

--- a/internal/workflow/verify.go
+++ b/internal/workflow/verify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/andrearaponi/walden/internal/evidence"
@@ -27,13 +28,18 @@ type VerifyResult struct {
 	Checked  bool
 	Skipped  []string
 	Pruned   []string
+	// Warnings carry run-level purity observations: the tree drifted across
+	// the run, or side-effect detection had to be skipped.
+	Warnings []string
 }
 
 // Verify re-executes the proofs of completed tasks against the current
 // working tree: non-verified ones by default, every one with all. Fresh
 // evidence replaces each task's entry unless check is set, which reports
 // without persisting anything. A failing proof never aborts the run — every
-// selected task is re-proven and failures are collected.
+// selected task is re-proven and failures are collected. Re-verification is
+// pure by contract: a proof that modifies the working tree fails its task,
+// with `.walden/` excluded as the ledger's own legitimate write path.
 func Verify(ctx context.Context, root, featureName string, all, check bool, runner shell.Runner) (VerifyResult, error) {
 	if runner == nil {
 		return VerifyResult{}, fmt.Errorf("proof runner is required")
@@ -62,12 +68,18 @@ func Verify(ctx context.Context, root, featureName string, all, check bool, runn
 	}
 	ledger.Feature = feature.Name
 
-	// Selection compares against the pre-run identity; the identity written
-	// into refreshed records is computed AFTER the proofs, because proofs
-	// that regenerate tracked artifacts (builds, go generate) change the
-	// tree they prove — the record must bind to the tree that exists once
-	// the proof has passed, exactly as CompleteTask does.
-	identity, _ := evidence.Identity(ctx, identityRunner, root)
+	// Purity chain: one manifest before the loop (its digest doubles as the
+	// selection identity) and one after each task's proof. Completion may
+	// legitimately mutate the tree; re-verification claims the current tree
+	// satisfies the proofs, so a proof that moves the manifest fails its
+	// task instead of silently dirtying the repository being certified.
+	previous, manifestOK := evidence.CaptureManifest(ctx, identityRunner, root)
+	initial := previous
+	detectionDegraded := !manifestOK
+	identity := ""
+	if manifestOK {
+		identity = previous.Digest()
+	}
 	current := evidence.ChainFingerprints{
 		Requirements: feature.Requirements.Fields["approved_fingerprint"],
 		Design:       feature.Design.Fields["approved_fingerprint"],
@@ -97,7 +109,7 @@ func Verify(ctx context.Context, root, featureName string, all, check bool, runn
 		fingerprint := executableTaskFingerprint(executable)
 
 		if !all {
-			derived := evidence.Derive(ledger, current, identity, identity != "", []evidence.LeafTask{
+			derived := evidence.Derive(ledger, current, identity, manifestOK, []evidence.LeafTask{
 				{ID: task.ID, Completed: true, Fingerprint: fingerprint},
 			})
 			if derived[0].State == evidence.StateVerified {
@@ -107,22 +119,45 @@ func Verify(ctx context.Context, root, featureName string, all, check bool, runn
 		}
 
 		stepResults, _, proofErr := executeProof(ctx, runner, executable)
+
+		// The record binds the tree the proof actually left behind; when the
+		// proof was pure that is the same tree it started from.
+		var sideEffectPaths []string
+		recordIdentity := ""
+		if manifestOK {
+			if post, postOK := evidence.CaptureManifest(ctx, identityRunner, root); postOK {
+				sideEffectPaths = evidence.DiffPaths(previous, post)
+				previous = post
+				recordIdentity = post.Digest()
+			} else {
+				detectionDegraded = true
+			}
+		}
+
 		record := evidence.Record{
 			TaskFingerprint:         fingerprint,
 			RequirementsFingerprint: current.Requirements,
 			DesignFingerprint:       current.Design,
 			TasksFingerprint:        feature.Tasks.Fields["approved_fingerprint"],
+			CodeIdentity:            recordIdentity,
 			Steps:                   stepResults,
 			Result:                  evidence.ResultPassed,
 			VerifiedAt:              verifiedAt,
 		}
 
 		outcome := VerifyOutcome{TaskID: task.ID, State: evidence.StateVerified, Passed: true}
-		if proofErr != nil {
+		switch {
+		case proofErr != nil:
 			record.Result = evidence.ResultFailed
 			outcome.State = evidence.StateFailed
 			outcome.Passed = false
 			outcome.Failure = proofErr.Error()
+			result.Failed = append(result.Failed, task.ID)
+		case len(sideEffectPaths) > 0:
+			record.Result = evidence.ResultFailed
+			outcome.State = evidence.StateFailed
+			outcome.Passed = false
+			outcome.Failure = fmt.Sprintf("working tree changed while task %s proof ran: modified paths: %s", task.ID, formatChangedPaths(sideEffectPaths))
 			result.Failed = append(result.Failed, task.ID)
 		}
 
@@ -132,11 +167,17 @@ func Verify(ctx context.Context, root, featureName string, all, check bool, runn
 		result.Outcomes = append(result.Outcomes, outcome)
 	}
 
+	if detectionDegraded {
+		result.Warnings = append(result.Warnings, "side-effect detection skipped: code identity unavailable (git not usable here)")
+	}
+	if manifestOK {
+		if drift := evidence.DiffPaths(initial, previous); len(drift) > 0 {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("proof side effects modified the repository: %s", formatChangedPaths(drift)))
+		}
+	}
+
 	if !check && (len(refreshed) > 0 || len(result.Pruned) > 0) {
-		// The post-proof identity: the tree the proofs actually left behind.
-		finalIdentity, _ := evidence.Identity(ctx, identityRunner, root)
 		for taskID, record := range refreshed {
-			record.CodeIdentity = finalIdentity
 			ledger.Tasks[taskID] = record
 		}
 		// The state map is a claim about the current plan: entries for task
@@ -153,6 +194,16 @@ func Verify(ctx context.Context, root, featureName string, all, check bool, runn
 		_ = check
 	}
 	return result, nil
+}
+
+// formatChangedPaths keeps side-effect failures readable on wide mutations:
+// the first ten paths verbatim, the rest as a count.
+func formatChangedPaths(paths []string) string {
+	const maxListed = 10
+	if len(paths) <= maxListed {
+		return strings.Join(paths, ", ")
+	}
+	return fmt.Sprintf("%s, +%d more", strings.Join(paths[:maxListed], ", "), len(paths)-maxListed)
 }
 
 // toExecutableTask bridges a parsed task into the execution view.

--- a/internal/workflow/verify_test.go
+++ b/internal/workflow/verify_test.go
@@ -271,16 +271,76 @@ func testDigest(content []byte) string {
 	return hex.EncodeToString(sum[:])
 }
 
-func TestVerifyRecordsPostProofIdentity(t *testing.T) {
+func TestVerifySideEffectFailsTask(t *testing.T) {
 	root := t.TempDir()
 	writeVerifyFixture(t, root)
 	overrideIdentityRunner(t, &dynamicIdentityRunner{root: root})
 	completeBoth(t, root)
 
-	// The proofs regenerate a tracked-visible artifact: the identity at the
-	// start of the run is not the identity of the tree the proofs leave.
-	if _, err := Verify(context.Background(), root, "todo-app-demo", true, false, &sideEffectRunner{root: root}); err != nil {
+	// Every proof regenerates an artifact inside the tree: re-verification
+	// must fail each mutating task, name the path, and keep going.
+	result, err := Verify(context.Background(), root, "todo-app-demo", true, false, &sideEffectRunner{root: root})
+	if err != nil {
 		t.Fatalf("Verify returned error: %v", err)
+	}
+
+	if len(result.Outcomes) != 2 {
+		t.Fatalf("expected the run to continue across both tasks, got %d outcomes", len(result.Outcomes))
+	}
+	for _, outcome := range result.Outcomes {
+		if outcome.Passed || outcome.State != evidence.StateFailed {
+			t.Fatalf("task %s = %s, want a side-effect failure", outcome.TaskID, outcome.State)
+		}
+		if !strings.Contains(outcome.Failure, "working tree changed while task "+outcome.TaskID+" proof ran") {
+			t.Fatalf("failure does not attribute the side effect: %q", outcome.Failure)
+		}
+		if !strings.Contains(outcome.Failure, "generated.txt") {
+			t.Fatalf("failure does not name the modified path: %q", outcome.Failure)
+		}
+	}
+	if len(result.Failed) != 2 {
+		t.Fatalf("expected both tasks in Failed, got %v", result.Failed)
+	}
+
+	// Persisting mode records the side-effect failures, bound to the tree
+	// each proof left behind.
+	ledger, err := evidence.Load(root, "todo-app-demo")
+	if err != nil {
+		t.Fatalf("load ledger: %v", err)
+	}
+	for _, taskID := range []string{"1.1", "1.2"} {
+		record, exists := ledger.Tasks[taskID]
+		if !exists {
+			t.Fatalf("no record persisted for task %s", taskID)
+		}
+		if record.Result != evidence.ResultFailed {
+			t.Fatalf("task %s recorded %q, want failed", taskID, record.Result)
+		}
+		if record.CodeIdentity == "" {
+			t.Fatalf("task %s record lacks the post-proof identity", taskID)
+		}
+	}
+}
+
+func TestVerifyPureProofsStayVerified(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, &dynamicIdentityRunner{root: root})
+	completeBoth(t, root)
+
+	// Pure proofs: no writes anywhere — every task re-verifies clean.
+	runner := testutil.NewFakeRunner(
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+		testutil.Response{Stdout: "ok", ExitCode: 0},
+	)
+	result, err := Verify(context.Background(), root, "todo-app-demo", true, false, runner)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	for _, outcome := range result.Outcomes {
+		if !outcome.Passed || outcome.State != evidence.StateVerified {
+			t.Fatalf("pure proof for task %s = %s (%s), want verified", outcome.TaskID, outcome.State, outcome.Failure)
+		}
 	}
 
 	_, entries, err := EvidenceReport(context.Background(), root, "todo-app-demo")
@@ -289,7 +349,7 @@ func TestVerifyRecordsPostProofIdentity(t *testing.T) {
 	}
 	for _, entry := range entries {
 		if entry.State != evidence.StateVerified {
-			t.Fatalf("task %s = %s immediately after verify, want verified (identity recorded pre-proof?)", entry.TaskID, entry.State)
+			t.Fatalf("task %s = %s after a pure verify, want verified", entry.TaskID, entry.State)
 		}
 	}
 }
@@ -337,5 +397,86 @@ func TestVerifyPrunesOrphanedEntries(t *testing.T) {
 	}
 	if len(final.Tasks) != 2 {
 		t.Fatalf("ledger holds %d entries, want the 2 plan tasks", len(final.Tasks))
+	}
+}
+
+func TestVerifySideEffectWarnings(t *testing.T) {
+	t.Run("run-level drift warning", func(t *testing.T) {
+		root := t.TempDir()
+		writeVerifyFixture(t, root)
+		overrideIdentityRunner(t, &dynamicIdentityRunner{root: root})
+		completeBoth(t, root)
+
+		result, err := Verify(context.Background(), root, "todo-app-demo", true, false, &sideEffectRunner{root: root})
+		if err != nil {
+			t.Fatalf("Verify returned error: %v", err)
+		}
+		found := false
+		for _, warning := range result.Warnings {
+			if strings.Contains(warning, "proof side effects modified the repository") && strings.Contains(warning, "generated.txt") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected a run-level drift warning naming the path, got %v", result.Warnings)
+		}
+	})
+
+	t.Run("detection skipped when git unusable", func(t *testing.T) {
+		root := t.TempDir()
+		writeVerifyFixture(t, root)
+		overrideIdentityRunner(t, identityYielding("100644 blob aaa\tmain.go\n"))
+		completeBoth(t, root)
+
+		overrideIdentityRunner(t, &scriptedIdentityRunner{
+			statusResponse: shell.Response{ExitCode: 128},
+			lsTreeResponse: shell.Response{ExitCode: 128},
+		})
+		result, err := Verify(context.Background(), root, "todo-app-demo", true, false, testutil.NewFakeRunner(
+			testutil.Response{Stdout: "ok", ExitCode: 0},
+			testutil.Response{Stdout: "ok", ExitCode: 0},
+		))
+		if err != nil {
+			t.Fatalf("Verify returned error: %v", err)
+		}
+		found := false
+		for _, warning := range result.Warnings {
+			if strings.Contains(warning, "side-effect detection skipped") {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected a detection-skipped warning, got %v", result.Warnings)
+		}
+	})
+}
+
+func TestVerifyCheckLeavesLedgerUntouched(t *testing.T) {
+	root := t.TempDir()
+	writeVerifyFixture(t, root)
+	overrideIdentityRunner(t, &dynamicIdentityRunner{root: root})
+	completeBoth(t, root)
+
+	ledgerPath := evidence.DocumentPath(root, "todo-app-demo")
+	before, err := os.ReadFile(ledgerPath)
+	if err != nil {
+		t.Fatalf("read ledger before check: %v", err)
+	}
+
+	// Even a mutating proof in check mode reports failures without writing.
+	result, err := Verify(context.Background(), root, "todo-app-demo", true, true, &sideEffectRunner{root: root})
+	if err != nil {
+		t.Fatalf("Verify --check returned error: %v", err)
+	}
+	if len(result.Failed) != 2 {
+		t.Fatalf("check mode should report the side-effect failures, got %v", result.Failed)
+	}
+
+	after, err := os.ReadFile(ledgerPath)
+	if err != nil {
+		t.Fatalf("read ledger after check: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Fatal("check mode modified the evidence ledger")
 	}
 }

--- a/skill/walden/SKILL.md
+++ b/skill/walden/SKILL.md
@@ -38,7 +38,7 @@ Walden is an open source spec-driven delivery kernel. It is not a complete enter
 - Use `walden review open <feature-name> --phase requirements|design|tasks` and `walden review approve <feature-name> --phase requirements|design|tasks` for deterministic review-state transitions.
 - Use `walden task status <feature-name> [--json]`, `walden task start <feature-name> [task-id] [--json]`, and `walden task complete <feature-name> <task-id> [--json]` for deterministic execution flow.
 - Use `walden task complete-all <feature-name> [--json]` to complete all runnable leaf tasks in order, stopping on first failure.
-- Use `walden verify <feature-name> [--all] [--check] [--json]` to re-execute completed tasks' proofs against the current code and refresh execution evidence; `--check` reports without persisting anything.
+- Use `walden verify <feature-name> [--all] [--check] [--json]` to re-execute completed tasks' proofs against the current code and refresh execution evidence; `--check` reports without persisting anything. Re-verification is pure: a proof that modifies the working tree fails its task naming the changed paths — author proofs as read-only assertions and route build outputs outside the repository (task completion keeps accepting generator mutations; the recorded identity binds the resulting tree).
 - Use `walden evidence status <feature-name> [--json]` to inspect each task's derived evidence state: verified, stale-spec, stale-code, failed, unrecorded, or pending.
 - Use `walden release check [<feature-name>] [--strict] [--json]` to certify the repository (or one feature) as releasable in one deterministic verdict; it executes no proofs and writes nothing.
 - Use `walden reconcile <feature-name> [--json]` when approved upstream documents changed or the approval chain is stale.
@@ -407,7 +407,8 @@ Task generation starts only from approved and non-stale design.
 - Reference design sections on every leaf task.
 - Add a `Verification:` block on every leaf task using the structured `command` format (Kubernetes pattern). The CLI executes commands via `exec.Command` without a shell, so use JSON arrays for exact argument control.
 - Optionally add a `covers:` field on proof steps to declare which acceptance criteria the proof demonstrates.
-- Prefer an `expect_output` assertion on test-running proof steps so a pattern that matches zero tests cannot pass vacuously. The CLI tracks proof reference coverage separately from task reference coverage and reports both in `walden validate --json`.
+- Prefer an `expect_output` assertion on test-running proof steps so a pattern that matches zero tests cannot pass vacuously.
+- Declare `timeout:` on proof steps that legitimately run long; every step is otherwise bounded by the executor's 10-minute default, and exceeding the budget is a proof failure. The CLI tracks proof reference coverage separately from task reference coverage and reports both in `walden validate --json`.
 - Approve with `walden review approve`, which records the upstream approval timestamp and fingerprint (`source_design_approved_at`, `source_design_fingerprint`).
 
 ### Verification Format
@@ -459,6 +460,14 @@ For proof reference coverage, add `covers:` to declare which acceptance criteria
 ```
 
 The CLI validates that `covers:` IDs reference known acceptance criteria and reports proof reference coverage separately from task reference coverage in the JSON output.
+
+Per-step `timeout:` (a positive Go duration string) bounds a slow proof; steps without one run under the executor's 10-minute default, and exceeding the budget is a proof failure:
+
+```markdown
+    - Verification:
+      - command: ["go", "test", "-run", "TestSlowIntegration", "./internal/integration"]
+        timeout: 30m
+```
 
 Legacy single-line format (`Verification: go test ./...`) still works but does not support quotes, pipes, or shell operators.
 
@@ -544,7 +553,7 @@ Execution is for approved specs only.
 - When the user asks whether the work is releasable — or before any tag, release branch, or delivery hand-off — run `walden release check` and report its verdict; do not assemble the answer from separate status checks.
 - The gate certifies and never releases: approved fresh chains, full-spec validation, decision markers in approved documents, execution evidence, and a clean worktree outside `.walden/` fold into one exit code. Tags, changelogs, and publishing stay with you and the user, after certification passes.
 - Read a failed certification as a work list: every blocker names its remedy. Apply the remedies and rerun the gate; never edit state by hand to silence a blocker.
-- Planned-but-unexecuted tasks are informational and never block; pass `--strict` only when the user wants plans-complete certification. Strict certification also requires committed `.walden/` state — commit specs and evidence before certifying.
+- Planned-but-unexecuted tasks are informational and never block; pass `--strict` only when the user wants plans-complete certification. The verdict names the certified commit and a completion class — `complete` when every planned leaf task is executed, `with-pending` otherwise; JSON carries `certified_commit` and `completion` for pipeline policy. Strict certification also requires committed `.walden/` state — commit specs and evidence before certifying.
 - The dirty-worktree blocker has no bypass by design: the remedy is committing the work. Do not look for a flag. Certification also fails closed without usable git — a verdict must name the code identity it certified — and on unterminated HTML comments in approved documents.
 - Compose production and judgment: `walden verify <feature-name>` re-proves execution, then `walden release check` judges the result. In CI, gate the pipeline on the exit code and use `--json` for structure.
 

--- a/templates/spec/design.md.tmpl
+++ b/templates/spec/design.md.tmpl
@@ -1,4 +1,5 @@
 ---
+walden_schema_version: {{ .SchemaVersion }}
 status: draft
 approved_at:
 last_modified: {{ .Timestamp }}

--- a/templates/spec/requirements.md.tmpl
+++ b/templates/spec/requirements.md.tmpl
@@ -1,4 +1,5 @@
 ---
+walden_schema_version: {{ .SchemaVersion }}
 status: draft
 approved_at:
 last_modified: {{ .Timestamp }}

--- a/templates/spec/tasks.md.tmpl
+++ b/templates/spec/tasks.md.tmpl
@@ -1,4 +1,5 @@
 ---
+walden_schema_version: {{ .SchemaVersion }}
 status: draft
 approved_at:
 last_modified: {{ .Timestamp }}


### PR DESCRIPTION
## v0.9.2 candidate — Batch 2 hardening

Three dogfooded specs — each delivered through Walden itself (approved chains, all leaf tasks completed with recorded evidence, `walden verify` green) — plus the skill update that teaches the new vocabulary.

### Proof execution policy (66db889)
- Every proof step runs under an effective timeout: per-step `timeout:` attribute (Go duration string), 10-minute default, expiry reported as a proof failure naming the budget.
- Process containment: process-group termination on deadline plus a bounded I/O wait — a hung proof, or an orphan process holding stdout, can no longer hang a command.
- Re-verification purity: a proof that modifies the working tree during `walden verify` fails its task naming the changed paths (`.walden/` exempt as the ledger's own write path); `task complete` keeps accepting generator mutations, with the recorded identity binding the resulting tree.

### Document evolution contract (4b69176)
- `walden_schema_version: v1alpha1` scaffolded by templates and stamped on every save — stamping-on-save migrates repositories through normal use; documents without the field load as legacy; unsupported versions are refused naming the declared version, the supported one, and the remedy.
- `x-` frontmatter extensions survive every mutation verbatim, serialized lexicographically after the core keys; unknown non-namespaced fields are refused with a rename-or-remove remedy instead of being silently deleted.
- Checkbox fingerprint normalization is scoped to `tasks.md`: checkbox edits in approved requirements or design now count as content changes, while marker-free documents keep byte-identical fingerprints.

### Release verdict facts (dbbfb20)
- `completion` class derived in the kernel: `complete` when every planned leaf task is executed, `with-pending` otherwise (`with-waivers` reserved for the v0.10 strict-by-default flip).
- `certified_commit` in the JSON result; the releasable summary names the short commit. Empty when git is unusable — the existing fail-closed blocker already reports that case.

### Skill (18cec41)
- Teaches the `timeout:` attribute, the verify purity contract, and the new verdict facts.

### Field validation
Exercised on two production-scale repositories (135-feature and 26-feature portfolios): portfolio validate ≤0.09s, full certification ≤0.25s, zero loader refusals across ~430 real documents, legacy documents load unchanged, and the new verdict facts populate correctly on both releasable and blocked outcomes.