### PR TITLE
docs: the agentic flow — the skill authors, the CLI enforces

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Walden is a spec-driven delivery kernel: a deterministic CLI that takes a featur
 ## Learn
 
 - **[Quickstart](quickstart.md)** — one real feature from `repo init` to a releasable verdict, in ten minutes.
+- **[The Agentic Flow](agentic.md)** — how most teams actually run Walden: the skill authors, the CLI enforces, you keep the judgment calls.
 
 ## Understand
 
@@ -29,7 +30,8 @@ Walden is a spec-driven delivery kernel: a deterministic CLI that takes a featur
 
 ## Reading paths
 
-- *Evaluating Walden?* [Quickstart](quickstart.md), then [The Spec Lifecycle](lifecycle.md).
+- *Evaluating Walden?* [Quickstart](quickstart.md), then [The Agentic Flow](agentic.md), then [The Spec Lifecycle](lifecycle.md).
+- *Working with a coding agent?* [The Agentic Flow](agentic.md) — one skill install, and the ceremony costs the agent, not you.
 - *Adopting it on an existing repository?* [The Spec Lifecycle](lifecycle.md), then [Brownfield Adoption](adoption.md).
 - *Using it every day?* [The Daily Workflow](workflow.md) with [CLI Commands](reference/cli.md) at hand.
 - *Building tooling on top?* [JSON Contract](reference/json.md), then [Spec File Format](reference/spec-format.md).

