### PR TITLE
docs: restructure by reader intent — learn, understand, operate, reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,37 @@
+# Walden Documentation
+
+Walden is a spec-driven delivery kernel: a deterministic CLI that takes a feature from intention to certified release through reviewed documents, executable proofs, and durable evidence. These pages are the reference for the mechanism, organized by what you are trying to do.
+
+## Learn
+
+- **[Quickstart](quickstart.md)** — one real feature from `repo init` to a releasable verdict, in ten minutes.
+
+## Understand
+
+- **[The Spec Lifecycle](lifecycle.md)** — the whole mechanism, end to end: how a feature is born, sealed, chained, executed, proven, and certified. Start here to understand *why* the commands do what they do.
+- **[Product Boundaries](boundaries.md)** — what the open-source kernel includes, what belongs to the orchestration layer above it, and where the line is.
+
+## Operate
+
+- **[The Daily Workflow](workflow.md)** — the command loop for authoring, approving, executing, reconciling, and certifying, phase by phase.
+- **[Brownfield Adoption](adoption.md)** — bringing a repository with existing specs into the current contract: `walden adopt`, triaging the partition, and retiring superseded eras.
+- **[CI Integration](ci.md)** — the generated validation workflow, evidence in pipelines, and gating releases on the certification verdict.
+
+## Reference
+
+- **[CLI Commands](reference/cli.md)** — every command: synopsis, flags, behavior, exit codes.
+- **[JSON Contract](reference/json.md)** — the versioned envelope, per-command result fields, the three evidence surfaces, and the additivity policy.
+- **[Spec File Format](reference/spec-format.md)** — the `.walden/` layout, document frontmatter, EARS criteria, the task and proof grammar, and every convention file.
+
+## Project
+
+- **[Roadmap](roadmap.md)** — current release, near-term work, and the enterprise layer.
+
+## Reading paths
+
+- *Evaluating Walden?* [Quickstart](quickstart.md), then [The Spec Lifecycle](lifecycle.md).
+- *Adopting it on an existing repository?* [The Spec Lifecycle](lifecycle.md), then [Brownfield Adoption](adoption.md).
+- *Using it every day?* [The Daily Workflow](workflow.md) with [CLI Commands](reference/cli.md) at hand.
+- *Building tooling on top?* [JSON Contract](reference/json.md), then [Spec File Format](reference/spec-format.md).
+
+Documentation describes the released version whose tag matches this checkout. Version history lives in the [CHANGELOG](../CHANGELOG.md); agent-facing operational instructions live in the embedded skill (`walden skill show`), which is distributed with the binary and intentionally self-contained.

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -1,0 +1,67 @@
+# Brownfield Adoption
+
+Repositories that adopted Walden early — or that accumulated specs under older CLI versions — hold approvals recorded before the current contract existed: approved documents without fingerprints, completed tasks without evidence records. `walden adopt` brings them into the contract without re-running the human approval ceremony, and without ever fabricating evidence.
+
+## Plan first
+
+```bash
+walden adopt            # whole portfolio
+walden adopt user-auth  # one feature
+```
+
+The default is a **read-only plan** that classifies every feature:
+
+| Class | Meaning | What apply would do |
+| --- | --- | --- |
+| `backfill` | Approved documents missing their fingerprints | Seal them, then re-prove unrecorded work |
+| `re-prove` | Chain already sealed and fresh; completed tasks lack evidence | Re-prove them |
+| `complete` | Nothing to adopt | Nothing |
+| `blocked` | A *present* fingerprint contradicts the content | Nothing — ever |
+
+```text
+ADOPTION PLAN — 133 backfill, 0 re-prove, 2 complete, 0 blocked (399 doc(s) to seal, 931 task(s) to re-prove)
+```
+
+The honesty rule that shapes the classifier: an **absent** fingerprint is sealable — the approval is on record, only the seal is missing, and stamping the current body's fingerprint under it is a stated, reviewable trust assumption. A **present but wrong** fingerprint is evidence of drift after approval — human reconcile territory, and the lane never writes there.
+
+Present the plan, review it, then:
+
+## Apply
+
+```bash
+walden adopt --apply
+```
+
+Apply seals the backfill class (stamping fingerprints and repairing empty chain links), then re-proves unrecorded completed work through the same machinery as `walden verify` — real proof execution, purity contract included, execution profiles on every record. The result is an honest partition:
+
+```text
+ADOPTION — sealed 399 doc(s), verified 472, failed 441, skipped 0, blocked 0
+```
+
+Exit `1` when anything failed, with the full per-feature partition rendered. Interrupted or partially failed runs **resume by classification** — re-running apply picks up exactly what is still unsealed or unproven; a second apply over a finished adoption is a no-op. The adoption diff is ordinary git state: review it and commit it like any other change.
+
+Plan-scale is cheap (a 135-feature portfolio classifies in under a second); apply costs what the proofs cost.
+
+## Triaging the partition
+
+A large failed partition is a work list, not a verdict on the adoption. In practice it decomposes into a few distinct populations:
+
+- **Superseded eras.** Specs describing a product generation that no longer exists — an old frontend whose test files are gone, runtime code long since replaced. These proofs can never pass again, and fixing them would mean resurrecting dead code. They want [retirement](#retirement), not repair.
+- **Mutating proofs.** Build or generate steps that write into the repository (`go build -o bin/…`, regenerated schemas). They fail the purity contract by design. Rewrite them as read-only assertions — `["go", "mod", "tidy", "-diff"]` instead of `["go", "mod", "tidy"]`, build outputs routed outside the tree.
+- **Real failures.** The remainder — usually small — is the genuine work list: proofs that name actual regressions on living code.
+
+## Retirement
+
+Superseded specs are **deleted, not labeled**. History lives in git — `git show` recovers any retired spec at any commit — so keeping dead directories in `.walden/specs/` only forces every future gate run and every future reader to wade through a product generation that no longer exists.
+
+The convention:
+
+1. Delete the feature's spec directory (and its evidence file).
+2. Record the retirement in `.walden/RETIRED.md` — one line per feature: name, date, reason, and the last commit where the spec was alive.
+3. One commit for the whole ceremony, so the retirement is a single, findable event in history.
+
+After retirement, `release check` judges only the living portfolio, and the narrative keeps its chapters: the repository ships a companion skill, [`walden-history`](../skill/walden-history/SKILL.md), that reconstructs sourced feature chronicles, product eras, and rework archaeology from committed `.walden/` history — and officiates the retirement ceremony itself.
+
+## After adoption
+
+The repository is on the current contract: fingerprinted chains, evidence with profiles, and a gate that means what it says. From here the [daily workflow](workflow.md) applies unchanged — and the first `walden release check` tells you exactly how far from certifiable the portfolio stands, one named blocker at a time.

--- a/docs/boundaries.md
+++ b/docs/boundaries.md
@@ -6,7 +6,7 @@ This document explains what Walden includes today and what is planned but not ye
 
 The open source release is a spec-driven delivery kernel. It includes:
 
-- **CLI** — deterministic workflow engine for phase enforcement, validation, review gates, task execution with verification proofs, reconciliation, and lesson logging.
+- **CLI** — deterministic workflow engine for phase enforcement, validation, review gates, task execution with verification proofs, the execution evidence ledger with re-verification (`walden verify`), the aggregate release gate (`walden release check`), brownfield adoption (`walden adopt`), reconciliation, and lesson logging.
 - **Skill** — optional AI-powered authoring layer that drafts requirements, designs, and task plans while delegating all deterministic operations to the CLI.
 - **File model** — `.walden/specs/` documents with YAML frontmatter for approval tracking and freshness.
 - **Templates** — repository bootstrap and feature scaffolding templates.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,49 @@
+# CI Integration
+
+Walden's commands are deterministic, exit-code honest, and split cleanly between producing evidence and judging it — which makes the CI story three small recipes rather than a framework.
+
+## Spec validation on every PR
+
+`walden repo init` generates `.github/workflows/validate-walden.yml`, pinned to the CLI version that generated it (`go install …/cmd/walden@vX.Y.Z`). It runs `walden validate <feature> --all --json` for every feature whenever `.walden/**` changes — structural validation, traceability, freshness — so a PR cannot merge a broken or stale spec chain unnoticed.
+
+The workflow is ordinary generated code: review it, commit it, adjust triggers to taste. Regenerating after a CLI upgrade re-pins it.
+
+## Evidence in pipelines: produce and judge
+
+The division of labor — [invariant #2](lifecycle.md#the-invariants) — maps directly onto pipeline stages:
+
+**Produce** (executes proofs, writes the ledger):
+
+```bash
+walden verify <feature> --check    # report-only: re-proves, writes nothing — the PR gate
+walden verify <feature>            # persisting: refreshes evidence — the merge/main job
+```
+
+`--check` is the pull-request shape: it answers "would the evidence hold on this tree?" with an exit code and no side effects. The persisting form belongs where its output can be committed — evidence documents are shared repository state, reviewed like the specs they prove, so a main-branch job that runs `verify` should commit the refreshed ledger (a dirty `.walden/` legitimately precedes its own commit and only warns at the gate; it blocks under `--strict`).
+
+Machines that run proofs should declare [environment probes](reference/spec-format.md#environmentmd): every record then carries the toolchain versions that produced it, and a later failure on a different machine diagnoses itself (`environment drift: go: recorded "go1.25.0" → current "go1.24.0"`).
+
+**Judge** (reads everything, writes nothing):
+
+```bash
+walden release check --json
+```
+
+Gate the release pipeline on the exit code. The verdict carries `completion` (`complete` | `with-pending` | `with-waivers`) and `certified_commit` — archive the JSON envelope and every release has a reproducible certification record naming the exact commit it judged.
+
+## The release job
+
+```bash
+walden verify <feature>            # re-prove execution on the current tree
+walden release check --strict --json   # certify; strict = the verdict must be reproducible from the commit
+```
+
+Policy knobs, all recorded, none silent:
+
+- **Pending work blocks by default.** A deliberate partial release is an explicit waiver — `--allow-pending --reason "<text>"` — and the reason plus waived task identifiers land in the archived verdict. Treat a waiver in CI as a decision that belongs to a human: pass it from a manually-set variable, never hardcode it into the pipeline.
+- **`--strict`** requires committed `.walden/` state, so the certification is reproducible including its evidence.
+- **No bypass exists** for uncommitted code outside `.walden/`, and a repository without usable git fails closed: certification requires a git-backed code identity.
+
+## Parsing output
+
+Every command takes `--json` and emits the [versioned envelope](reference/json.md) on success and error paths alike — parse `result` fields by name, gate on the process exit code, and treat unknown fields as future additions (the contract only grows within `schema_version: v0beta1`). Warnings ride `result.warnings`; do not drop them — purity violations during verify surface there, naming mutated paths and affected tasks.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,105 +1,14 @@
 # Concepts
 
-## Spec-Driven Delivery
+The conceptual documentation has moved and grown into [**The Spec Lifecycle**](lifecycle.md) — the whole mechanism end to end: documents and phases, fingerprint seals and the approval chain, the two execution lanes, the evidence ledger and derived states, environment profiles, and the certification verdict.
 
-Walden structures work as a sequence of reviewed documents. Every feature progresses through three phases before code is written:
+Quick pointers for topics this page used to cover:
 
-1. **Requirements** — What the feature must do, expressed as EARS acceptance criteria.
-2. **Design** — How the feature will be built, including architecture, alternatives, and tradeoffs.
-3. **Tasks** — What code to write, in what order, with what verification proof.
-
-This sequence is enforced by the CLI. You cannot skip phases, and you cannot execute tasks from an unapproved or stale plan.
-
-## The Two Halves
-
-Walden splits work into two complementary halves:
-
-**Deterministic (CLI)** — repeatable, rule-based operations:
-- Validating phase order and freshness
-- Opening and approving review gates
-- Checking execution readiness
-- Running verification proofs
-- Reconciling stale approval chains
-- Logging lessons
-
-**Non-deterministic (Skill or human)** — interpretation and judgment:
-- Drafting requirements and acceptance criteria
-- Designing architecture and evaluating alternatives
-- Generating implementation plans
-- Deciding when to re-plan from an earlier phase
-- Reviewing and approving documents
-
-The CLI never authors content. The skill never mutates workflow state.
-
-## Documents
-
-Every feature lives in `.walden/specs/{feature-name}/` with three files:
-
-- `requirements.md` — problem statement, user stories, EARS acceptance criteria, non-functional requirements, constraints, and out-of-scope items.
-- `design.md` — architecture, component interfaces, data models, options considered, failure modes, testing strategy, and requirement coverage mapping.
-- `tasks.md` — two-level task hierarchy where every leaf task references acceptance criteria IDs (e.g., `R1.AC1`), design sections, and a verification proof.
-
-## Frontmatter
-
-Each document begins with YAML frontmatter that tracks its lifecycle:
-
-```yaml
----
-status: draft|in-review|approved
-approved_at: 2026-03-22T10:00:00Z
-last_modified: 2026-03-22T10:00:00Z
-approved_fingerprint: sha256:...              # recorded at approval
-source_requirements_approved_at:              # design.md only
-source_requirements_fingerprint: sha256:...   # design.md only
-source_design_approved_at:                    # tasks.md only
-source_design_fingerprint: sha256:...         # tasks.md only
----
-```
-
-The `source_*` fields create an approval chain. `walden review approve` records a SHA-256 fingerprint of the approved body and binds downstream approvals to the upstream's fingerprint. If an upstream document's approved content changes, downstream documents become stale and must be reconciled.
-
-## Freshness
-
-Freshness is decided by content fingerprints alone; timestamps remain as human-readable context.
-
-An approved document is **intact** when its body still matches its own `approved_fingerprint` — editing approved content without re-approval makes it stale regardless of metadata. A downstream document is **fresh** when it is intact and its `source_*_fingerprint` equals the upstream's current `approved_fingerprint`. Content-identical re-approval does not stale the chain. Missing or malformed fingerprints fail closed with a named cause (documents approved by pre-fingerprint versions repair with one `walden reconcile` + re-approval cycle).
-
-Stale documents block execution. Use `walden reconcile` to repair the chain.
-
-## Verification Proofs
-
-Every leaf task in `tasks.md` includes a `Verification:` line. This is the command or script that proves the task is complete. The CLI runs this proof during `task complete` and only marks the task done if the proof passes.
-
-Proofs use structured `command` format to avoid shell-quoting issues:
-
-```markdown
-- Verification:
-  - command: ["go", "test", "./internal/workflow/..."]
-```
-
-## Evidence
-
-Completing a task records durable execution evidence in `.walden/evidence/<feature>.json`: the proof's steps bound to the approved chain fingerprints and to a deterministic code identity of the working tree (`.walden/` excluded, so committing the evidence never invalidates it). States are derived at read time — `verified`, `stale-spec`, `stale-code`, `failed`, `unrecorded`, `pending` — never stored. `walden verify` re-executes the proofs of completed tasks against the current code; `--check` reports without writing. The checkbox in `tasks.md` remains the human-readable projection; the evidence document is the authoritative execution state, committed and reviewed like the specs it proves.
-
-Task evidence appears on three surfaces sharing one record shape. The on-disk ledger is storage: a state map keyed by task identifier carrying facts only — fingerprints, code identity, profile, steps, `result` — never derived states. `verify --json` and `evidence status --json` are views: ordered lists of entries under `result.evidence`, both using the same field names for the same facts — `passed`, `failure`, `recorded_identity`, `current_identity`, `profile`. The map-versus-list difference is deliberate — the ledger is a claim about the plan's tasks, the outputs are reports — so consumers should parse the commands, not the file.
-
-## Constitution
-
-`.walden/constitution.md` is an optional repo-wide file that captures stable project context: tech stack, conventions, sanity checks, key files, and hard rules. Unlike the three per-feature documents (`requirements.md`, `design.md`, `tasks.md`), the constitution is not part of the approval workflow. It does not block any phase transition, does not have freshness rules, and is not validated by the CLI. The skill reads it when present to reduce context rediscovery across features.
-
-## Lessons
-
-`.walden/lessons.md` is an append-only file of reusable patterns. Each lesson records a trigger (what happened), a pattern (what went wrong), and a guardrail (what to check next time). The skill reviews lessons before non-trivial work to avoid repeating mistakes.
-
-## EARS
-
-The Easy Approach to Requirements Syntax. Walden uses EARS for all acceptance criteria:
-
-| Form | Template |
-| --- | --- |
-| Ubiquitous | The system SHALL [response] |
-| Event-driven | WHEN [trigger], the system SHALL [response] |
-| State-driven | WHILE [precondition], the system SHALL [response] |
-| Optional | WHERE [feature], the system SHALL [response] |
-| Unwanted | IF [trigger], THEN the system SHALL [response] |
-| Complex | WHILE [precondition], WHEN [trigger], the system SHALL [response] |
+- Spec-driven phases, the deterministic/non-deterministic split → [Lifecycle](lifecycle.md) and [Boundaries](boundaries.md)
+- Documents and frontmatter → [Spec File Format](reference/spec-format.md)
+- EARS acceptance criteria → [Spec File Format § EARS](reference/spec-format.md#ears-acceptance-criteria)
+- Freshness and fingerprints → [Lifecycle § The seal](lifecycle.md#the-seal) and [§ The chain](lifecycle.md#the-chain)
+- Verification proofs → [Spec File Format § tasks.md](reference/spec-format.md#tasksmd)
+- Evidence and derived states → [Lifecycle § Evidence](lifecycle.md#evidence)
+- The three evidence surfaces (JSON) → [JSON Contract](reference/json.md#evidence-one-shape-three-surfaces)
+- Constitution and lessons → [Spec File Format](reference/spec-format.md#constitutionmd)

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,0 +1,152 @@
+# The Spec Lifecycle
+
+This is the whole mechanism, told once, end to end — the biography of a feature from intention to certified release. Every command in the CLI exists to serve one station of this lifecycle; if you understand this page, the reference pages become obvious.
+
+## The problem Walden solves
+
+A checked checkbox proves that *one day* a test passed. Then the code changes, the requirements change — and the checkbox keeps saying "done" forever, even when it is no longer true. A spec document approved in March says nothing about whether the code in July still implements it.
+
+Walden's answer is to make every claim **re-provable**. Approvals are sealed with content fingerprints, completions are recorded with executable proofs bound to a snapshot of the world, and every state you can ask about is *derived by comparison at read time* — never stored, never trusted from memory. When something no longer holds, Walden is the one that tells you.
+
+Two photographs run through everything below: the fingerprint of the **specs** as approved, and the identity of the **code** as proven. Every mechanism in the lifecycle is a way of taking, chaining, or comparing those photographs.
+
+## Birth
+
+`walden feature init <name>` scaffolds `.walden/specs/<name>/` with three documents, each in `status: draft`:
+
+| Document | Question it answers |
+| --- | --- |
+| `requirements.md` | *What* must be true, as [EARS acceptance criteria](reference/spec-format.md#ears-acceptance-criteria) with stable IDs |
+| `design.md` | *How* it will be built — architecture, alternatives considered, failure modes, coverage |
+| `tasks.md` | *In what order*, with an executable proof per leaf task |
+
+Every document declares `walden_schema_version: v1alpha1` in its frontmatter. The CLI stamps the version on every save (so existing repositories migrate through normal use), refuses documents declaring an unsupported version, and rejects unknown frontmatter fields — while preserving `x-` prefixed extension fields verbatim, so integrators can attach durable metadata without forking the format.
+
+Phases are ordered and enforced: you cannot approve a design before its requirements, and you cannot execute tasks from an unapproved or stale plan. `walden validate` checks each document's structure and traceability at any point; `walden status` tells you where you are and what comes next.
+
+## The seal
+
+Approval is a two-step gate — `walden review open --phase <phase>` moves a document to `in-review`, `walden review approve` moves it to `approved` — and the approve step runs full phase validation first: nothing structurally invalid can be sealed.
+
+At approval, the CLI records `approved_fingerprint`: a SHA-256 over the document **body**. Three properties make this seal precise rather than brittle:
+
+- **Body-only.** Frontmatter never participates. Timestamps, status flips, and `x-` extension fields can change freely without invalidating an approval — only the approved *content* is sealed.
+- **Path-aware normalization.** For `tasks.md` only, checkbox states (`[ ]`/`[x]`) are normalized out of the fingerprint: executing the plan is not editing the plan. For every other document, every body byte counts.
+- **Fail-closed.** A missing or malformed fingerprint on an approved document is a named blocker, not a shrug. Documents approved by pre-fingerprint versions of the CLI repair through one `reconcile` + re-approval cycle — or in bulk through the [adoption lane](adoption.md).
+
+From this moment, "approved" is not a status label anyone typed. It is a claim the CLI can check byte-for-byte, forever.
+
+## The chain
+
+Approvals do not stand alone — they bind to what they were built on. When `design.md` is approved, its frontmatter records the requirements' fingerprint (`source_requirements_fingerprint`); when `tasks.md` is approved, it records the design's. The three seals form a chain:
+
+```text
+requirements.md ──fingerprint──▶ design.md ──fingerprint──▶ tasks.md
+     (what)          binds           (how)        binds       (in what order)
+```
+
+Freshness is decided by fingerprints alone:
+
+- A document is **intact** when its body still matches its own `approved_fingerprint`.
+- A downstream document is **fresh** when it is intact *and* its `source_*` fingerprint equals the upstream's current one.
+
+Edit an approved requirement, and the design and tasks built on it are stale *by construction* — no timestamps, no heuristics. Re-approving identical content does not stale anything: content-identical means fingerprint-identical.
+
+**Drift and repair.** Software changes; requirements change with it. When an upstream document must move, `walden reconcile <feature>` resets the modified document and everything downstream of it to draft and clears their fingerprints; the chain is then re-walked through the normal review gates, and re-approval records fresh seals. Stale documents block execution until reconciled — the plan you execute is always the plan that was approved against the requirements that exist.
+
+## Execution: two lanes, one proof grammar
+
+Every leaf task carries a proof — one or more steps in argv form, immune to shell quoting:
+
+```markdown
+- Verification:
+  - command: ["go", "test", "-run", "TestAuth", "./internal/auth"]
+    expect_output: "--- PASS: TestAuth"
+    timeout: 30m
+    covers: ["R1.AC1", "R1.AC2"]
+```
+
+A step passes when its exit code matches (`expect_exit`, default `0`) and its output contains the declared pattern (`expect_output` — declare it on test runners, so a `-run` pattern matching zero tests cannot pass vacuously). Every step runs under a timeout — declared, or a 10-minute default — and expiry kills the step's whole process group and fails the proof naming the exceeded budget. `covers` declares which acceptance criteria the proof demonstrates; the validator tracks proof coverage separately from task references.
+
+The same grammar serves two lanes with deliberately different contracts:
+
+**Completion** (`walden task complete`) is where implementation happens. The proof runs, and only a pass checks the box. The evidence record binds the tree the proof *left behind* — builds and generators legitimately mutate here, and the post-proof tree is what you will commit.
+
+**Re-verification** (`walden verify`) is where trust is refreshed. It re-executes the proofs of completed tasks against the current tree — and it is **pure by contract**: a proof that modifies the working tree fails its task, naming the modified paths (`.walden/` excluded, as the ledger's own legitimate write path). A failing proof never aborts the run; every selected task is re-proven and failures are collected into one honest partition.
+
+Verify records bind the code identity captured **at the start of the run**. Under purity the distinction is invisible — a compliant proof leaves the tree where it found it — but when a proof does mutate, the anchoring confines the damage: the mutant fails on its own side effects, while the tasks proven after it keep the identity the run promised, and the run-level warning names both the paths and the affected tasks (`proof side effects modified the repository: go.mod; tasks re-proven on the modified tree: 5.2, 5.3`). One misbehaving proof fails alone.
+
+Author verify-able proofs as read-only assertions: prefer `["go", "mod", "tidy", "-diff"]` over `["go", "mod", "tidy"]`, route build outputs outside the repository, and let tests assert instead of regenerate.
+
+## Evidence
+
+Completions and verifications write to `.walden/evidence/<feature>.json` — the **evidence ledger**. Each task's record holds facts only:
+
+- the proof's steps with their outcomes,
+- the fingerprints of the approved chain at proof time (the spec photograph),
+- the code identity at proof time (the code photograph — a deterministic digest over every tracked file's content, `.walden/` excluded so committing evidence never invalidates it),
+- the [execution profile](#the-environment) of the machine that ran it,
+- `result: passed | failed` and a timestamp.
+
+What the ledger deliberately does **not** hold is any state label. When you ask — `walden evidence status`, or any command that reads evidence — Walden takes today's photographs and compares:
+
+| State | Meaning |
+| --- | --- |
+| `verified` | Both photographs match: the proof's claim holds on the specs and code you have right now. |
+| `stale-spec` | The approved chain moved since the proof ran — the evidence certifies a different plan. |
+| `stale-code` | The tree moved since the proof ran — the evidence certifies a different implementation. |
+| `failed` | The recorded proof outcome is a failure — re-proven and found broken, with the task named. |
+| `unrecorded` | The task is checked but has no record — completed outside the ledger; re-prove it. |
+| `pending` | Not completed yet. |
+
+*Stale* does not mean broken. It means **"no longer known"** — the world moved since the claim was proven, and the honest state is a declared doubt. A code-only bugfix needs no spec ceremony: evidence goes `stale-code`, and one `walden verify` either restores `verified` on today's tree or names exactly which task's proof broke.
+
+The ledger is regenerable, not archival: it is the current truth, and history lives in git — the file is committed and reviewed like the specs it proves. Records for tasks that leave the plan are pruned on the next verify; a corrupted or lost record simply reads as `unrecorded` and is recreated by re-proving. Never a silent lie.
+
+## The environment
+
+Every record also carries the **execution profile** of the machine that produced it: `platform` (OS/arch) and `walden` (recording CLI version) always, plus the outputs of probes the repository declares in `.walden/environment.md`:
+
+```markdown
+# Environment Probes
+
+- go: ["go", "version"]
+- node: ["node", "--version"]
+```
+
+Profiles are diagnostic by design — they never change a derived state, so evidence recorded in CI keeps certifying on any machine. Their payoff is the failure you can finally read: when a proof that passed under go 1.25 fails on a machine running 1.24, the failure says so — `environment drift: go: recorded "go1.25.0" → current "go1.24.0"` — and `evidence status` shows recorded-versus-current differences per task. Fix the environment, or knowingly re-record on the current one; never edit proofs to paper over drift.
+
+## The verdict
+
+`walden release check` folds the whole lifecycle into one deterministic answer per feature, plus one repository-level check:
+
+| Criterion | What must hold |
+| --- | --- |
+| `chain` | Every document approved, every fingerprint intact, the chain fresh |
+| `validation` | Full-spec structural validation passes |
+| `decisions` | No unresolved `[decision: …]` markers in approved documents |
+| `evidence` | Every completed task's evidence derives `verified`; every planned task executed — or explicitly waived |
+| worktree | No uncommitted changes outside `.walden/` — what you certify is what you tag |
+
+Exit `0` if and only if no blocker exists; every blocker names its remedy. The gate is **judgment only**: it executes no proofs and writes nothing. `verify` produces evidence; `release check` judges it — so certification is cheap enough to run on every pipeline, and the verdict is reproducible from the commit it names (`certified_commit` in the result).
+
+**Pending work blocks by default.** An approved plan's unexecuted task means unimplemented acceptance criteria in the thing being tagged. Partial releases remain expressible — as a recorded decision: `--allow-pending --reason "<text>"` waives pending work for that verdict, the completion class becomes `with-waivers` (against `complete` and `with-pending`), and the reason plus the waived task identifiers ride the verdict itself. No reason, no waiver. `--strict` adds one requirement — committed `.walden/` state, so the verdict is reproducible including its evidence — and composes with a waiver.
+
+A repository without usable git fails closed: certification requires a git-backed code identity. There is no bypass flag for a dirty worktree.
+
+## Beyond one feature
+
+Two lanes extend the lifecycle across a whole portfolio:
+
+- **[Brownfield adoption](adoption.md)** — `walden adopt` brings repositories whose specs predate the current contract into it: sealing recorded approvals with fingerprint backfill, re-proving unrecorded work, and reporting an honest verified/failed partition.
+- **[Retirement](adoption.md#retirement)** — superseded specs are deleted, not labeled: history lives in git, an index entry in `.walden/RETIRED.md` records the ceremony, and the release gate judges only the living portfolio.
+
+## The invariants
+
+Five rules hold everywhere and explain most design decisions you will encounter:
+
+1. **Derive, don't store.** States (`verified`, `stale-*`, phase freshness) are computed from facts at read time. There is nothing to forget to update.
+2. **Produce and judge are separate.** Commands that execute proofs (`task complete`, `verify`, `adopt --apply`) write evidence; the gate (`release check`) only reads. No verdict has side effects.
+3. **Fail closed, name the remedy.** Missing fingerprints, unusable git, unsupported schema versions — each is a named blocker with its fix, never a silent pass.
+4. **The relaxation is always recorded.** There is no quiet bypass: waivers require a reason and ride the verdict; adoption's trust assumption is stated in the plan.
+5. **The JSON contract only grows.** Machine output is versioned (`schema_version: v0beta1`) and changes additively; see the [JSON reference](reference/json.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,145 @@
+# Quickstart
+
+One real feature, from an empty repository to a releasable verdict. Ten minutes, no AI required — the CLI is the whole mechanism; an agent skill can author the documents for you later, but everything below is what actually happens underneath.
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/andrearaponi/walden/main/install.sh | sh
+walden version
+```
+
+## Initialize
+
+```bash
+git init my-project && cd my-project
+walden repo init
+```
+
+This creates `.walden/` (a `constitution.md` for stable project context, a `lessons.md`, a scoped `.gitignore`) and a generated CI workflow (`.github/workflows/validate-walden.yml`) pinned to the version that generated it.
+
+```bash
+walden feature init "Greeting Service"
+```
+
+Feature names normalize to kebab-case: the spec lives in `.walden/specs/greeting-service/` as three draft documents — `requirements.md`, `design.md`, `tasks.md`.
+
+## Phase 1 — Requirements
+
+Edit `.walden/specs/greeting-service/requirements.md`. Keep the frontmatter; replace the template body:
+
+```markdown
+# Requirements Document
+
+## Introduction
+
+A command that greets a named user, as the smallest end-to-end slice of the CLI.
+
+## Requirements
+
+### R1 Greeting
+
+**User Story:** As a user, I want a greeting by name, so that I know the CLI sees my input.
+
+#### Acceptance Criteria
+
+1. `R1.AC1` WHEN the user runs `greet <name>`, the system SHALL print `Hello, <name>!`.
+2. `R1.AC2` IF `<name>` is empty, THEN the system SHALL exit non-zero naming the missing argument.
+
+## Non-Functional Requirements
+
+- `NFR1` The command SHALL complete in under one second. (bridged by `R1.AC1`)
+
+## Constraints And Dependencies
+
+- `C1` Standard library only.
+
+## Out Of Scope
+
+- Localization.
+```
+
+Validate, then walk the review gate:
+
+```bash
+walden validate greeting-service
+walden review open greeting-service --phase requirements
+walden review approve greeting-service --phase requirements
+```
+
+Approval does more than flip a status: it records a SHA-256 **fingerprint of the approved body** in the frontmatter. From now on, any edit to this content is detectable — and stales everything built on top of it. This is the first link of the [approval chain](lifecycle.md#the-seal).
+
+## Phase 2 — Design
+
+Edit `design.md` (architecture, at least one alternative considered, failure modes, testing strategy, a requirement coverage table — the validator checks the structure), then:
+
+```bash
+walden validate greeting-service
+walden review open greeting-service --phase design
+walden review approve greeting-service --phase design
+```
+
+The design's approval binds to the requirements' fingerprint. If requirements change later, the design is stale by construction, not by convention.
+
+## Phase 3 — Tasks
+
+Edit `tasks.md`: a two-level plan where every leaf task names the acceptance criteria it implements, the design section it follows, and — the part that matters — an executable **proof**:
+
+```markdown
+# Implementation Plan
+
+- [ ] 1. Greeting command
+  - [ ] 1.1 Implement greet with argument validation
+    - Requirements: `R1.AC1`, `R1.AC2`, `NFR1`
+    - Design: Command Surface
+    - Verification:
+      - command: ["go", "test", "-run", "TestGreet", "./..."]
+        expect_output: "--- PASS: TestGreet"
+        covers: ["R1.AC1", "R1.AC2"]
+```
+
+```bash
+walden validate greeting-service
+walden review open greeting-service --phase tasks
+walden review approve greeting-service --phase tasks
+```
+
+## Execute
+
+Write the code and the test, then complete the task — the CLI runs the proof and refuses the completion if it fails:
+
+```bash
+walden task status greeting-service     # readiness and next runnable task
+walden task complete greeting-service 1.1
+```
+
+A passing completion checks the box **and** writes a record to `.walden/evidence/greeting-service.json`: the proof's steps and outcome, bound to the approved spec fingerprints and to a digest of the working tree. "Done" is now a claim you can re-prove.
+
+## Trust, later
+
+Weeks pass, code changes. Ask what still holds:
+
+```bash
+walden evidence status greeting-service   # derived state per task, ~milliseconds, never writes
+walden verify greeting-service            # re-runs proofs for anything no longer verified
+```
+
+States are **derived at read time** by comparing recorded fingerprints against the present — `verified`, `stale-spec`, `stale-code`, `failed`, `unrecorded`, `pending`. Nothing ever stores "stale" on disk; the comparison is recomputed every time you ask.
+
+## Certify
+
+```bash
+walden release check
+```
+
+One deterministic verdict: approved fresh chains, full-spec validation, no unresolved `[decision:]` markers, execution evidence verified, pending work executed or explicitly waived, clean worktree. Exit `0` if and only if no blocker exists — and every blocker names its remedy. The gate executes no proofs and writes nothing: `verify` produces evidence, `release check` judges it.
+
+```text
+Summary: RELEASABLE — 1 feature(s) certified, completion complete, commit 3f2a91c40d77
+```
+
+## Where to next
+
+- The mechanism behind each step: [The Spec Lifecycle](lifecycle.md)
+- The full command loop, including reconciliation and lessons: [The Daily Workflow](workflow.md)
+- An existing repository with specs that predate Walden's current contract: [Brownfield Adoption](adoption.md)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,117 @@
+# CLI Reference
+
+Every command, with behavior, flags, and exit codes. Global conventions first:
+
+- **`--json`** on any command emits the [versioned envelope](json.md) instead of text — same facts, same exit code.
+- **Exit codes** are the contract: `0` means the command's claim holds (valid, releasable, all proofs passed); `1` means blockers, failures, or a refused invocation — always with the remedy named. Reports that never gate (like `evidence status`) always exit `0`.
+- **Refusals over surprises**: unknown flags, missing required values, and invalid combinations are rejected with the fix named, on every command uniformly. Each command supports `--help`.
+- Commands run against the current working directory's repository.
+
+## Setup
+
+### `walden version [--json]`
+
+Prints CLI version, JSON contract version (`v0beta1`), and supported document schema (`v1alpha1`).
+
+### `walden update [--check] [--version <tag>] [--json]`
+
+Self-updates the binary from GitHub releases with checksum verification and rollback on failure, then re-syncs every installed skill. `--check` reports availability without applying; `--version` pins a specific tag (strict `vX.Y.Z` tags only).
+
+### `walden repo init [--json]`
+
+Initializes Walden in the current repository: `.walden/` (`constitution.md`, `lessons.md`, scoped `.gitignore`), a PR template, and the generated CI workflow pinned to this CLI version. Initializes git first if absent. Idempotent.
+
+### `walden feature init <name> [--json]`
+
+Scaffolds `.walden/specs/<kebab-name>/` with the three draft documents. Refuses names that normalize to empty.
+
+## Authoring and gates
+
+### `walden status <feature> [--json]`
+
+Current phase, blockers, and the next action. Read-only.
+
+### `walden validate [<feature>] [--all] [--json]`
+
+Structural validation: frontmatter contract, EARS criteria shape, traceability (task references to criteria and design sections), proof coverage (`covers:`), freshness of the approval chain. Without `--all`, validates up to the current phase; with it, the full spec. With no feature name, validates the whole portfolio. Exit `1` on any finding.
+
+### `walden review open <feature> --phase <requirements|design|tasks> [--json]`
+
+Opens the review gate: moves the phase document to `in-review`. Refuses out-of-order phases.
+
+### `walden review approve <feature> --phase <phase> [--json]`
+
+Runs full phase validation, then seals the approval: `status: approved`, `approved_at`, and the body's `approved_fingerprint`; downstream documents record the upstream fingerprint as their `source_*_fingerprint` when they are approved in turn. Nothing invalid can be sealed.
+
+### `walden reconcile <feature> [--json]`
+
+Repairs a stale chain after upstream edits: resets the modified document and everything downstream to draft, clearing their fingerprints for re-approval. Read-only on fresh chains.
+
+## Execution
+
+### `walden task status <feature> [--json]`
+
+Execution readiness: gate state, blockers, the next runnable task, and evidence warnings when completed tasks are no longer verified.
+
+### `walden task start <feature> [task-id] [--json]`
+
+Resolves normalized execution context for a task (the next runnable one when no id is given): requirements referenced, design sections, verification steps.
+
+### `walden task complete <feature> <task-id> [--json]`
+
+Runs the task's proof steps; on pass, records the evidence (steps, chain fingerprints, post-proof code identity, execution profile) and checks the box. On failure the box stays unchecked and the failing step is named. Every step runs under its declared `timeout:` or the 10-minute default; expiry kills the step's process group and fails the proof.
+
+### `walden task complete-all <feature> [--json]`
+
+Completes all runnable tasks in order, stopping at the first failing proof while preserving earlier completions.
+
+## Evidence
+
+### `walden evidence status <feature> [--json]`
+
+Derives each task's evidence state — `verified`, `stale-spec`, `stale-code`, `failed`, `unrecorded`, `pending` — by comparing recorded fingerprints, code identity, and profile against the present. Shows recorded-versus-current profile drift per task. Pure read, milliseconds, always exit `0`: a report, never a gate.
+
+### `walden verify <feature> [--all] [--check] [--json]`
+
+Re-executes the proofs of completed tasks against the current tree: those no longer `verified` by default, every one with `--all`. Fresh evidence replaces each task's record; `--check` reports without persisting anything. A failing proof never aborts the run — every selected task is re-proven and failures are collected. Exit `1` if any proof failed.
+
+Re-verification is **pure**: a proof that modifies the working tree (`.walden/` excluded) fails its task naming the modified paths. Records bind the code identity captured at run start, so one mutating proof cannot poison the identity of tasks proven after it; the run warning names both the mutated paths and the affected tasks. Entries for tasks that left the plan are pruned.
+
+### `walden adopt [<feature>] [--apply] [--json]`
+
+Brownfield lane. Default is a read-only plan classifying every feature (`backfill` / `re-prove` / `complete` / `blocked`); `--apply` seals recorded approvals (absent fingerprints only — present-but-wrong is `blocked`, never written), repairs empty chain links, then re-proves unrecorded completed work through the verify machinery. Resumes by classification; idempotent once finished. Exit `1` when any proof failed, with the full per-feature partition rendered. See [Brownfield Adoption](../adoption.md).
+
+## Certification
+
+### `walden release check [<feature>] [--strict] [--allow-pending --reason <text>] [--json]`
+
+One deterministic verdict per feature — `chain`, `validation`, `decisions`, `evidence` criteria — plus the repository-level clean-worktree check. Executes no proofs, writes nothing. Exit `0` iff no blocker.
+
+- Pending leaf tasks **block by default**; `--allow-pending --reason "<text>"` waives them for this verdict, recording reason and task identifiers in the result (completion class `with-waivers`). `--allow-pending` without a non-empty reason, or `--reason` alone, is refused.
+- `--strict` additionally requires committed `.walden/` state.
+- Uncommitted changes outside `.walden/` always block, with no bypass. No usable git fails closed. Dirty `.walden/` warns by default (a refreshed ledger legitimately precedes its own commit) and blocks under `--strict`.
+- The verdict carries `completion` (`complete` | `with-pending` | `with-waivers`) and `certified_commit`.
+
+## Lessons
+
+### `walden lesson log --feature <name> --phase <phase> --trigger <text> --lesson <text> --guardrail <text> [--json]`
+
+Appends a structured lesson to `.walden/lessons.md`: what happened, what was learned, and the guardrail that prevents the repeat.
+
+## Skills
+
+### `walden skill install <agent>|--all [--project] [--json]`
+
+Installs the embedded AI skill for `claude`, `codex`, `copilot`, or `opencode` (user scope by default, `--project` for repository scope). The skill is versioned with the binary; `walden update` re-syncs installed copies.
+
+### `walden skill uninstall <agent>|--all [--project] [--json]`
+
+Removes installed skills.
+
+### `walden skill status [--json]`
+
+Reports installed skills and drift against the embedded copy.
+
+### `walden skill show [--json]`
+
+Prints the embedded `SKILL.md`.

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -1,0 +1,108 @@
+# JSON Contract
+
+Every command takes `--json` and emits one versioned envelope on stdout — on success and error paths alike. This page is the contract for tooling: field names, the three evidence surfaces, and what "additive" promises.
+
+## The envelope
+
+```json
+{
+  "schema_version": "v0beta1",
+  "command": "release-check",
+  "ok": true,
+  "result": { }
+}
+```
+
+- `schema_version` — the contract version. `v0beta1` until the CLI stabilizes at v1.0.0; within a schema version, changes are **additive only**: existing fields keep their names and meanings, new fields appear. Parse by name, ignore what you don't know.
+- `command` — the invoked command's identifier (e.g. `verify`, `evidence-status`, `release-check`).
+- `ok` — `false` when the result carries an error outcome. Gate on the **process exit code**, which is the primary contract; `ok` mirrors it.
+- `result` — the command-specific payload, drawn from one shared field vocabulary.
+
+## Common result fields
+
+Every command populates the subset that applies:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `summary` | string | One-line human outcome — display it, don't parse it |
+| `next_action` | string | The single next step, when one exists |
+| `blockers` | string[] | Named blockers, each carrying its remedy |
+| `warnings` | string[] | Non-blocking observations. **Do not drop these** — verify's purity violations surface here |
+| `exit_code` | int | Mirrors the process exit code |
+| `created_files`, `updated_files` | string[] | Filesystem effects (init, scaffold) |
+| `current_phase` | string | Workflow position (status, review) |
+| `completed_tasks`, `auto_completed` | string[] | Execution effects (task complete) |
+| `validated_phases`, `skipped_phases` | string[] | Validation scope |
+| `document_schema_version` | string | Supported document schema (`version` command) |
+
+## Evidence: one shape, three surfaces
+
+Task evidence appears on three surfaces. Two are **views** — ordered lists under `result.evidence`, sharing one entry shape and one set of field names. One is **storage** — the on-disk ledger. Consumers should parse the commands, not the file.
+
+The shared entry shape (`result.evidence[]`, emitted by both `verify --json` and `evidence status --json`):
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `task_id` | string | Leaf task identifier |
+| `state` | string | `verified` \| `stale-spec` \| `stale-code` \| `failed` \| `unrecorded` \| `pending` |
+| `passed` | bool | The proof outcome — this run's (verify) or the stored result (status). Omitted when no record exists |
+| `failure` | string | Failure detail, when the entry failed in this run (verify) |
+| `recorded_identity` | string | Code identity the record binds |
+| `current_identity` | string | Code identity of the present tree |
+| `profile` | object | Recorded execution profile, `{"key": "value"}` |
+| `profile_drift` | array | `{key, recorded, current}` per differing profile entry (status) |
+| `profile_legacy` | bool | Record predates profiles |
+
+The **on-disk ledger** (`.walden/evidence/<feature>.json`, schema `v1alpha1`) is a state map keyed by task identifier, holding facts only — proof steps, chain fingerprints, `code_identity`, `profile`, `result: passed|failed`, `verified_at`. It never stores derived states: those are computed at read time by the views above. The map-versus-list difference is deliberate — the ledger is a claim about the plan's tasks; the outputs are reports.
+
+## Certification (`release check --json`)
+
+```json
+{
+  "result": {
+    "summary": "RELEASABLE — 3 feature(s) certified, completion complete, commit ba53cfe55b40",
+    "completion": "complete",
+    "certified_commit": "ba53cfe55b40…",
+    "release": {
+      "releasable": true,
+      "strict": false,
+      "features": [
+        {
+          "feature": "user-auth",
+          "criteria": [
+            {"name": "chain", "passed": true},
+            {"name": "validation", "passed": true},
+            {"name": "decisions", "passed": true},
+            {"name": "evidence", "passed": true}
+          ],
+          "pending": []
+        }
+      ],
+      "worktree": {"git_skipped": false}
+    }
+  }
+}
+```
+
+- `completion` — `complete` | `with-pending` | `with-waivers`. Populated on releasable and blocked verdicts alike.
+- `certified_commit` — the HEAD revision the verdict ran against; empty when git is unusable (which itself blocks).
+- `release.features[].criteria[]` — per-criterion verdicts; failing criteria carry `blockers` with remedies.
+- `release.worktree` — repository-level criterion: `blockers` (uncommitted paths outside `.walden/`), `walden_dirty` (informational by default, blocking under strict), `git_skipped` (no usable git — blocking).
+- `waiver` — present only when a waiver was active: `{"reason": "<text>", "tasks": ["feature: 1.2", …]}`. The archived envelope is the waiver's durable record.
+
+The gate criteria (`chain`, `validation`, `decisions`, `evidence`, plus the worktree policy) are a **frozen public contract**: semantic changes to what they judge are breaking changes, announced as such.
+
+## Adoption (`adopt --json`)
+
+`result.adoption`: `{"apply": bool, "features": []}` where each feature carries `class` (`backfill` | `re-prove` | `complete` | `blocked`) and, per mode: plan — `sealable_docs`, `reprove_count`; apply — `sealed_docs`, `verified`, `failed`, `skipped`; plus `reason` when blocked or errored. Exit `1` when apply produced failures; the JSON envelope always carries the full report.
+
+## Error paths
+
+Errors use the same envelope: `ok: false`, `result.summary` naming the error, `exit_code: 1`. There is no separate error format — a parser that handles the envelope handles everything.
+
+## Stability policy
+
+- Within `v0beta1`: additive only. New fields appear (recent examples: `completion`, `certified_commit`, `profile`, `waiver`, `adoption`); nothing is renamed or removed, and existing semantics hold.
+- Exit codes and the produce/judge split are contract.
+- Human-facing strings (`summary`, blocker texts, warnings) are **not** contract — display them, never parse them.
+- At CLI v1.0.0 the schema bumps to `v1` with a documented migration guide.

--- a/docs/reference/spec-format.md
+++ b/docs/reference/spec-format.md
@@ -1,0 +1,155 @@
+# Spec File Format
+
+The complete file-level contract: the `.walden/` layout, document frontmatter, EARS criteria, the task and proof grammar, and every convention file. Everything here is plain Markdown and JSON in your repository — reviewable, diffable, recoverable from git.
+
+## Layout
+
+```text
+.walden/
+  constitution.md          # optional stable project context (no approval workflow)
+  environment.md           # optional declared toolchain probes
+  lessons.md               # append-only structured lessons
+  RETIRED.md               # retirement index (convention; created at first retirement)
+  .gitignore               # excludes transient staging artifacts only
+  specs/<feature>/
+    requirements.md
+    design.md
+    tasks.md
+  evidence/<feature>.json  # execution evidence ledger (committed, reviewed)
+```
+
+Feature names are kebab-case (`feature init` normalizes). A feature is a directory by contract; plain files under `specs/` are ignored.
+
+## Frontmatter
+
+Every spec document opens with YAML frontmatter:
+
+```yaml
+---
+walden_schema_version: v1alpha1
+status: draft            # draft | in-review | approved
+approved_at:             # stamped at approval (UTC, RFC 3339)
+last_modified: 2026-07-17T10:00:00Z
+approved_fingerprint:    # sha256:… — recorded at approval
+source_requirements_approved_at:      # design.md only
+source_requirements_fingerprint:      # design.md only
+source_design_approved_at:            # tasks.md only
+source_design_fingerprint:            # tasks.md only
+---
+```
+
+Rules the loader enforces:
+
+- **Schema version.** `walden_schema_version: v1alpha1` is scaffolded on new documents and stamped on every CLI save (existing repositories migrate through normal use). A document declaring an unsupported version is refused, naming the declared version, the supported one, and the remedy. Documents without the field load as legacy.
+- **Unknown fields are refused** — the writer's allowlist is the loader's rejection list, so a typo'd field cannot silently vanish on the next save.
+- **`x-` extensions survive.** Fields prefixed `x-` (e.g. `x-tracking-url`) are preserved verbatim through every CLI mutation, serialized in lexicographic order after the core keys. They never participate in fingerprints: attaching metadata cannot invalidate an approval.
+
+### Fingerprints
+
+`approved_fingerprint` is SHA-256 over the document **body** — frontmatter never participates, so timestamps, status flips, and extensions don't break seals. One path-aware rule: for `tasks.md` only, checkbox states (`[ ]`/`[x]`) are normalized out — executing the plan is not editing the plan. Everywhere else, every body byte counts.
+
+The `source_*` pairs chain approvals: design binds to the requirements fingerprint, tasks to the design's. Freshness derives from these fields alone; see [the lifecycle](../lifecycle.md#the-chain).
+
+## `requirements.md`
+
+Required structure (validated):
+
+```markdown
+# Requirements Document
+
+## Introduction
+## Requirements
+### R1 <Short title>
+**User Story:** As a <role>, I want <capability>, so that <benefit>
+#### Acceptance Criteria
+1. `R1.AC1` WHEN <trigger>, the system SHALL <response>
+## Non-Functional Requirements
+- `NFR1` <requirement> (bridged by `R1.AC1`)
+## Constraints And Dependencies
+- `C1` <constraint>
+## Out Of Scope
+```
+
+### EARS acceptance criteria
+
+Every criterion has a stable ID (`R<n>.AC<m>`) and one EARS form, classified by the validator:
+
+| Form | Shape |
+| --- | --- |
+| ubiquitous | `The system SHALL <response>` |
+| event-driven | `WHEN <trigger>, the system SHALL <response>` |
+| state-driven | `WHILE <state>, the system SHALL <response>` |
+| optional | `WHERE <feature is present>, the system SHALL <response>` |
+| unwanted | `IF <undesired condition>, THEN the system SHALL <response>` |
+| complex | combined keywords |
+
+One `SHALL` per criterion (two SHALLs = two criteria); `IF` requires a matching `THEN` before the `SHALL`. The validator reports the form distribution and warns when no unwanted-behavior (IF/THEN) criteria exist — failure modes deserve criteria too. IDs are the traceability currency: tasks and proofs reference them, and they should never be renumbered once referenced.
+
+## `design.md`
+
+Required structure: overview, architecture, **options considered** (at least one alternative with a why-rejected), simplicity review, components and interfaces (each naming the requirements it covers), data models, error handling, security considerations, failure modes and tradeoffs, testing strategy, verification plan, and a requirement coverage table mapping every `R*`/`NFR*` to what covers it.
+
+Open forks can be parked as `[decision: which store backs this?]` markers — visible, greppable, and blocking at the release gate while unresolved in an approved document. HTML comments (`<!-- assumed: … -->`) are the place for recorded assumptions; an *unterminated* HTML comment in an approved document blocks certification, because it would blind the decision scan.
+
+## `tasks.md`
+
+A two-level plan; only leaf tasks execute:
+
+```markdown
+# Implementation Plan
+
+- [ ] 1. <Top-level objective>
+  - [ ] 1.1 <Concrete step>
+    - Requirements: `R1.AC1`, `NFR1`
+    - Design: <Design section name>
+    - Verification:
+      - command: ["go", "test", "-run", "TestX", "./internal/x"]
+        expect_exit: 0
+        expect_output: "--- PASS: TestX"
+        timeout: 30m
+        covers: ["R1.AC1"]
+```
+
+Per leaf task:
+
+- **`Requirements:`** — acceptance-criterion IDs this task implements. Validated against known IDs.
+- **`Design:`** — the design section it follows.
+- **`Verification:`** — one or more proof steps. Each step:
+  - `command:` — argv as a JSON array; no shell interpretation, no quoting pitfalls.
+  - `expect_exit:` — required exit code (default `0`).
+  - `expect_output:` — substring the combined output must contain. Declare it on test runners so a `-run` pattern matching zero tests cannot pass vacuously.
+  - `timeout:` — positive Go duration (`90s`, `30m`) bounding the step; default 10 minutes. Expiry kills the step's process group and fails the proof naming the budget. A *declared* timeout participates in the task-definition fingerprint; the default does not.
+  - `covers:` — acceptance-criterion IDs this proof demonstrates; validated, and reported as proof coverage distinct from task references.
+
+A legacy single-line form (`Verification: go test ./...`) still parses but supports no quotes, pipes, or attributes.
+
+Checkbox flips are workflow state, not content: they are excluded from the tasks fingerprint, and `task complete` is the intended way to flip them (proof first, checkbox second).
+
+## `constitution.md`
+
+Optional, repo-wide, and deliberately outside the approval workflow: project summary, tech stack, conventions, sanity-check commands, key files, hard rules. No freshness rules, no gates — the CLI never validates it. Agent skills read it to avoid rediscovering stable context per feature.
+
+## `environment.md`
+
+Declared toolchain probes, in the same argv format as proof steps:
+
+```markdown
+# Environment Probes
+
+- go: ["go", "version"]
+- node: ["node", "--version"]
+```
+
+Probe outputs (trimmed) join every evidence record's execution profile alongside the reserved keys `platform` and `walden`. Probes run once per command under a 30-second shared budget; a failing or hung probe degrades to a marker value, never a failed command. Prefer commands with stable output — timestamps or absolute paths in probe output read as permanent drift.
+
+## `lessons.md`
+
+Append-only, written by `walden lesson log`: feature, phase, trigger, lesson, guardrail. The structured form is the point — a lesson without a guardrail is a story; with one, it is a check.
+
+## `RETIRED.md`
+
+The retirement index (see [Adoption](../adoption.md#retirement)): one line per retired feature — name, date, reason, last commit where the spec was alive. The spec directories themselves are deleted; git keeps the full history and `git show <commit>:.walden/specs/<name>/requirements.md` recovers any of it.
+
+## `evidence/<feature>.json`
+
+The execution ledger, schema `v1alpha1`: a map keyed by task ID, each record holding proof steps and outcomes, the chain fingerprints and code identity at proof time, the execution profile, `result`, and `verified_at`. Facts only — states are derived at read time. Committed and reviewed like the specs it proves; fully regenerable by re-proving (history lives in git). The field-level shape is documented in the [JSON reference](json.md#evidence-one-shape-three-surfaces).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,19 +2,21 @@
 
 This is the public roadmap for Walden. It distinguishes committed open source work from exploratory and enterprise-only work.
 
-## Current Release: v0.9.x
+## Current Release: v0.10.x
 
 The open source core today includes:
 
 - Deterministic CLI with all core commands
-- Content-fingerprint freshness chain: tamper detection and provable approval binding on every spec document
+- Content-fingerprint freshness chain: tamper detection and provable approval binding on every spec document, with document schema versioning (`walden_schema_version: v1alpha1`) and preserved `x-` frontmatter extensions
 - Versioned JSON output contract (`v0beta1`), honored on success and error paths alike
 - AI skill embedded in the binary (`walden skill install|status|show`) for Claude Code, Codex, Copilot, and OpenCode, with drift detection against the embedded copy
 - One-liner installer consuming checksum-verified release binaries
 - Self-update from GitHub releases (`walden update`) with fail-closed verification, rollback, and skill re-sync
-- Execution evidence ledger: task completions bound to spec fingerprints and a code identity, derived states, `walden verify` re-verification, `expect_output` proof assertions
-- Aggregate release gate (`walden release check`): one deterministic releasability verdict per repository — chain freshness, full-spec validation, decision-marker lint, evidence states, clean-worktree policy — judging only, executing nothing
-- Documentation pack (concepts, workflow, boundaries)
+- Execution evidence ledger: task completions bound to spec fingerprints and a code identity, derived states, `walden verify` re-verification with a purity contract and run-start identity anchoring, per-step proof timeouts, `expect_exit`/`expect_output` assertions, and execution profiles with declared environment probes
+- Aggregate release gate (`walden release check`): one deterministic releasability verdict per repository — chain freshness, full-spec validation, decision-marker lint, evidence states, clean-worktree policy — judging only, executing nothing; pending work blocks by default, with recorded waivers (`--allow-pending --reason`), completion classes, and a certified commit in every verdict
+- Brownfield adoption lane (`walden adopt`): read-only classification plan, fingerprint backfill for recorded approvals, bulk re-proving with an honest verified/failed partition
+- Retirement convention (`.walden/RETIRED.md`) and the `walden-history` companion skill for sourced chronicles over committed spec history
+- Documentation pack (quickstart, lifecycle, workflow, adoption, CI, and full CLI/JSON/format references)
 - Example project with shell-safe verification, validated in CI as a compatibility fixture
 - Repository bootstrap and feature scaffolding templates (generated CI pinned to the generating version)
 - Apache-2.0 license
@@ -27,8 +29,9 @@ These improvements are planned for the open source core:
 - **JSON contract stabilization** — now at `v0beta1`; move toward a stable `v1` schema as the contract matures.
 - **Skill refinement** — tighter CLI delegation, fewer redundant instructions, better example conversations.
 - **Additional examples** — backend service demo, multi-feature workflow example.
-- **CI integration patterns** — documented patterns for using Walden validation in CI pipelines.
+- **Scoped code identity** — narrowing the identity a proof binds from the whole tree to the slice it depends on, so unrelated changes stop staling a feature's evidence at portfolio scale.
 - **Multi-root identity** — code identity spanning multiple repositories, unblocking cross-repo proofs and multi-repo certification.
+- **Rework provenance** — recording the origin of post-approval rework to close the loop between shipped specs and what they missed.
 
 ## Medium-Term (Enterprise, Exploratory)
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,59 +1,38 @@
-# Workflow
+# The Daily Workflow
 
-This document walks through the complete Walden workflow from repository bootstrap to lesson logging.
+The complete command loop, from repository bootstrap to certification. This page is operational — for the *why* behind each step, read [The Spec Lifecycle](lifecycle.md); for every flag, the [CLI reference](reference/cli.md).
 
 ## 1. Bootstrap
-
-Initialize Walden in an existing or new repository:
 
 ```bash
 walden repo init
 ```
 
-This creates `.walden/` (including an optional `constitution.md` for project-wide context), `.github/workflows/`, and helper files. If Git is not initialized, the CLI initializes it first.
-
-Then scaffold a feature:
+Creates `.walden/` (`constitution.md` for stable project context, `lessons.md`, a scoped `.gitignore`) and the generated CI workflow `.github/workflows/validate-walden.yml`, pinned to the generating version. If git is not initialized, the CLI initializes it first.
 
 ```bash
-walden feature init user-auth
+walden feature init "User Auth"
 ```
 
-This creates `.walden/specs/user-auth/` with `requirements.md`, `design.md`, and `tasks.md` in draft status.
+Names normalize to kebab-case; the spec scaffolds in `.walden/specs/user-auth/` as three draft documents.
+
+Optionally declare [environment probes](reference/spec-format.md#environmentmd) in `.walden/environment.md` for the toolchains your proofs depend on — evidence records will carry their outputs, and drift becomes a printed diagnosis instead of forensics.
 
 ## 2. Requirements
 
-Edit `requirements.md` with:
-- A problem statement
-- User stories for context
-- EARS acceptance criteria with stable IDs (`R1.AC1`, `R1.AC2`)
-- Non-functional requirements (`NFR1`, `NFR2`)
-- Constraints (`C1`, `C2`)
-- Out-of-scope items
-
-When ready, validate and open review:
+Edit `requirements.md`: introduction, user stories, [EARS acceptance criteria](reference/spec-format.md#ears-acceptance-criteria) with stable IDs (`R1.AC1`), non-functional requirements (`NFR1`), constraints (`C1`), out-of-scope. Then:
 
 ```bash
 walden validate user-auth
 walden review open user-auth --phase requirements
-```
-
-After the reviewer approves:
-
-```bash
 walden review approve user-auth --phase requirements
 ```
 
+Approve runs full phase validation before sealing — nothing structurally invalid gets a fingerprint.
+
 ## 3. Design
 
-With approved requirements, edit `design.md`:
-- Architecture and component boundaries
-- At least one alternative option considered
-- Simplicity review
-- Failure modes and tradeoffs
-- Testing strategy
-- Requirement coverage matrix
-
-Validate, review, and approve:
+Edit `design.md`: architecture, at least one alternative considered, simplicity review, failure modes and tradeoffs, testing strategy, requirement coverage table. Same gate:
 
 ```bash
 walden validate user-auth
@@ -61,12 +40,11 @@ walden review open user-auth --phase design
 walden review approve user-auth --phase design
 ```
 
+Unresolved forks can be parked as `[decision: which store backs this?]` markers — but they must be resolved before certification: the release gate blocks on decision markers in approved documents.
+
 ## 4. Tasks
 
-With approved design, edit `tasks.md`:
-- Two-level task hierarchy
-- Every leaf task references acceptance criteria IDs (e.g., `R1.AC1`) and design sections
-- Every leaf task has a `Verification:` proof
+Edit `tasks.md`: a two-level hierarchy where every leaf task names its acceptance criteria, its design section, and an executable proof:
 
 ```markdown
 - [ ] 1. Implement authentication service
@@ -74,10 +52,12 @@ With approved design, edit `tasks.md`:
     - Requirements: `R1.AC1`, `R1.AC2`, `NFR2`
     - Design: Authentication Service
     - Verification:
-      - command: ["go", "test", "./internal/auth/..."]
+      - command: ["go", "test", "-run", "TestHash", "./internal/auth"]
+        expect_output: "--- PASS: TestHash"
+        covers: ["R1.AC1", "R1.AC2"]
 ```
 
-Validate, review, and approve:
+Declare `expect_output` on test runners so a pattern matching zero tests cannot pass vacuously; declare `timeout:` on steps that legitimately run long (the default budget is 10 minutes per step). Prefer read-only proof commands — `["go", "mod", "tidy", "-diff"]`, not `["go", "mod", "tidy"]` — because [re-verification is pure](lifecycle.md#execution-two-lanes-one-proof-grammar).
 
 ```bash
 walden validate user-auth
@@ -87,42 +67,60 @@ walden review approve user-auth --phase tasks
 
 ## 5. Execute
 
-Check readiness and start working:
-
 ```bash
-walden task status user-auth
-walden task start user-auth
+walden task status user-auth        # readiness, blockers, next runnable task
+walden task start user-auth         # normalized execution context for the next task
+walden task complete user-auth 1.1  # runs the proof; only a pass checks the box
+walden task complete-all user-auth  # all runnable tasks in order, stops at first failure
 ```
 
-Implement the task, then complete it with proof:
-
-```bash
-walden task complete user-auth 1.1
-```
-
-The CLI runs the verification proof. If it passes, the task is marked complete. If it fails, the task stays unchecked and you fix the issue first.
-
-To complete all remaining tasks in order:
-
-```bash
-walden task complete-all user-auth
-```
-
-This stops on the first failing proof while preserving earlier completions.
+A passing completion writes the task's evidence record — proof steps, chain fingerprints, code identity, execution profile — to `.walden/evidence/user-auth.json`. A failing proof leaves the box unchecked; fix and retry.
 
 ## 6. Reconcile
 
-If you edit an approved document, its content no longer matches the `approved_fingerprint` recorded at approval: the document and everything downstream become stale. Reconcile before continuing:
+Editing an approved document breaks its seal: the document and everything downstream become stale, and execution blocks. Repair the chain:
 
 ```bash
 walden reconcile user-auth
 ```
 
-This resets the modified document and stale downstream documents to draft and clears their approval fingerprints; re-approval records fresh ones.
+This resets the modified document and its downstream to draft and clears their fingerprints; re-walk the review gates to record fresh seals. Content-identical re-approval does not stale anything.
 
-## 7. Lessons
+## 7. Verify
 
-After a correction, failed validation, or execution surprise:
+When code or specs move, evidence tells you what still holds:
+
+```bash
+walden evidence status user-auth   # derived state per task; read-only, always exit 0
+walden verify user-auth            # re-prove what is no longer verified
+walden verify user-auth --all      # re-prove everything
+walden verify user-auth --check    # report only, write nothing (CI mode)
+```
+
+A code-only bugfix needs no spec ceremony: evidence goes `stale-code`, and one `verify` proves the acceptance criteria still hold — or names the task whose proof broke. Failures on a drifted machine carry the diagnosis: `environment drift: go: recorded "go1.25.0" → current "go1.24.0"`.
+
+## 8. Certify
+
+```bash
+walden release check               # every feature
+walden release check user-auth     # one feature
+walden release check --strict      # additionally require committed .walden/ state
+```
+
+One deterministic verdict per feature — fresh approved chain, full validation, no decision markers, evidence verified — plus the repository-level criterion: a clean worktree outside `.walden/`. Exit `0` iff no blocker exists; every blocker names its remedy. The gate executes no proofs and writes nothing.
+
+**Pending tasks block by default.** Shipping less than the approved plan is a recorded decision, not a default:
+
+```bash
+walden release check --allow-pending --reason "auth hardening deferred to 1.3"
+# RELEASABLE — 3 feature(s) certified, 2 task(s) waived (reason: auth hardening deferred to 1.3), commit ba53cfe55b40
+```
+
+The reason and the waived task identifiers ride the verdict (completion class `with-waivers`). `--allow-pending` without a non-empty `--reason` is refused. Uncommitted code outside `.walden/` always blocks with no bypass; a repository without usable git fails closed.
+
+## 9. Lessons
+
+After a correction, failed validation, or execution surprise, make the failure reusable:
 
 ```bash
 walden lesson log \
@@ -133,69 +131,14 @@ walden lesson log \
   --guardrail "before approving design, confirm test strategy uses real dependencies"
 ```
 
-Lessons are appended to `.walden/lessons.md` and reviewed before similar future work.
+Lessons append to `.walden/lessons.md` and are reviewed before similar future work.
 
-## Status and Validation
-
-At any point, check where you are:
+## At any point
 
 ```bash
-walden status user-auth
-walden validate user-auth
+walden status user-auth       # phase, blockers, next action
+walden validate user-auth     # structural validation of the current phase
+walden validate --all         # every feature, full spec
 ```
 
-For machine-readable output:
-
-```bash
-walden status user-auth --json
-walden validate user-auth --json
-```
-
-## JSON Contract
-
-All `--json` commands return a versioned envelope:
-
-```json
-{
-  "schema_version": "v0beta1",
-  "command": "status",
-  "ok": true,
-  "result": {
-    "summary": "workflow status for user-auth",
-    "current_phase": "tasks",
-    "next_action": "Start execution from the next unchecked task"
-  }
-}
-```
-
-## 8. Verify
-
-Execution leaves evidence behind: every completed task's proof is recorded in `.walden/evidence/<feature>.json`, bound to the approved chain and to a code identity of the working tree. When the code or the specs move, `walden task status` warns that completed tasks are no longer verified.
-
-```bash
-walden evidence status <feature>   # derived state per task, always exit 0
-walden verify <feature>            # re-prove what is no longer verified
-walden verify <feature> --all      # re-prove everything
-walden verify <feature> --check    # CI mode: report only, write nothing
-```
-
-A code-only bugfix needs no spec ceremony: the evidence goes `stale-code`, and one `verify` proves the acceptance criteria still hold — or names the task whose proof broke.
-
-## 9. Certify
-
-`walden release check` folds everything above into one deterministic verdict per feature — approved fresh chain, full-spec validation, no unresolved `[decision:]` markers in approved documents, execution evidence verified — plus one repository-level criterion: a clean worktree outside `.walden/`. Exit zero iff no blocker exists. It executes no proofs and writes nothing: verify produces evidence, release check judges it.
-
-```bash
-walden release check               # certify every feature
-walden release check <feature>     # certify one feature
-walden release check --strict      # planned-but-unexecuted tasks block too
-```
-
-The CI recipe composes the two:
-
-```bash
-walden verify <feature>            # re-prove execution on the current tree
-walden release check --json        # certify; gate the pipeline on the exit code
-```
-
-Planned work never blocks a release (`--strict` opts into plans-complete). Uncommitted code outside `.walden/` always blocks with no bypass flag — what you certify is what you tag — and a repository without usable git fails closed: certification requires a git-backed code identity. Dirty `.walden/` warns by default, since a refreshed ledger legitimately precedes its own commit, but blocks under `--strict`, where the verdict must be reproducible from the commit it judges. An unterminated HTML comment in an approved document blocks the decision scan it would blind. Every blocker names its remedy.
+Every command takes `--json` for a [versioned machine-readable envelope](reference/json.md) — same information, same exit codes.


### PR DESCRIPTION
Phase 1 of the documentation overhaul discussed for the site restructure: **content first**, one source of truth in `docs/`, organized by what the reader is trying to do. Phases 2 (site `/docs` section rendered from these files) and 3 (README slimming) build on top.

## Structure

| Lane | Pages |
| --- | --- |
| Learn | `quickstart.md` — one real feature from `repo init` to a releasable verdict |
| Understand | `lifecycle.md` — the whole mechanism end to end (the new core piece); `boundaries.md` |
| Operate | `workflow.md` (rewritten to v0.10.1), `adoption.md` (brownfield + retirement), `ci.md` |
| Reference | `reference/cli.md`, `reference/json.md`, `reference/spec-format.md` |

`docs/README.md` is the index with reading paths per audience; `concepts.md` becomes a pointer page (its content moved into lifecycle + references); `roadmap.md` current-release list brought from v0.9.x to v0.10.x.

## Notable content

- **lifecycle.md** tells the mechanism once, end to end — seals (body-only, path-aware), the approval chain, the two execution lanes (completion may mutate, verify is pure with run-start anchoring), derived evidence states, environment profiles, the certification verdict with waivers, and the five design invariants.
- **reference/json.md** is the page the first external feedback was missing: the envelope, the three evidence surfaces with the shared field names, certification fields, and the additivity policy.
- **workflow.md** fixes stale pre-v0.10.0 semantics (it still said pending never blocks).

## Verification

Every factual claim checked against the v0.10.1 binary (`--help`, generated templates, real `repo init` output) and source (validator EARS forms, JSON field tags, selfupdate tag rules). All internal links and anchors machine-verified.