### PR TITLE
fix(site): mobile docs menu no longer overlays the article

### DIFF
--- a/site/docs.css
+++ b/site/docs.css
@@ -69,16 +69,15 @@ body {
   max-width: 76rem; margin: 0 auto;
   padding: 2.2rem clamp(1.2rem, 4vw, 3rem) 4rem;
 }
-@media (max-width: 54rem) {
-  .layout { grid-template-columns: 1fr; }
-  .sidebar { position: static; border-right: none; border-bottom: 1px solid var(--rule); padding-bottom: 1.2rem; }
-}
 
 /* sidebar --------------------------------------------------------------- */
 .sidebar {
   font-family: var(--mono); font-size: 0.78rem; line-height: 1.5;
   align-self: start; position: sticky; top: 1.4rem;
 }
+/* Desktop: the menu is a plain always-open panel — the summary control
+   disappears, and with it the only way to collapse the details. */
+.sidenav > summary { display: none; }
 .sidebar .lane {
   margin: 1.3rem 0 0.45rem; font-size: 0.62rem; letter-spacing: 0.16em;
   text-transform: uppercase; color: var(--ink-mute);
@@ -92,6 +91,23 @@ body {
 }
 .sidebar a:hover { color: var(--pine); }
 .sidebar a.here { color: var(--pine); border-left-color: var(--pine); font-weight: 500; }
+
+/* Mobile: single column, static collapsible menu. This block must stay
+   after the .sidebar base rules — equal specificity, source order wins. */
+@media (max-width: 54rem) {
+  .layout { grid-template-columns: 1fr; padding-top: 1.4rem; }
+  .sidebar { position: static; }
+  .sidenav {
+    border: 1px solid var(--rule); border-radius: 8px;
+    background: var(--paper-2); padding: 0.65rem 0.9rem; margin-bottom: 1.6rem;
+  }
+  .sidenav > summary {
+    display: list-item; cursor: pointer;
+    font-size: 0.7rem; letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--pine); font-weight: 500;
+  }
+  .sidenav[open] > summary { margin-bottom: 0.8rem; }
+}
 
 /* article --------------------------------------------------------------- */
 .doc { max-width: 46rem; min-width: 0; }

--- a/site/index.html
+++ b/site/index.html
@@ -34,7 +34,7 @@
       <a class="version-tag" id="version-tag" href="https://github.com/andrearaponi/walden/releases/latest" aria-label="Latest release">v0.10.1</a>
     </div>
     <nav class="nav" aria-label="Primary">
-      <a href="docs/">Docs</a>
+      <a class="nav-docs" href="docs/">Docs</a>
       <a href="#workflow">Workflow</a>
       <a class="nav-cta" href="#howto">How to use<span class="nav-cursor" aria-hidden="true"></span></a>
       <a href="#install">Install</a>

--- a/site/styles.css
+++ b/site/styles.css
@@ -124,7 +124,7 @@ a { color: inherit; }
 
 /* Mobile keeps the two links that matter: the CTA and GitHub. */
 @media (max-width: 620px) {
-  .nav a:not(.nav-gh):not(.nav-cta) { display: none; }
+  .nav a:not(.nav-gh):not(.nav-cta):not(.nav-docs) { display: none; }
   .version-tag { display: none; }
 }
 

--- a/tools/sitegen/main.go
+++ b/tools/sitegen/main.go
@@ -382,10 +382,21 @@ func pageHTML(current page, body string) string {
   </header>
   <div class="layout">
     <aside class="sidebar" aria-label="Documentation">
-` + sidebar.String() + `    </aside>
+      <details class="sidenav" open>
+        <summary>Documentation menu</summary>
+        <nav>
+` + sidebar.String() + `        </nav>
+      </details>
+    </aside>
     <main class="doc">
 ` + body + `    </main>
   </div>
+  <script>
+    // Mobile: the menu starts collapsed; without JS it stays open and stacks.
+    if (matchMedia("(max-width: 54rem)").matches) {
+      document.querySelector(".sidenav").removeAttribute("open");
+    }
+  </script>
   <footer class="foot">
     <span>intention before code · proof before completion</span>
     <a href="https://github.com/andrearaponi/walden/tree/main/docs">Edit these pages on GitHub ↗</a>


### PR DESCRIPTION
Fixes the two mobile defects reported on the live /docs section.

## Root cause — one bug, both symptoms

The mobile media query in `docs.css` was placed **before** the `.sidebar` base rules. Equal specificity → source order wins → `position: sticky` survived on phones. The ~500px menu rode over the article while scrolling (the overlay mess), and long-press selection hit the menu instead of the text underneath (the non-copyable text).

## Fix

- **`docs.css`** — the mobile block moves after the base rules, with a comment locking the ordering constraint. On small screens the sidebar is static and the menu renders as a collapsible panel.
- **`sitegen`** — the sidebar nav is now a `<details open>` with a styled summary; a two-line script collapses it on small screens at load. Progressive: without JS it stays open and simply stacks above the article.
- **Landing** — bonus defect found while reproducing: the mobile nav-hiding rule (`styles.css`) also hid the new Docs link, so phones had no path into the docs at all. The link now carries `nav-docs` and is exempted.

## Verified in a real browser (390×844 and 1400×900)

- Menu collapsed on load, `position: static`; after deep scroll the element under the viewport center is the **article paragraph**, not the sidebar.
- Programmatic text selection returns the paragraph content (253 chars) — selection works.
- Landing mobile nav shows Docs · How to use · GitHub, no header overflow.
- Desktop unchanged: two columns, sticky expanded sidebar, summary hidden.
- `go vet`/`go test ./tools/sitegen` green; docs regenerated cleanly.