--- a/docs/agentic.md
+++ b/docs/agentic.md
@@ -1,0 +1,68 @@
+# The Agentic Flow
+
+Most teams do not hand-write EARS criteria — their coding agent does. Walden is built for exactly that division of labor: the **skill** authors, the **CLI** enforces. This page is how the two halves compose into the flow you actually run: one prompt in, a reviewed spec tree out, every gate passed, every proof recorded — nothing typed but the intent.
+
+## The division of labor
+
+Walden splits every feature into work that needs judgment and work that needs enforcement:
+
+| Non-deterministic — the skill (or a human) | Deterministic — the CLI |
+| --- | --- |
+| Drafting requirements and acceptance criteria | Validating structure, traceability, freshness |
+| Designing architecture, weighing alternatives | Opening and sealing review gates |
+| Generating the implementation plan | Running proofs, recording evidence |
+| Writing the code | Deriving states, judging releasability |
+| Deciding when to re-plan | Reconciling stale chains |
+
+The boundary is absolute in both directions: **the CLI never authors content, and the skill never mutates workflow state**. Every status flip, approval seal, checkbox, and evidence record goes through a command — so the guarantees in [the lifecycle](lifecycle.md) hold identically whether a human or a model did the typing. Trust comes from the gates, not from the model.
+
+## Install the skill
+
+The skill ships embedded in the binary, versioned with it:
+
+```bash
+walden skill install claude     # or: codex | copilot | opencode | --all
+walden skill status             # drift against the embedded copy
+```
+
+`walden update` re-syncs every installed skill with the binary, so the instructions and the CLI they drive never diverge. `--project` installs at repository scope instead of user scope.
+
+## What a session looks like
+
+You open your agent in a Walden-initialized repository and state the intent:
+
+> We need a small, single-user todo app on the command line — add a task, list what's still pending, mark one done, all kept in a plain-text file, POSIX shell only. Let's use Walden.
+
+From there the skill drives, and the CLI keeps score:
+
+1. **Context first.** The skill reads `.walden/constitution.md` (your stack, conventions, hard rules) and `.walden/lessons.md` (past corrections) so it doesn't rediscover or repeat.
+2. **Requirements.** It asks its clarifying questions, drafts `requirements.md` as EARS criteria, runs `walden validate` until clean — then **stops and presents the document to you**. Approval is yours: on your word it runs `walden review open` / `review approve`, and the CLI seals your decision with a fingerprint.
+3. **Design, then tasks.** Same rhythm at each gate: draft, validate, present, wait, seal. Unresolved forks are parked as `[decision: …]` markers for you to settle — the release gate will not let them ship unresolved.
+4. **Execution.** The skill implements task by task and completes each through `walden task complete`, which runs the proof and refuses anything that doesn't pass. Checkboxes are earned, not typed; evidence records land in the ledger with fingerprints, code identity, and the machine's profile.
+5. **Certification.** `walden release check` renders the verdict. If it blocks, the blockers name their remedies and the skill works through them.
+
+What's left behind is the spec tree from the [site's example](https://andrearaponi.github.io/walden/): three approved documents with sealed frontmatter, an evidence ledger, generated CI — and the same commands available to you, because the skill holds no private powers.
+
+## What stays yours
+
+The skill is deliberately constitution-bound at the points where judgment must be human:
+
+- **Approvals.** The three gates seal *your* review, never the skill's own. It presents; you approve.
+- **Waivers.** The skill never passes `--allow-pending` on its own — shipping less than the approved plan is a recorded human decision, reason included.
+- **Decision markers.** `[decision: …]` forks are surfaced to you, not resolved silently.
+- **Retirement.** Deleting superseded specs is confirmation-gated ceremony, never housekeeping.
+
+## Why this favors adoption
+
+The failure mode of agent-driven development is unverifiable velocity: plausible code, green-looking sessions, no durable claim about what was actually specified, reviewed, or proven. Walden inverts the economics — the agent supplies the speed, the kernel supplies claims that survive it:
+
+- The fingerprint seals **what you approved**, not what the model generated afterward — post-approval drift is detected by construction.
+- Evidence doesn't care who typed the code: `verified` means the proof passes on the tree in front of you, today.
+- Every agent action that matters is a CLI invocation — auditable in the same JSON envelope your pipelines already parse.
+
+Onboarding a team is therefore one command and one habit: `walden skill install`, and "let's use Walden" at the start of the session. The ceremony costs the agent, not the human — the human keeps the judgment calls.
+
+## Companions and internals
+
+- **`walden skill show`** prints the embedded `SKILL.md` — the exact operational instructions the agent follows. It is intentionally self-contained and is the agent-facing counterpart of these human-facing docs.
+- **`walden-history`** (shipped in-repo at `skill/walden-history/`, installed manually) narrates committed `.walden/` history — sourced feature chronicles, product eras, rework archaeology — and officiates the [retirement ceremony](adoption.md#retirement).

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -8,6 +8,8 @@ A checked checkbox proves that *one day* a test passed. Then the code changes, t
 
 Walden's answer is to make every claim **re-provable**. Approvals are sealed with content fingerprints, completions are recorded with executable proofs bound to a snapshot of the world, and every state you can ask about is *derived by comparison at read time* — never stored, never trusted from memory. When something no longer holds, Walden is the one that tells you.
 
+This matters most in the [agentic flow](agentic.md), where a coding agent authors the documents and writes the code: the guarantees below are enforced by the CLI at every station, so they hold identically whoever — or whatever — did the typing. The skill drafts and implements; the kernel seals, proves, and judges; the human approves. Trust comes from the gates, not from the model.
+
 Two photographs run through everything below: the fingerprint of the **specs** as approved, and the identity of the **code** as proven. Every mechanism in the lifecycle is a way of taking, chaining, or comparing those photographs.
 
 ## Birth

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-One real feature, from an empty repository to a releasable verdict. Ten minutes, no AI required — the CLI is the whole mechanism; an agent skill can author the documents for you later, but everything below is what actually happens underneath.
+One real feature, from an empty repository to a releasable verdict — by hand, so you see every moving part. In daily use you will rarely type most of this: [the agentic flow](agentic.md) has your coding agent author the documents and drive these same commands, stopping at each gate for your approval. Everything below is what actually happens underneath.
 
 ## Install
 
@@ -138,8 +138,19 @@ One deterministic verdict: approved fresh chains, full-spec validation, no unres
 Summary: RELEASABLE — 1 feature(s) certified, completion complete, commit 3f2a91c40d77
 ```
 
+## The same loop, driven by an agent
+
+Everything you just did by hand is what the embedded skill does for you. Install it once —
+
+```bash
+walden skill install claude     # or codex | copilot | opencode
+```
+
+— then open your agent and state the intent ("We need a small todo CLI… let's use Walden"). The skill drafts each document, runs the validations, and stops at every gate for *your* approval; the CLI seals the decisions and runs the proofs exactly as above. Same gates, same evidence, none of the typing: [The Agentic Flow](agentic.md).
+
 ## Where to next
 
+- How the skill and the CLI divide the work: [The Agentic Flow](agentic.md)
 - The mechanism behind each step: [The Spec Lifecycle](lifecycle.md)
 - The full command loop, including reconciliation and lessons: [The Daily Workflow](workflow.md)
 - An existing repository with specs that predate Walden's current contract: [Brownfield Adoption](adoption.md)

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -2,6 +2,8 @@
 
 The complete command loop, from repository bootstrap to certification. This page is operational — for the *why* behind each step, read [The Spec Lifecycle](lifecycle.md); for every flag, the [CLI reference](reference/cli.md).
 
+In [the agentic flow](agentic.md), the authoring steps below (drafting requirements, design, tasks; implementing code) are what the skill does for you, driving these exact commands and stopping at each gate for your approval. The loop is the same either way — this page describes what runs underneath.
+
 ## 1. Bootstrap
 
 ```bash


### PR DESCRIPTION
Follow-up to #34, which was merged while this commit was still on its branch — re-landed cleanly on top of main.

Adds the page the restructure was missing: **the skill-driven flow is how most teams actually run Walden**, and the docs never told it.

- **`docs/agentic.md`** (Learn lane): the division of labor (the skill authors, the CLI enforces, the human approves — *trust comes from the gates, not from the model*), skill install and re-sync, a session walkthrough mirroring the site's todo example, what stays human (approvals, waivers, decision markers, retirement), and why deterministic gates are what make agent velocity trustworthy.
- Woven into the existing pages: index reading paths ("Working with a coding agent?"), quickstart ("The same loop, driven by an agent"), lifecycle intro, workflow intro.

Links and anchors machine-verified.