### PR TITLE
site: /docs section generated from the documentation at deploy time

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'site/**'
+      - 'docs/**'
+      - 'tools/sitegen/**'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 
@@ -30,6 +32,16 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # site/docs/ is generated, never committed: the markdown under docs/
+      # is the single source of truth and the generator is stdlib-only.
+      - name: Generate docs section
+        run: go run ./tools/sitegen
 
       - name: Configure Pages
         uses: actions/configure-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ sonar-project.properties
 # Local-only material (reports, demo assets, launch notes)
 temp/
 HACKER_NEWS.md
+
+# Generated docs section (built by tools/sitegen at Pages deploy time)
+site/docs/

--- a/site/docs.css
+++ b/site/docs.css
@@ -1,0 +1,159 @@
+/* ============================================================
+   Walden Docs — paper, ink & pine, in reading form.
+   Shares the landing's palette; owns its own layout.
+   ============================================================ */
+
+:root {
+  --paper:      #f2eee4;
+  --paper-2:    #ece6d8;
+  --paper-3:    #e4ddcc;
+  --ink:        #181610;
+  --ink-soft:   rgba(24, 22, 16, 0.66);
+  --ink-mute:   rgba(24, 22, 16, 0.45);
+  --rule:       rgba(24, 22, 16, 0.14);
+  --rule-soft:  rgba(24, 22, 16, 0.08);
+  --pine:       #2c4734;
+  --pine-deep:  #1f3527;
+  --pine-bright:#3b6049;
+
+  --serif: "Fraunces", Georgia, "Times New Roman", serif;
+  --mono:  "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+@media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--serif);
+  font-optical-sizing: auto;
+  font-size: clamp(1rem, 0.4vw + 0.94rem, 1.1rem);
+  line-height: 1.65;
+  font-weight: 380;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+::selection { background: var(--pine); color: var(--paper); }
+
+/* header ---------------------------------------------------------------- */
+.site-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 1.5rem; flex-wrap: wrap;
+  padding: 1.1rem clamp(1.2rem, 4vw, 3rem);
+  border-bottom: 1px solid var(--rule);
+}
+.brand { display: flex; align-items: baseline; gap: 0.7rem; }
+.wordmark {
+  font-family: var(--serif); font-weight: 600; font-size: 1.15rem;
+  color: var(--ink); text-decoration: none; letter-spacing: 0.01em;
+}
+.wordmark .mark { color: var(--pine); }
+.version-tag {
+  font-family: var(--mono); font-size: 0.66rem; letter-spacing: 0.12em;
+  text-transform: uppercase; color: var(--pine);
+  border: 1px solid var(--rule); border-radius: 999px;
+  padding: 0.14rem 0.6rem; text-decoration: none;
+}
+.nav { display: flex; gap: 1.3rem; font-family: var(--mono); font-size: 0.78rem; }
+.nav a { color: var(--ink-soft); text-decoration: none; }
+.nav a:hover { color: var(--pine); }
+
+/* layout ---------------------------------------------------------------- */
+.layout {
+  display: grid; grid-template-columns: 15.5rem minmax(0, 1fr);
+  gap: clamp(1.5rem, 4vw, 4rem);
+  max-width: 76rem; margin: 0 auto;
+  padding: 2.2rem clamp(1.2rem, 4vw, 3rem) 4rem;
+}
+@media (max-width: 54rem) {
+  .layout { grid-template-columns: 1fr; }
+  .sidebar { position: static; border-right: none; border-bottom: 1px solid var(--rule); padding-bottom: 1.2rem; }
+}
+
+/* sidebar --------------------------------------------------------------- */
+.sidebar {
+  font-family: var(--mono); font-size: 0.78rem; line-height: 1.5;
+  align-self: start; position: sticky; top: 1.4rem;
+}
+.sidebar .lane {
+  margin: 1.3rem 0 0.45rem; font-size: 0.62rem; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--ink-mute);
+}
+.sidebar .lane:first-child { margin-top: 0; }
+.sidebar ul { list-style: none; margin: 0; padding: 0; }
+.sidebar li { margin: 0.28rem 0; }
+.sidebar a {
+  color: var(--ink-soft); text-decoration: none;
+  border-left: 2px solid transparent; padding-left: 0.6rem; display: inline-block;
+}
+.sidebar a:hover { color: var(--pine); }
+.sidebar a.here { color: var(--pine); border-left-color: var(--pine); font-weight: 500; }
+
+/* article --------------------------------------------------------------- */
+.doc { max-width: 46rem; min-width: 0; }
+.doc h1 {
+  font-size: clamp(1.7rem, 3.4vw, 2.2rem); font-weight: 600;
+  line-height: 1.15; letter-spacing: -0.01em; margin: 0 0 1rem;
+}
+.doc h2 {
+  font-size: 1.32rem; font-weight: 600; letter-spacing: -0.005em;
+  margin: 2.4rem 0 0.7rem; padding-top: 1.2rem; border-top: 1px solid var(--rule-soft);
+}
+.doc h3 { font-size: 1.08rem; font-weight: 600; margin: 1.8rem 0 0.5rem; }
+.doc h4 { font-size: 0.95rem; font-weight: 600; margin: 1.4rem 0 0.4rem; }
+.doc h1 code, .doc h2 code, .doc h3 code, .doc h4 code { font-size: 0.85em; }
+.doc p { margin: 0 0 1rem; }
+.doc strong { color: var(--pine-deep); font-weight: 600; }
+.doc a { color: var(--pine); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 2px; }
+.doc a:hover { color: var(--pine-deep); }
+
+.doc code {
+  font-family: var(--mono); font-size: 0.82em;
+  background: var(--paper-2); border: 1px solid var(--rule-soft);
+  border-radius: 4px; padding: 0.08em 0.35em;
+}
+.doc pre {
+  background: var(--pine-deep); color: #e9e5d8;
+  border-radius: 8px; padding: 1rem 1.2rem; margin: 1.1rem 0 1.4rem;
+  overflow-x: auto; font-size: 0.8rem; line-height: 1.7;
+}
+.doc pre code { background: none; border: none; padding: 0; color: inherit; font-size: inherit; }
+
+.doc ul, .doc ol { margin: 0 0 1rem; padding-left: 1.4rem; }
+.doc li { margin: 0.3rem 0; }
+.doc li > ul, .doc li > ol { margin: 0.3rem 0 0.3rem; }
+
+.doc blockquote {
+  margin: 1.2rem 0; padding: 0.5rem 0 0.5rem 1.1rem;
+  border-left: 3px solid var(--pine);
+  font-style: italic; color: var(--ink-soft);
+}
+.doc blockquote p { margin: 0; }
+
+.table-scroll { overflow-x: auto; margin: 1.1rem 0 1.4rem; }
+.doc table { border-collapse: collapse; width: 100%; font-size: 0.92rem; }
+.doc th {
+  font-family: var(--mono); font-size: 0.64rem; letter-spacing: 0.12em;
+  text-transform: uppercase; color: var(--ink-mute); text-align: left;
+  padding: 0.4rem 0.9rem 0.4rem 0; border-bottom: 1px solid var(--rule);
+}
+.doc td {
+  padding: 0.55rem 0.9rem 0.55rem 0; border-bottom: 1px solid var(--rule-soft);
+  vertical-align: top;
+}
+
+/* footer ---------------------------------------------------------------- */
+.foot {
+  display: flex; justify-content: space-between; gap: 1rem; flex-wrap: wrap;
+  max-width: 76rem; margin: 0 auto;
+  padding: 1.2rem clamp(1.2rem, 4vw, 3rem) 2.5rem;
+  border-top: 1px solid var(--rule);
+  font-family: var(--mono); font-size: 0.68rem; letter-spacing: 0.06em;
+  color: var(--ink-mute);
+}
+.foot a { color: var(--ink-soft); text-decoration: none; }
+.foot a:hover { color: var(--pine); }

--- a/site/index.html
+++ b/site/index.html
@@ -34,6 +34,7 @@
       <a class="version-tag" id="version-tag" href="https://github.com/andrearaponi/walden/releases/latest" aria-label="Latest release">v0.10.1</a>
     </div>
     <nav class="nav" aria-label="Primary">
+      <a href="docs/">Docs</a>
       <a href="#workflow">Workflow</a>
       <a class="nav-cta" href="#howto">How to use<span class="nav-cursor" aria-hidden="true"></span></a>
       <a href="#install">Install</a>
@@ -363,7 +364,7 @@
     </div>
     <nav class="foot-nav" aria-label="Footer">
       <a href="https://github.com/andrearaponi/walden">GitHub</a>
-      <a href="https://github.com/andrearaponi/walden/tree/main/docs">Docs</a>
+      <a href="docs/">Docs</a>
       <a href="https://github.com/andrearaponi/walden/releases">Releases</a>
     </nav>
   </footer>

--- a/tools/sitegen/main.go
+++ b/tools/sitegen/main.go
@@ -1,0 +1,396 @@
+// Command sitegen renders docs/*.md into site/docs/*.html at Pages deploy
+// time. It is deliberately stdlib-only and parses exactly the Markdown
+// subset the documentation uses — the docs and the generator are versioned
+// together, so an unsupported construct is a build error to fix here, not
+// a silent rendering bug to ship.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// page is one documentation page in navigation order.
+type page struct {
+	src   string // path under docs/
+	out   string // path under site/docs/
+	title string // sidebar label
+	lane  string // sidebar group; empty pages are rendered but unlisted
+}
+
+// nav is the single source of the section's information architecture. It
+// mirrors docs/README.md's lanes; a page missing from disk fails the build.
+var nav = []page{
+	{"README.md", "index.html", "Overview", "Start"},
+	{"quickstart.md", "quickstart.html", "Quickstart", "Learn"},
+	{"agentic.md", "agentic.html", "The Agentic Flow", "Learn"},
+	{"lifecycle.md", "lifecycle.html", "The Spec Lifecycle", "Understand"},
+	{"boundaries.md", "boundaries.html", "Product Boundaries", "Understand"},
+	{"workflow.md", "workflow.html", "The Daily Workflow", "Operate"},
+	{"adoption.md", "adoption.html", "Brownfield Adoption", "Operate"},
+	{"ci.md", "ci.html", "CI Integration", "Operate"},
+	{"reference/cli.md", "reference/cli.html", "CLI Commands", "Reference"},
+	{"reference/json.md", "reference/json.html", "JSON Contract", "Reference"},
+	{"reference/spec-format.md", "reference/spec-format.html", "Spec File Format", "Reference"},
+	{"roadmap.md", "roadmap.html", "Roadmap", "Project"},
+	{"concepts.md", "concepts.html", "Concepts", ""}, // pointer page: kept for old links, unlisted
+}
+
+const repoBlobURL = "https://github.com/andrearaponi/walden/blob/main/"
+
+func main() {
+	docsDir, outDir := "docs", filepath.Join("site", "docs")
+	if len(os.Args) == 3 {
+		docsDir, outDir = os.Args[1], os.Args[2]
+	}
+	if err := generate(docsDir, outDir); err != nil {
+		fmt.Fprintf(os.Stderr, "sitegen: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("sitegen: %d pages → %s\n", len(nav), outDir)
+}
+
+func generate(docsDir, outDir string) error {
+	for _, p := range nav {
+		raw, err := os.ReadFile(filepath.Join(docsDir, p.src))
+		if err != nil {
+			return fmt.Errorf("read %s: %w", p.src, err)
+		}
+		body, err := render(string(raw), p.src)
+		if err != nil {
+			return fmt.Errorf("render %s: %w", p.src, err)
+		}
+		html := pageHTML(p, body)
+		dest := filepath.Join(outDir, filepath.FromSlash(p.out))
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return fmt.Errorf("mkdir for %s: %w", p.out, err)
+		}
+		if err := os.WriteFile(dest, []byte(html), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", p.out, err)
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Markdown subset renderer
+// ---------------------------------------------------------------------------
+
+var (
+	headerPattern = regexp.MustCompile(`^(#{1,4}) (.+)$`)
+	fencePattern  = regexp.MustCompile("^```([a-z]*)$")
+	olPattern     = regexp.MustCompile(`^(\s*)(\d+)\. (.+)$`)
+	ulPattern     = regexp.MustCompile(`^(\s*)- (.+)$`)
+	tableRow      = regexp.MustCompile(`^\|.*\|$`)
+	tableSep      = regexp.MustCompile(`^\|[\s:|-]+\|$`)
+)
+
+// render converts one document body to HTML. srcPath (relative to docs/)
+// determines how relative links are rewritten. Link resolution panics
+// surface as ordinary errors.
+func render(src, srcPath string) (out string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%v", r)
+		}
+	}()
+	return renderBody(src, srcPath)
+}
+
+func renderBody(src, srcPath string) (string, error) {
+	lines := strings.Split(src, "\n")
+	var out strings.Builder
+	var para []string
+	var listStack []string // open list tags, innermost last
+
+	flushPara := func() {
+		if len(para) == 0 {
+			return
+		}
+		out.WriteString("<p>" + inline(strings.Join(para, " "), srcPath) + "</p>\n")
+		para = nil
+	}
+	closeLists := func(depth int) {
+		for len(listStack) > depth {
+			tag := listStack[len(listStack)-1]
+			listStack = listStack[:len(listStack)-1]
+			out.WriteString("</li></" + tag + ">\n")
+		}
+	}
+
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimRight(line, " ")
+
+		// Fenced code blocks take everything verbatim until the closing fence.
+		if m := fencePattern.FindStringSubmatch(trimmed); m != nil {
+			flushPara()
+			closeLists(0)
+			var code []string
+			for i++; i < len(lines); i++ {
+				if strings.TrimRight(lines[i], " ") == "```" {
+					break
+				}
+				code = append(code, lines[i])
+			}
+			if i == len(lines) {
+				return "", fmt.Errorf("unterminated code fence")
+			}
+			lang := ""
+			if m[1] != "" {
+				lang = ` class="lang-` + m[1] + `"`
+			}
+			out.WriteString("<pre><code" + lang + ">" + escape(strings.Join(code, "\n")) + "</code></pre>\n")
+			continue
+		}
+
+		if trimmed == "" {
+			flushPara()
+			closeLists(0)
+			continue
+		}
+
+		if m := headerPattern.FindStringSubmatch(trimmed); m != nil {
+			flushPara()
+			closeLists(0)
+			level := len(m[1])
+			out.WriteString(fmt.Sprintf("<h%d id=%q>%s</h%d>\n", level, slug(m[2]), inline(m[2], srcPath), level))
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "> ") {
+			flushPara()
+			closeLists(0)
+			var quote []string
+			for ; i < len(lines) && strings.HasPrefix(lines[i], "> "); i++ {
+				quote = append(quote, strings.TrimPrefix(lines[i], "> "))
+			}
+			i--
+			out.WriteString("<blockquote><p>" + inline(strings.Join(quote, " "), srcPath) + "</p></blockquote>\n")
+			continue
+		}
+
+		// Tables: a pipe row followed by a separator row.
+		if tableRow.MatchString(trimmed) && i+1 < len(lines) && tableSep.MatchString(strings.TrimRight(lines[i+1], " ")) {
+			flushPara()
+			closeLists(0)
+			out.WriteString("<div class=\"table-scroll\"><table>\n<thead><tr>")
+			for _, cell := range splitRow(trimmed) {
+				out.WriteString("<th>" + inline(cell, srcPath) + "</th>")
+			}
+			out.WriteString("</tr></thead>\n<tbody>\n")
+			for i += 2; i < len(lines) && tableRow.MatchString(strings.TrimRight(lines[i], " ")); i++ {
+				out.WriteString("<tr>")
+				for _, cell := range splitRow(strings.TrimRight(lines[i], " ")) {
+					out.WriteString("<td>" + inline(cell, srcPath) + "</td>")
+				}
+				out.WriteString("</tr>\n")
+			}
+			i--
+			out.WriteString("</tbody></table></div>\n")
+			continue
+		}
+
+		// Lists: two indentation levels, ordered and unordered.
+		if m := ulPattern.FindStringSubmatch(trimmed); m != nil {
+			flushPara()
+			handleListItem(&out, &listStack, "ul", len(m[1])/2, m[2], srcPath, closeLists)
+			continue
+		}
+		if m := olPattern.FindStringSubmatch(trimmed); m != nil {
+			flushPara()
+			handleListItem(&out, &listStack, "ol", len(m[1])/2, m[3], srcPath, closeLists)
+			continue
+		}
+
+		// A further-indented plain line inside a list continues the item.
+		if len(listStack) > 0 && strings.HasPrefix(line, "  ") {
+			out.WriteString(" " + inline(strings.TrimSpace(line), srcPath))
+			continue
+		}
+
+		para = append(para, trimmed)
+	}
+	flushPara()
+	closeLists(0)
+	return out.String(), nil
+}
+
+func handleListItem(out *strings.Builder, stack *[]string, tag string, depth int, text, srcPath string, closeLists func(int)) {
+	want := depth + 1
+	closeLists(want)
+	for len(*stack) < want {
+		out.WriteString("<" + tag + "><li>")
+		*stack = append(*stack, tag)
+	}
+	// Close the previous sibling item unless this <li> was just opened.
+	if !strings.HasSuffix(out.String(), "<li>") {
+		out.WriteString("</li><li>")
+	}
+	out.WriteString(inline(text, srcPath))
+}
+
+// splitRow splits a table row on unescaped pipes; `\|` renders literally.
+func splitRow(row string) []string {
+	row = strings.TrimSuffix(strings.TrimPrefix(row, "|"), "|")
+	row = strings.ReplaceAll(row, `\|`, "\x00")
+	cells := strings.Split(row, "|")
+	for i := range cells {
+		cells[i] = strings.ReplaceAll(strings.TrimSpace(cells[i]), "\x00", "|")
+	}
+	return cells
+}
+
+var (
+	codeSpan    = regexp.MustCompile("`([^`]+)`")
+	linkSpan    = regexp.MustCompile(`\[([^\]]+)\]\(([^)\s]+)\)`)
+	boldSpan    = regexp.MustCompile(`\*\*([^*]+)\*\*`)
+	italicSpan  = regexp.MustCompile(`\*([^*]+)\*`)
+	placeholder = regexp.MustCompile("\x00(\\d+)\x00")
+)
+
+// inline renders spans: code first (protected from further processing),
+// then links, bold, italic, over HTML-escaped text.
+func inline(text, srcPath string) string {
+	var protected []string
+	text = codeSpan.ReplaceAllStringFunc(text, func(m string) string {
+		inner := codeSpan.FindStringSubmatch(m)[1]
+		protected = append(protected, "<code>"+escape(inner)+"</code>")
+		return fmt.Sprintf("\x00%d\x00", len(protected)-1)
+	})
+	text = escape(text)
+	text = linkSpan.ReplaceAllStringFunc(text, func(m string) string {
+		parts := linkSpan.FindStringSubmatch(m)
+		return `<a href="` + rewriteLink(parts[2], srcPath) + `">` + parts[1] + `</a>`
+	})
+	text = boldSpan.ReplaceAllString(text, "<strong>$1</strong>")
+	text = italicSpan.ReplaceAllString(text, "<em>$1</em>")
+	return placeholder.ReplaceAllStringFunc(text, func(m string) string {
+		var idx int
+		fmt.Sscanf(m, "\x00%d\x00", &idx)
+		return protected[idx]
+	})
+}
+
+// rewriteLink maps documentation links onto the generated site: .md targets
+// become .html, links escaping docs/ point at the repository on GitHub.
+func rewriteLink(href, srcPath string) string {
+	if strings.HasPrefix(href, "http://") || strings.HasPrefix(href, "https://") || strings.HasPrefix(href, "#") {
+		return href
+	}
+	target, anchor, _ := strings.Cut(href, "#")
+	if anchor != "" {
+		anchor = "#" + anchor
+	}
+	resolved := filepath.ToSlash(filepath.Join(filepath.Dir(srcPath), target))
+	if strings.HasPrefix(resolved, "../") {
+		return repoBlobURL + strings.TrimPrefix(resolved, "../") + anchor
+	}
+	for _, p := range nav {
+		if p.src == resolved {
+			rel, err := filepath.Rel(filepath.Dir(filepath.FromSlash(srcPath)), filepath.FromSlash(p.out))
+			if err != nil {
+				panic(fmt.Sprintf("relativize %s from %s: %v", p.out, srcPath, err))
+			}
+			return filepath.ToSlash(rel) + anchor
+		}
+	}
+	panic(fmt.Sprintf("link to unknown page %q in %s", href, srcPath))
+}
+
+func escape(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	return s
+}
+
+// slug mirrors GitHub's header anchors so cross-page fragment links written
+// for the repository view keep working on the site.
+var slugStrip = regexp.MustCompile(`[^\w\s-]`)
+
+func slug(header string) string {
+	s := strings.ToLower(strings.TrimSpace(header))
+	s = strings.ReplaceAll(s, "`", "")
+	s = strings.ReplaceAll(s, "*", "")
+	s = slugStrip.ReplaceAllString(s, "")
+	return strings.Join(strings.Fields(s), "-")
+}
+
+// ---------------------------------------------------------------------------
+// Page template
+// ---------------------------------------------------------------------------
+
+func pageHTML(current page, body string) string {
+	depth := strings.Count(current.out, "/")
+	root := strings.Repeat("../", depth) // to site/docs/
+	site := root + "../"                 // to site/
+
+	var sidebar strings.Builder
+	lane := ""
+	for _, p := range nav {
+		if p.lane == "" {
+			continue
+		}
+		if p.lane != lane {
+			if lane != "" {
+				sidebar.WriteString("</ul>\n")
+			}
+			lane = p.lane
+			sidebar.WriteString(`<p class="lane">` + escape(lane) + "</p>\n<ul>\n")
+		}
+		class := ""
+		if p.src == current.src {
+			class = ` class="here" aria-current="page"`
+		}
+		sidebar.WriteString(`<li><a` + class + ` href="` + root + p.out + `">` + escape(p.title) + "</a></li>\n")
+	}
+	sidebar.WriteString("</ul>\n")
+
+	title := current.title
+	if current.src == "README.md" {
+		title = "Documentation"
+	}
+
+	return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>` + escape(title) + ` · Walden Docs</title>
+  <meta name="description" content="Walden documentation — the spec-driven delivery kernel: lifecycle, workflow, adoption, and full CLI/JSON references." />
+  <link rel="icon" href="` + site + `walden.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,380;9..144,500;9..144,600&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="` + site + `docs.css" />
+</head>
+<body>
+  <header class="site-head">
+    <div class="brand">
+      <a class="wordmark" href="` + site + `index.html">Walden<span class="mark">§</span></a>
+      <a class="version-tag" href="https://github.com/andrearaponi/walden/releases/latest">docs</a>
+    </div>
+    <nav class="nav" aria-label="Primary">
+      <a href="` + root + `index.html">Docs</a>
+      <a href="` + site + `index.html#install">Install</a>
+      <a href="https://github.com/andrearaponi/walden">GitHub&nbsp;↗</a>
+    </nav>
+  </header>
+  <div class="layout">
+    <aside class="sidebar" aria-label="Documentation">
+` + sidebar.String() + `    </aside>
+    <main class="doc">
+` + body + `    </main>
+  </div>
+  <footer class="foot">
+    <span>intention before code · proof before completion</span>
+    <a href="https://github.com/andrearaponi/walden/tree/main/docs">Edit these pages on GitHub ↗</a>
+  </footer>
+</body>
+</html>
+`
+}

--- a/tools/sitegen/main_test.go
+++ b/tools/sitegen/main_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestRenderSubset locks the Markdown constructs the docs are allowed to use.
+func TestRenderSubset(t *testing.T) {
+	src := strings.Join([]string{
+		"# Title",
+		"",
+		"A paragraph with **bold**, *italic*, `code`, and a [link](lifecycle.md#the-seal).",
+		"",
+		"| Col | Meaning |",
+		"| --- | --- |",
+		"| `a` \\| `b` | escaped pipe |",
+		"",
+		"- outer",
+		"  - inner",
+		"- second",
+		"",
+		"1. first",
+		"2. second",
+		"",
+		"> a quote",
+		"",
+		"```bash",
+		"walden verify <feature>",
+		"```",
+	}, "\n")
+
+	html, err := render(src, "quickstart.md")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	for _, want := range []string{
+		`<h1 id="title">Title</h1>`,
+		"<strong>bold</strong>", "<em>italic</em>", "<code>code</code>",
+		`<a href="lifecycle.html#the-seal">link</a>`,
+		"<th>Col</th>",
+		"<td><code>a</code> | <code>b</code></td>",
+		"<ul><li>outer<ul><li>inner</li></ul>\n</li><li>second</li></ul>",
+		"<ol><li>first</li><li>second</li></ol>",
+		"<blockquote><p>a quote</p></blockquote>",
+		`<pre><code class="lang-bash">walden verify &lt;feature&gt;</code></pre>`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("output lacks %q\n---\n%s", want, html)
+		}
+	}
+}
+
+func TestRenderRefusesUnknownLink(t *testing.T) {
+	if _, err := render("[x](no-such-page.md)", "quickstart.md"); err == nil {
+		t.Fatal("a link to an unknown page must fail the build")
+	}
+}
+
+func TestRenderRefusesUnterminatedFence(t *testing.T) {
+	if _, err := render("```bash\nnever closed", "quickstart.md"); err == nil {
+		t.Fatal("an unterminated fence must fail the build")
+	}
+}
+
+// TestGenerateRealDocs builds the actual documentation tree, so a doc using
+// an unsupported construct or a broken cross-page link fails at PR time —
+// not at deploy time.
+func TestGenerateRealDocs(t *testing.T) {
+	root := repoRoot(t)
+	out := t.TempDir()
+	if err := generate(filepath.Join(root, "docs"), out); err != nil {
+		t.Fatalf("generate over real docs: %v", err)
+	}
+
+	// Every generated internal link and anchor must resolve.
+	idPattern := regexp.MustCompile(`id="([^"]+)"`)
+	hrefPattern := regexp.MustCompile(`href="([^"]+)"`)
+	pages := map[string]string{}
+	for _, p := range nav {
+		raw, err := os.ReadFile(filepath.Join(out, filepath.FromSlash(p.out)))
+		if err != nil {
+			t.Fatalf("missing generated page %s: %v", p.out, err)
+		}
+		pages[p.out] = string(raw)
+	}
+	ids := func(page string) map[string]bool {
+		set := map[string]bool{}
+		for _, m := range idPattern.FindAllStringSubmatch(pages[page], -1) {
+			set[m[1]] = true
+		}
+		return set
+	}
+	for name, html := range pages {
+		for _, m := range hrefPattern.FindAllStringSubmatch(html, -1) {
+			href := m[1]
+			if strings.HasPrefix(href, "http") {
+				continue
+			}
+			target, anchor, _ := strings.Cut(href, "#")
+			if target == "" {
+				if !ids(name)[anchor] {
+					t.Errorf("%s: dangling local anchor #%s", name, anchor)
+				}
+				continue
+			}
+			resolved := filepath.ToSlash(filepath.Join(filepath.Dir(name), target))
+			if strings.HasPrefix(resolved, "..") {
+				continue // landing page, css, icons: outside the generated tree
+			}
+			body, ok := pages[resolved]
+			if !ok {
+				t.Errorf("%s: link to unknown generated page %s", name, href)
+				continue
+			}
+			if anchor != "" && !idPattern.MatchString(body) {
+				t.Errorf("%s: target %s has no anchors at all", name, target)
+			}
+			if anchor != "" && !ids(resolved)[anchor] {
+				t.Errorf("%s: anchor #%s missing in %s", name, anchor, target)
+			}
+		}
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("repository root not found")
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
Phase 2 of the documentation overhaul (#34, #35 were phase 1): the site now renders `docs/` instead of duplicating it — one source of truth, two renderings.

## What's in

- **`tools/sitegen`** — a stdlib-only Go generator (no new dependencies anywhere) for the exact Markdown subset the docs use. Links are rewritten `.md → .html`, anchor slugs mirror GitHub's so fragment links written for the repository view keep working on the site, and links escaping `docs/` point at the repository. A link to an unknown page or an unsupported construct **fails the build**.
- **Tests that move breakage to PR time**: subset lock, refusal cases (unknown link, unterminated fence), and a full generation over the real `docs/` tree with generated-link/anchor verification — running in the existing Go Test workflow, so a bad doc never reaches the deploy.
- **`site/docs.css`** — the reading layout in the landing's own language: paper, ink and pine, Fraunces + JetBrains Mono, sticky sidebar with the four lanes, responsive.
- **`pages.yml`** — triggers extended to `docs/**` and `tools/sitegen/**`; the build job sets up Go and runs the generator before uploading the artifact. `site/docs/` is generated, never committed.
- **Landing** — header and footer now link to `/docs`.

## Verified

- `go build/vet/test ./...` green (generator included).
- All 13 pages generated; every internal link and anchor machine-checked.
- Rendering visually verified in a browser (lifecycle and JSON reference pages: tables, escaped pipes, code blocks, nested lists, blockquote, sidebar active state).